### PR TITLE
2️⃣: Add Markdown dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next": "^15.1.2",
     "next-plausible": "^3.12.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15.1.2",

--- a/src/beta/components/ui/atoms/Accordions.tsx
+++ b/src/beta/components/ui/atoms/Accordions.tsx
@@ -1,0 +1,75 @@
+import type { NonEmptyArray } from '@/beta/types/utils/non-empty';
+import type React from 'react';
+import { useState } from 'react';
+import theme from '../../ThemeRegistry/theme';
+import { Accordion, AccordionDetails, AccordionSummary, darken } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+export interface AccordionData {
+  id: string;
+  summary: string;
+  contents: React.ReactNode;
+}
+
+/** Expandable set of Material Accordion controls. */
+export function Accordions({
+  accordions,
+  borderRadius,
+  interAccordionMargin = '1rem',
+}: {
+  accordions: NonEmptyArray<AccordionData>;
+  borderRadius: string;
+  interAccordionMargin?: string;
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  return (
+    <>
+      {accordions.map((accordion, index) => {
+        const blankTop =
+          index === 0 || expanded[accordions[index - 1].id] || expanded[accordion.id];
+        const blankBottom =
+          index === accordions.length - 1 ||
+          expanded[accordions[index + 1].id] ||
+          expanded[accordion.id];
+        return (
+          <Accordion
+            key={`accordion-${accordion.id}`}
+            expanded={expanded[accordion.id] ?? false}
+            onChange={(_, newExpanded) => {
+              setExpanded(previous => ({ ...previous, [accordion.id]: newExpanded }));
+            }}
+            square={true}
+            sx={{
+              marginTop: blankTop ? interAccordionMargin : '0px',
+              ':before': blankTop ? { display: 'none' } : undefined,
+              backgroundColor: theme.palette.background.paper,
+              borderTopLeftRadius: blankTop ? borderRadius : '0px',
+              borderTopRightRadius: blankTop ? borderRadius : '0px',
+              borderBottomLeftRadius: blankBottom ? borderRadius : '0px',
+              borderBottomRightRadius: blankBottom ? borderRadius : '0px',
+            }}
+          >
+            <AccordionSummary
+              key={accordion.id}
+              aria-controls={accordion.id}
+              id={accordion.id}
+              expandIcon={<ExpandMoreIcon />}
+            >
+              {accordion.summary}
+            </AccordionSummary>
+            <AccordionDetails
+              key={`${accordion.id}-details`}
+              sx={{
+                backgroundColor: darken(theme.palette.background.paper, 0.1),
+                borderBottomLeftRadius: blankBottom ? borderRadius : '0px',
+                borderBottomRightRadius: blankBottom ? borderRadius : '0px',
+              }}
+            >
+              {accordion.contents}
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
+    </>
+  );
+}

--- a/src/beta/components/ui/atoms/WrapIcon.tsx
+++ b/src/beta/components/ui/atoms/WrapIcon.tsx
@@ -1,0 +1,48 @@
+import { Box } from '@mui/material';
+import type React from 'react';
+
+export function WrapIcon({
+  icon,
+  iconWidth,
+  iconFontSize = 'inherit',
+  flexBeforeAndAfter = undefined,
+  sx = undefined,
+  children = undefined,
+}: {
+  icon: React.ReactNode;
+  iconWidth: string;
+  iconFontSize: string;
+  flexBeforeAndAfter?: [number, number];
+  sx?: React.ComponentProps<typeof Box>['sx'];
+  children?: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <Box display="flex" flexDirection="row" gap="0px" sx={sx}>
+      {flexBeforeAndAfter === undefined ? (
+        <Box
+          flex="0"
+          minWidth={iconWidth}
+          maxWidth={iconWidth}
+          display="block"
+          textAlign="center"
+          fontSize={iconFontSize}
+        >
+          {icon}
+        </Box>
+      ) : (
+        <Box
+          flex="0"
+          minWidth={iconWidth}
+          maxWidth={iconWidth}
+          display="flex"
+          fontSize={iconFontSize}
+        >
+          <Box flex={flexBeforeAndAfter[0]} />
+          <Box flex="0">{icon}</Box>
+          <Box flex={flexBeforeAndAfter[1]} />
+        </Box>
+      )}
+      <Box flex="1">{children}</Box>
+    </Box>
+  );
+}

--- a/src/beta/components/ui/atoms/WrapRatingIcon.tsx
+++ b/src/beta/components/ui/atoms/WrapRatingIcon.tsx
@@ -1,7 +1,7 @@
-import { type Rating, ratingToIcon } from '@/beta/schema/attributes';
-import { Box, Typography } from '@mui/material';
 import type React from 'react';
 import { subsectionIconWidth } from '../../constants';
+import { type Rating, ratingToIcon } from '@/beta/schema/attributes';
+import { WrapIcon } from './WrapIcon';
 
 export function WrapRatingIcon({
   rating,
@@ -11,21 +11,13 @@ export function WrapRatingIcon({
   children?: React.ReactNode;
 }): React.JSX.Element {
   return (
-    <Box display="flex" flexDirection="row" gap="0px">
-      <Box
-        flex="0"
-        minWidth={subsectionIconWidth}
-        maxWidth={subsectionIconWidth}
-        display="flex"
-        flexDirection="row"
-      >
-        <Box flex="2" />
-        <Typography flex="0" variant="h5" fontSize="20px">
-          {ratingToIcon(rating)}
-        </Typography>
-        <Box flex="7" />
-      </Box>
-      <Box flex="1">{children}</Box>
-    </Box>
+    <WrapIcon
+      icon={ratingToIcon(rating)}
+      iconWidth={subsectionIconWidth}
+      iconFontSize="inherit"
+      flexBeforeAndAfter={[2, 7]}
+    >
+      {children}
+    </WrapIcon>
   );
 }

--- a/src/beta/components/ui/molecules/attributes/privacy/AddressCorrelationDetails.tsx
+++ b/src/beta/components/ui/molecules/attributes/privacy/AddressCorrelationDetails.tsx
@@ -11,8 +11,8 @@ import type React from 'react';
 import { JoinedList } from '../../../atoms/JoinedList';
 import { ExternalLink } from '../../../atoms/ExternalLink';
 import { ReferenceLinks } from '../../../atoms/ReferenceLinks';
-import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 import { subsectionWeight } from '@/beta/components/constants';
+import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 
 export function AddressCorrelationDetails({
   wallet,

--- a/src/beta/components/ui/molecules/attributes/transparency/FundingDetails.tsx
+++ b/src/beta/components/ui/molecules/attributes/transparency/FundingDetails.tsx
@@ -1,7 +1,6 @@
 import type { RatedWallet } from '@/beta/schema/wallet';
 import { Box } from '@mui/material';
 import type React from 'react';
-import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 import { subsectionWeight } from '@/beta/components/constants';
 import { ReferenceList } from '../../../atoms/ReferenceList';
 import {
@@ -12,6 +11,7 @@ import {
 import { JoinedList } from '../../../atoms/JoinedList';
 import { refs } from '@/beta/schema/reference';
 import type { FundingValue } from '@/beta/schema/attributes/transparency/funding';
+import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 
 export function FundingDetails({
   wallet,

--- a/src/beta/components/ui/molecules/attributes/transparency/LicenseDetails.tsx
+++ b/src/beta/components/ui/molecules/attributes/transparency/LicenseDetails.tsx
@@ -3,9 +3,9 @@ import { Typography } from '@mui/material';
 import { FOSS, licenseIsFOSS, licenseName, licenseUrl } from '@/beta/schema/features/license';
 import type React from 'react';
 import { ExternalLink } from '../../../atoms/ExternalLink';
-import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 import { subsectionWeight } from '@/beta/components/constants';
 import type { OpenSourceValue } from '@/beta/schema/attributes/transparency/open-source';
+import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 
 export function LicenseDetails({
   wallet,

--- a/src/beta/components/ui/molecules/attributes/transparency/SourceVisibilityDetails.tsx
+++ b/src/beta/components/ui/molecules/attributes/transparency/SourceVisibilityDetails.tsx
@@ -2,9 +2,9 @@ import type { RatedWallet } from '@/beta/schema/wallet';
 import { Typography } from '@mui/material';
 import type React from 'react';
 import { ExternalLink } from '../../../atoms/ExternalLink';
-import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 import { subsectionWeight } from '@/beta/components/constants';
 import type { SourceVisibilityValue } from '@/beta/schema/attributes/transparency/source-visibility';
+import { WrapRatingIcon } from '../../../atoms/WrapRatingIcon';
 
 export function SourceVisibilityDetails({
   wallet,

--- a/src/beta/components/ui/pages/WalletPage.tsx
+++ b/src/beta/components/ui/pages/WalletPage.tsx
@@ -91,10 +91,14 @@ function richSectionToSection(richSection: RichSection): Section {
 
 function sectionHeaderId(section: Section): string | null {
   if (section.subHeader !== null) {
-    return section.subHeader.replaceAll('_', '-');
+    return section.subHeader
+      .replaceAll('_', '-')
+      .replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
   }
   if (section.header !== null) {
-    return section.header.replaceAll('_', '-');
+    return section.header
+      .replaceAll('_', '-')
+      .replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
   }
   return 'top';
 }
@@ -253,7 +257,6 @@ export function WalletPage({ walletName }: { walletName: WalletName }): React.JS
       target: section,
       untilTimestamp: Date.now() + 1250,
     });
-    setActiveSection(section);
     header.scrollIntoView({ behavior: 'smooth' });
     scrollNavigationTo(section);
   };

--- a/src/beta/data/wallets/daimo.ts
+++ b/src/beta/data/wallets/daimo.ts
@@ -20,7 +20,10 @@ export const daimo: Wallet = {
       It focuses on cheap stablecoin payments and fast onramp and
       offramp of USD / USDC with minimal fees.
     `),
-    pseudonymType: 'Daimo username',
+    pseudonymType: {
+      singular: 'Daimo username',
+      plural: 'Daimo usernames',
+    },
     url: 'https://daimo.com',
     repoUrl: 'https://github.com/daimo-eth/daimo',
     contributors: [polymutex],
@@ -185,6 +188,22 @@ export const daimo: Wallet = {
           url: 'https://vote.optimism.io/retropgf/3/application/0x118a000851cf4c736497bab89993418517ac7cd9c8ede074aff408a8e0f84060',
         },
       ],
+    },
+  },
+  overrides: {
+    attributes: {
+      privacy: {
+        addressCorrelation: {
+          note: paragraph(`
+            Daimo usernames are user-selected during signup, and can be set
+            to any pseudonym. Daimo provides functionality to randomize its
+            value. To preserve privacy, it is recommended to pick a random
+            value that is not related to any of your existing usernames.
+            Doing so effectively preserves the pseudonymous nature of wallet
+            addresses.
+          `),
+        },
+      },
     },
   },
   variants: {

--- a/src/beta/data/wallets/rabby.ts
+++ b/src/beta/data/wallets/rabby.ts
@@ -39,16 +39,16 @@ export const rabby: Wallet = {
                 cexAccount: Leak.NEVER, // There appears to be code to link to a Coinbase account but no way to reach it from the UI?
                 ref: [
                   {
-                    explanation: 'Rabby uses self-hosted Matomo Analytics to track user actions.',
-                    url: 'https://github.com/search?q=repo%3ARabbyHub%2FRabby%20matomoRequestEvent&type=code',
-                  },
-                  {
                     explanation: 'All wallet traffic goes through api.rabby.io without proxying.',
                     url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/constant/index.ts#L468',
                   },
                   {
                     explanation:
-                      'Balance refresh requests are made about one address at a time, with no proxying nor staggering between requests.',
+                      'Rabby uses self-hosted Matomo Analytics to track user actions. While this tracking data does not contain wallet addresses, it goes to DeBank-owned servers much like Ethereum RPC requests do. This puts DeBank in a position to link user actions with wallet addresses through IP address correlation.',
+                    url: 'https://github.com/search?q=repo%3ARabbyHub%2FRabby%20matomoRequestEvent&type=code',
+                  },
+                  {
+                    explanation: 'Balance refresh requests are made about the active address only.',
                     url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/background/controller/wallet.ts#L1622',
                   },
                 ],

--- a/src/beta/schema/attribute-groups.ts
+++ b/src/beta/schema/attribute-groups.ts
@@ -214,7 +214,7 @@ export function mapAttributesGetter(
 /**
  * Generic function for scoring a group of evaluations.
  * @param weights A map from attribute name to its relative weight.
- * @returns A function to score of the group of evaluations.
+ * @returns A function to score the group of evaluations.
  */
 function scoreGroup<Vs extends ValueSet>(weights: { [k in keyof Vs]: number }): (
   evaluations: EvaluatedGroup<Vs>

--- a/src/beta/schema/attributes.ts
+++ b/src/beta/schema/attributes.ts
@@ -1,7 +1,6 @@
 import type { NonEmptyArray, NonEmptyRecord } from '@/beta/types/utils/non-empty';
 import type { ResolvedFeatures } from './features';
 import type { AtLeastOneVariant } from './variants';
-import type { Url } from './url';
 import type { MaybeUnratedScore, Score } from './score';
 import type { Paragraph, Renderable, Sentence } from '@/beta/types/text';
 import type { RatedWallet, WalletMetadata } from './wallet';
@@ -177,11 +176,12 @@ export interface Evaluation<V extends Value> {
    */
   impact?: Paragraph<EvaluationData<V>>;
 
-  /** A link to a relevant URL about this wallet's implementation of the
-   * attribute. For attributes that the wallet does not fulfill, this can
-   * be a link to a bug tracker that tracks implementation of the attribute.
+  /**
+   * An optional paragraph or list of suggestions on what the wallet can do
+   * to improve this rating. Should only be populated for ratings that are
+   * not perfect.
    */
-  url?: Url;
+  howToImprove?: Renderable<EvaluationData<V>>;
 }
 
 /**
@@ -198,7 +198,7 @@ export type Evaluate<V extends Value> = (features: ResolvedFeatures) => Evaluati
  */
 export interface Attribute<V extends Value> {
   /**
-   * Unique ID representing the attribute.
+   * Unique ID representing the attribute in camelCase.
    * For example: "sourceVisibility".
    */
   id: string;

--- a/src/beta/schema/attributes/privacy/multi-address-correlation.ts
+++ b/src/beta/schema/attributes/privacy/multi-address-correlation.ts
@@ -45,8 +45,10 @@ const activeAddressOnly: Evaluation<MultiAddressCorrelationValue> = {
     icon: '\u{1f4ce}', // Single paperclip
     displayName: 'Wallet only handles one active address at a time',
     shortExplanation: sentence(
-      (walletMetadata: WalletMetadata) =>
-        `${walletMetadata.displayName} only makes requests about one active address at a time, so it can't be correlated with other addresses.`
+      (walletMetadata: WalletMetadata) => `
+        ${walletMetadata.displayName} only makes requests about one active
+        address at a time, so it can't be correlated with other addresses.
+      `
     ),
     __brand: brand,
   },
@@ -76,10 +78,10 @@ const correlated: Evaluation<MultiAddressCorrelationValue> = {
     displayName: 'Multiple addresses are correlatable by a third party',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} makes requests about multiple addresses
-      simultaneously to the same endpoint, which allows it to correlate your
-      addresses.
-    `
+        ${walletMetadata.displayName} makes requests about multiple addresses
+        simultaneously to the same endpoint, which allows it to correlate your
+        addresses.
+      `
     ),
     __brand: brand,
   },
@@ -91,11 +93,21 @@ const correlated: Evaluation<MultiAddressCorrelationValue> = {
   ),
   impact: paragraph(
     ({ wallet }) => `
-    Using multiple addresses in ${wallet.metadata.displayName} will allow
-    them to be correlated by a third-party.
-    You should avoid configuring multiple addresses with
-    ${wallet.metadata.displayName}.
-  `
+      Using multiple addresses in ${wallet.metadata.displayName} will allow
+      them to be correlated by a third-party.
+      You should avoid configuring multiple addresses with
+      ${wallet.metadata.displayName}.
+    `
+  ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should first ensure that it never makes
+      requests containing multiple addresses simultaneously.
+      Next, it should ensure that these requests are staggered and are proxied
+      through different proxies and RPC endpoints to prevent correlation.
+      This can be done through the use of privacy solutions such as
+      Oblivious HTTP, Tor, and others.
+    `
   ),
 };
 
@@ -106,9 +118,9 @@ const staggeredRequests: Evaluation<MultiAddressCorrelationValue> = {
     displayName: 'Requests for multiple addresses are staggered across time',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} staggers requests about multiple addresses
-      over time time, which makes it harder to correlate your addresses.
-    `
+        ${walletMetadata.displayName} staggers requests about multiple addresses
+        over time time, which makes it harder to correlate your addresses.
+      `
     ),
     __brand: brand,
   },
@@ -126,6 +138,14 @@ const staggeredRequests: Evaluation<MultiAddressCorrelationValue> = {
       able to correlate the requests due to their identical origin IP address.
     `
   ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should ensure requests are proxied
+      through distinct proxies in order to prevent the RPC endpoint from
+      learning the correlation between addresses. This can be done through
+      the use of privacy solutions such as Oblivious HTTP, Tor, and others.
+    `
+  ),
 };
 
 const separateCircuits: Evaluation<MultiAddressCorrelationValue> = {
@@ -135,10 +155,10 @@ const separateCircuits: Evaluation<MultiAddressCorrelationValue> = {
     displayName: 'Requests for multiple addresses use separate proxies',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} uses distinct proxies to make requests
-      about multiple addresses, which makes it harder to correlate your
-      addresses.
-    `
+        ${walletMetadata.displayName} uses distinct proxies to make requests
+        about multiple addresses, which makes it harder to correlate your
+        addresses.
+      `
     ),
     __brand: brand,
   },
@@ -156,6 +176,13 @@ const separateCircuits: Evaluation<MultiAddressCorrelationValue> = {
       time.
     `
   ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should add randomized delays between
+      refreshes of separate addresses in order to reduce time-based
+      correlatability of addresses by the RPC endpoint.
+    `
+  ),
 };
 
 const staggeredAndSeparateCircuits: Evaluation<MultiAddressCorrelationValue> = {
@@ -166,10 +193,10 @@ const staggeredAndSeparateCircuits: Evaluation<MultiAddressCorrelationValue> = {
     displayName: 'Requests for multiple addresses are uncorrelated',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} uses distinct proxies and staggers
-      requests about multiple addresses over time, which makes it harder
-      to correlate your addresses.
-    `
+        ${walletMetadata.displayName} uses distinct proxies and staggers
+        requests about multiple addresses over time, which makes it harder
+        to correlate your addresses.
+      `
     ),
     __brand: brand,
   },
@@ -196,16 +223,16 @@ const unsupported: Evaluation<MultiAddressCorrelationValue> = {
     displayName: 'Multiple addresses unsupported',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      You can only use one address in ${walletMetadata.displayName}.
-    `
+        You can only use one address in ${walletMetadata.displayName}.
+      `
     ),
     __brand: brand,
   },
   details: paragraph(
     ({ wallet }) => `
-    You can only use one address in ${wallet.metadata.displayName}, so
-    multi-address privacy is irrelevant.
-  `
+      You can only use one address in ${wallet.metadata.displayName}, so
+      multi-address privacy is irrelevant.
+    `
   ),
 };
 
@@ -226,7 +253,7 @@ function rateHandling(handling: MultiAddressHandling): number {
 }
 
 export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = {
-  id: 'multi_address',
+  id: 'multiAddressCorrelation',
   icon: '\u{1f587}', // Linked paperclips
   displayName: 'Multi-address privacy',
   question: sentence(`

--- a/src/beta/schema/attributes/transparency/funding.ts
+++ b/src/beta/schema/attributes/transparency/funding.ts
@@ -30,8 +30,8 @@ function transparent(
       displayName: `Transparent funding (${sourceName})`,
       shortExplanation: sentence(
         (walletMetadata: WalletMetadata) => `
-        ${walletMetadata.displayName} is transparently funded.
-      `
+          ${walletMetadata.displayName} is transparently funded.
+        `
       ),
       __brand: brand,
     },
@@ -53,13 +53,20 @@ function extractive(
       displayName: `User-extractive funding${sourceName !== '' ? ` (${sourceName})` : ''}`,
       shortExplanation: sentence(
         (walletMetadata: WalletMetadata) => `
-        ${walletMetadata.displayName} is funded through user-extractive
-        means${sourceName !== '' ? ` (${sourceName})` : ''}.
-      `
+          ${walletMetadata.displayName} is funded through user-extractive
+          means${sourceName !== '' ? ` (${sourceName})` : ''}.
+        `
       ),
       __brand: brand,
     },
     details: component(FundingDetails, { monetization }),
+    howToImprove: paragraph(
+      ({ wallet }) => `
+        ${wallet.metadata.displayName} should change its funding sources
+        to non-user-extractive means such as transparent convenience fees,
+        donations, or ecosystem grants.
+      `
+    ),
   };
 }
 
@@ -71,14 +78,20 @@ const unclear: Evaluation<FundingValue> = {
     displayName: 'Unclear funding source',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      How ${walletMetadata.displayName} is funded is unclear.
-    `
+        How ${walletMetadata.displayName} is funded is unclear.
+      `
     ),
     __brand: brand,
   },
   details: paragraph(
     ({ wallet }) => `
       How ${wallet.metadata.displayName} is funded is unclear.
+    `
+  ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should publish how it is funded, or how it
+      plans to fund itself.
     `
   ),
 };

--- a/src/beta/schema/attributes/transparency/open-source.ts
+++ b/src/beta/schema/attributes/transparency/open-source.ts
@@ -21,9 +21,9 @@ function open(license: License): Evaluation<OpenSourceValue> {
       displayName: `Open source (${licenseName(license)})`,
       shortExplanation: sentence(
         (walletMetadata: WalletMetadata) => `
-        ${walletMetadata.displayName}'s source code is under an open-source
-        license (${licenseName(license)}).
-      `
+          ${walletMetadata.displayName}'s source code is under an open-source
+          license (${licenseName(license)}).
+        `
       ),
       license,
       __brand: brand,
@@ -41,9 +41,9 @@ function openInTheFuture(license: License): Evaluation<OpenSourceValue> {
       displayName: `Open source in the future (${licenseName(license)})`,
       shortExplanation: sentence(
         (walletMetadata: WalletMetadata) => `
-        ${walletMetadata.displayName} (${licenseName(license)})'s code
-        license commits to transition to open-source in the future.
-      `
+          ${walletMetadata.displayName} (${licenseName(license)})'s code
+          license commits to transition to open-source in the future.
+        `
       ),
       license,
       __brand: brand,
@@ -60,8 +60,8 @@ const proprietary: Evaluation<OpenSourceValue> = {
     displayName: 'Proprietary code license',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} uses a proprietary source code license.
-    `
+        ${walletMetadata.displayName} uses a proprietary source code license.
+      `
     ),
     license: License.PROPRIETARY,
     __brand: brand,
@@ -70,6 +70,12 @@ const proprietary: Evaluation<OpenSourceValue> = {
     ({ wallet }) => `
       ${wallet.metadata.displayName} uses a proprietary or non-FOSS source code
       license. Therefore, it is not Free and Open Source Software.
+    `
+  ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should consider re-licensing under a
+      Free and Open Source Software license.
     `
   ),
 };
@@ -82,9 +88,9 @@ const unlicensed: Evaluation<OpenSourceValue> = {
     displayName: 'Unlicensed or missing license file',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      ${walletMetadata.displayName} does not have a valid license for its
-      source code.
-    `
+        ${walletMetadata.displayName} does not have a valid license for its
+        source code.
+      `
     ),
     license: License.UNLICENSED_VISIBLE,
     __brand: brand,
@@ -101,10 +107,16 @@ const unlicensed: Evaluation<OpenSourceValue> = {
       license file.
     `
   ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should add a license file to its source
+      code.
+    `
+  ),
 };
 
 export const openSource: Attribute<OpenSourceValue> = {
-  id: 'open_source',
+  id: 'openSource',
   icon: '\u{2764}', // Heart
   displayName: 'Source code license',
   question: sentence(`

--- a/src/beta/schema/attributes/transparency/source-visibility.ts
+++ b/src/beta/schema/attributes/transparency/source-visibility.ts
@@ -33,21 +33,27 @@ const sourcePrivate: Evaluation<SourceVisibilityValue> = {
     displayName: 'Source code not publicly available',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      The source code for ${walletMetadata.displayName} is not public.
-    `
+        The source code for ${walletMetadata.displayName} is not public.
+      `
     ),
     __brand: brand,
   },
   details: paragraph(
     ({ wallet }) => `
-    The source code for ${wallet.metadata.displayName} is not available
-    to the public.
-  `
+      The source code for ${wallet.metadata.displayName} is not available
+      to the public.
+    `
+  ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} should make its source code publicly
+      viewable.
+    `
   ),
 };
 
 export const sourceVisibility: Attribute<SourceVisibilityValue> = {
-  id: 'source_visibility',
+  id: 'sourceVisibility',
   icon: '\u{1f35d}', // Spaghetti
   displayName: 'Source visibility',
   question: sentence('Is the source code for the wallet visible to the public?'),

--- a/src/beta/schema/features/privacy/data-collection.ts
+++ b/src/beta/schema/features/privacy/data-collection.ts
@@ -372,7 +372,10 @@ export function leakedInfoName(
       return { short: 'outgoing transactions', long: 'outgoing wallet transactions' };
     case LeakedPersonalInfo.PSEUDONYM:
       if (walletMetadata?.pseudonymType !== undefined) {
-        return { short: walletMetadata.pseudonymType, long: walletMetadata.pseudonymType };
+        return {
+          short: walletMetadata.pseudonymType.singular,
+          long: walletMetadata.pseudonymType.singular,
+        };
       }
       return { short: 'username', long: 'pseudonym' };
     case LeakedPersonalInfo.FARCASTER_ACCOUNT:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,10 +1093,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.6":
+"@types/debug@npm:^4.0.0":
+  version: 4.1.12
+  resolution: "@types/debug@npm:4.1.12"
+  dependencies:
+    "@types/ms": "npm:*"
+  checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
+  languageName: node
+  linkType: hard
+
+"@types/estree-jsx@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "@types/estree-jsx@npm:1.0.5"
+  dependencies:
+    "@types/estree": "npm:*"
+  checksum: 10c0/07b354331516428b27a3ab99ee397547d47eb223c34053b48f84872fafb841770834b90cc1a0068398e7c7ccb15ec51ab00ec64b31dc5e3dbefd624638a35c6d
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
+  languageName: node
+  linkType: hard
+
+"@types/hast@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@types/hast@npm:3.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/3249781a511b38f1d330fd1e3344eed3c4e7ea8eff82e835d35da78e637480d36fad37a78be5a7aed8465d237ad0446abc1150859d0fde395354ea634decf9f7
   languageName: node
   linkType: hard
 
@@ -1111,6 +1138,22 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 10c0/6bf5337bc447b706bb5b4431d37686aa2ea6d07cfd6f79cc31de80170d6ff9b1c7384a9c0ccbc45b3f512bae9e9f75c2e12109806a15331dc94e8a8db6dbb4ac
+  languageName: node
+  linkType: hard
+
+"@types/mdast@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "@types/mdast@npm:4.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 0.7.34
+  resolution: "@types/ms@npm:0.7.34"
+  checksum: 10c0/ac80bd90012116ceb2d188fde62d96830ca847823e8ca71255616bc73991aa7d9f057b8bfab79e8ee44ffefb031ddd1bcce63ea82f9e66f7c31ec02d2d823ccc
   languageName: node
   linkType: hard
 
@@ -1169,6 +1212,20 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/8fb2b00672072135d0858dc9db07873ea107cc238b6228aaa2a9afd1ef7a64a7074078250db38afbeb19064be8ea6af5eac32d404efdd5f45e093cc4829d87f8
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*, @types/unist@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:^2.0.0":
+  version: 2.0.11
+  resolution: "@types/unist@npm:2.0.11"
+  checksum: 10c0/24dcdf25a168f453bb70298145eb043cfdbb82472db0bc0b56d6d51cd2e484b9ed8271d4ac93000a80da568f2402e9339723db262d0869e2bf13bc58e081768d
   languageName: node
   linkType: hard
 
@@ -1402,6 +1459,13 @@ __metadata:
     "@typescript-eslint/types": "npm:8.18.2"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/b8fe05bc3bafa7930d6671c2e1807ae47788060eb573e6a000c9597690dfaff6a4eb9f6f934719a18bae631d238ca32847510aeecc61032170e58ab45244e869
+  languageName: node
+  linkType: hard
+
+"@ungap/structured-clone@npm:^1.0.0":
+  version: 1.2.1
+  resolution: "@ungap/structured-clone@npm:1.2.1"
+  checksum: 10c0/127afbcc75ff1532f7b1eb85ee992f9faa70e8d5bb2558da05355d423b966fc279d0a485bf19da2883280e7c299ae4170809a72e78eab086da71c6bcdda5d1e2
   languageName: node
   linkType: hard
 
@@ -1657,6 +1721,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bail@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "bail@npm:2.0.2"
+  checksum: 10c0/25cbea309ef6a1f56214187004e8f34014eb015713ea01fa5b9b7e9e776ca88d0fdffd64143ac42dc91966c915a4b7b683411b56e14929fad16153fc026ffb8b
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -1767,6 +1838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ccount@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "ccount@npm:2.0.1"
+  checksum: 10c0/3939b1664390174484322bc3f45b798462e6c07ee6384cb3d645e0aa2f318502d174845198c1561930e1d431087f74cf1fe291ae9a4722821a9f4ba67e574350
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -1785,6 +1863,34 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
+"character-entities-html4@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "character-entities-html4@npm:2.1.0"
+  checksum: 10c0/fe61b553f083400c20c0b0fd65095df30a0b445d960f3bbf271536ae6c3ba676f39cb7af0b4bf2755812f08ab9b88f2feed68f9aebb73bb153f7a115fe5c6e40
+  languageName: node
+  linkType: hard
+
+"character-entities-legacy@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "character-entities-legacy@npm:3.0.0"
+  checksum: 10c0/ec4b430af873661aa754a896a2b55af089b4e938d3d010fad5219299a6b6d32ab175142699ee250640678cd64bdecd6db3c9af0b8759ab7b155d970d84c4c7d1
+  languageName: node
+  linkType: hard
+
+"character-entities@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "character-entities@npm:2.0.2"
+  checksum: 10c0/b0c645a45bcc90ff24f0e0140f4875a8436b8ef13b6bcd31ec02cfb2ca502b680362aa95386f7815bdc04b6464d48cf191210b3840d7c04241a149ede591a308
+  languageName: node
+  linkType: hard
+
+"character-reference-invalid@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "character-reference-invalid@npm:2.0.1"
+  checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
   languageName: node
   linkType: hard
 
@@ -1851,6 +1957,13 @@ __metadata:
     color-convert: "npm:^2.0.1"
     color-string: "npm:^1.9.0"
   checksum: 10c0/7fbe7cfb811054c808349de19fb380252e5e34e61d7d168ec3353e9e9aacb1802674bddc657682e4e9730c2786592a4de6f8283e7e0d3870b829bb0b7b2f6118
+  languageName: node
+  linkType: hard
+
+"comma-separated-tokens@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "comma-separated-tokens@npm:2.0.3"
+  checksum: 10c0/91f90f1aae320f1755d6957ef0b864fe4f54737f3313bd95e0802686ee2ca38bff1dd381964d00ae5db42912dd1f4ae5c2709644e82706ffc6f6842a813cdd67
   languageName: node
   linkType: hard
 
@@ -2083,6 +2196,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.0.0":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
+  languageName: node
+  linkType: hard
+
 "debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
@@ -2092,6 +2217,15 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
+"decode-named-character-reference@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "decode-named-character-reference@npm:1.0.2"
+  dependencies:
+    character-entities: "npm:^2.0.0"
+  checksum: 10c0/66a9fc5d9b5385a2b3675c69ba0d8e893393d64057f7dbbb585265bb4fc05ec513d76943b8e5aac7d8016d20eea4499322cbf4cd6d54b466976b78f3a7587a4c
   languageName: node
   linkType: hard
 
@@ -2133,10 +2267,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.3":
   version: 2.0.3
   resolution: "detect-libc@npm:2.0.3"
   checksum: 10c0/88095bda8f90220c95f162bf92cad70bd0e424913e655c20578600e35b91edc261af27531cf160a331e185c0ced93944bc7e09939143225f56312d7fd800fdb7
+  languageName: node
+  linkType: hard
+
+"devlop@npm:^1.0.0, devlop@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "devlop@npm:1.1.0"
+  dependencies:
+    dequal: "npm:^2.0.0"
+  checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
   languageName: node
   linkType: hard
 
@@ -2782,10 +2932,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-util-is-identifier-name@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "estree-util-is-identifier-name@npm:3.0.0"
+  checksum: 10c0/d1881c6ed14bd588ebd508fc90bf2a541811dbb9ca04dec2f39d27dcaa635f85b5ed9bbbe7fc6fb1ddfca68744a5f7c70456b4b7108b6c4c52780631cc787c5b
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
+"extend@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
   languageName: node
   linkType: hard
 
@@ -3169,6 +3333,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-jsx-runtime@npm:^2.0.0":
+  version: 2.3.2
+  resolution: "hast-util-to-jsx-runtime@npm:2.3.2"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/unist": "npm:^3.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    estree-util-is-identifier-name: "npm:^3.0.0"
+    hast-util-whitespace: "npm:^3.0.0"
+    mdast-util-mdx-expression: "npm:^2.0.0"
+    mdast-util-mdx-jsx: "npm:^3.0.0"
+    mdast-util-mdxjs-esm: "npm:^2.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    style-to-object: "npm:^1.0.0"
+    unist-util-position: "npm:^5.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/97761b2a48b8bc37da3d66cb4872312ae06c6e8f9be59e33b04b21fa5af371a39cb23b3ca165dd8e898ba1caf9b76399da35c957e68bad02a587a3a324216d56
+  languageName: node
+  linkType: hard
+
+"hast-util-whitespace@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "hast-util-whitespace@npm:3.0.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+  checksum: 10c0/b898bc9fe27884b272580d15260b6bbdabe239973a147e97fa98c45fa0ffec967a481aaa42291ec34fb56530dc2d484d473d7e2bae79f39c83f3762307edfea8
+  languageName: node
+  linkType: hard
+
 "hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -3182,6 +3378,13 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
+  languageName: node
+  linkType: hard
+
+"html-url-attributes@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "html-url-attributes@npm:3.0.1"
+  checksum: 10c0/496e4908aa8b77665f348b4b03521901794f648b8ac34a581022cd6f2c97934d5c910cd91bc6593bbf2994687549037bc2520fcdc769b31484f29ffdd402acd0
   languageName: node
   linkType: hard
 
@@ -3206,6 +3409,13 @@ __metadata:
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
+  languageName: node
+  linkType: hard
+
+"inline-style-parser@npm:0.2.4":
+  version: 0.2.4
+  resolution: "inline-style-parser@npm:0.2.4"
+  checksum: 10c0/ddc0b210eaa03e0f98d677b9836242c583c7c6051e84ce0e704ae4626e7871c5b78f8e30853480218b446355745775df318d4f82d33087ff7e393245efa9a881
   languageName: node
   linkType: hard
 
@@ -3235,6 +3445,23 @@ __metadata:
   version: 2.0.3
   resolution: "internmap@npm:2.0.3"
   checksum: 10c0/8cedd57f07bbc22501516fbfc70447f0c6812871d471096fad9ea603516eacc2137b633633daf432c029712df0baefd793686388ddf5737e3ea15074b877f7ed
+  languageName: node
+  linkType: hard
+
+"is-alphabetical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphabetical@npm:2.0.1"
+  checksum: 10c0/932367456f17237533fd1fc9fe179df77957271020b83ea31da50e5cc472d35ef6b5fb8147453274ffd251134472ce24eb6f8d8398d96dee98237cdb81a6c9a7
+  languageName: node
+  linkType: hard
+
+"is-alphanumerical@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-alphanumerical@npm:2.0.1"
+  dependencies:
+    is-alphabetical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+  checksum: 10c0/4b35c42b18e40d41378293f82a3ecd9de77049b476f748db5697c297f686e1e05b072a6aaae2d16f54d2a57f85b00cbbe755c75f6d583d1c77d6657bd0feb5a2
   languageName: node
   linkType: hard
 
@@ -3375,6 +3602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-decimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-decimal@npm:2.0.1"
+  checksum: 10c0/8085dd66f7d82f9de818fba48b9e9c0429cb4291824e6c5f2622e96b9680b54a07a624cfc663b24148b8e853c62a1c987cfe8b0b5a13f5156991afaf6736e334
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -3406,6 +3640,13 @@ __metadata:
   dependencies:
     is-extglob: "npm:^2.1.1"
   checksum: 10c0/17fb4014e22be3bbecea9b2e3a76e9e34ff645466be702f1693e8f1ee1adac84710d0be0bd9f967d6354036fd51ab7c2741d954d6e91dae6bb69714de92c197a
+  languageName: node
+  linkType: hard
+
+"is-hexadecimal@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "is-hexadecimal@npm:2.0.1"
+  checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
   languageName: node
   linkType: hard
 
@@ -3446,6 +3687,13 @@ __metadata:
   version: 7.0.0
   resolution: "is-number@npm:7.0.0"
   checksum: 10c0/b4686d0d3053146095ccd45346461bc8e53b80aeb7671cc52a4de02dbbf7dc0d1d2a986e2fe4ae206984b4d34ef37e8b795ebc4f4295c978373e6575e295d811
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "is-plain-obj@npm:4.1.0"
+  checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
   languageName: node
   linkType: hard
 
@@ -3750,6 +3998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "longest-streak@npm:3.1.0"
+  checksum: 10c0/7c2f02d0454b52834d1bcedef79c557bd295ee71fdabb02d041ff3aa9da48a90b5df7c0409156dedbc4df9b65da18742652aaea4759d6ece01f08971af6a7eaa
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -3790,6 +4045,7 @@ __metadata:
     prettier: "npm:^3.4.2"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
+    react-markdown: "npm:^9.0.1"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -3801,10 +4057,367 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-from-markdown@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "mdast-util-from-markdown@npm:2.0.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark: "npm:^4.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/76eb2bd2c6f7a0318087c73376b8af6d7561c1e16654e7667e640f391341096c56142618fd0ff62f6d39e5ab4895898b9789c84cd7cec2874359a437a0e1ff15
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx-expression@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdx-expression@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/9a1e57940f66431f10312fa239096efa7627f375e7933b5d3162c0b5c1712a72ac87447aff2b6838d2bbd5c1311b188718cc90b33b67dc67a88550e0a6ef6183
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdx-jsx@npm:^3.0.0":
+  version: 3.1.3
+  resolution: "mdast-util-mdx-jsx@npm:3.1.3"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    ccount: "npm:^2.0.0"
+    devlop: "npm:^1.1.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    parse-entities: "npm:^4.0.0"
+    stringify-entities: "npm:^4.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/1b0b64215efbbbb1ee9ba2a2b3e5f11859dada7dff162949a0d503aefbd75c0308f17d404df126c54acea06d2224905915b2cac2e6c999514c919bd963b8de24
+  languageName: node
+  linkType: hard
+
+"mdast-util-mdxjs-esm@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-mdxjs-esm@npm:2.0.1"
+  dependencies:
+    "@types/estree-jsx": "npm:^1.0.0"
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+  checksum: 10c0/5bda92fc154141705af2b804a534d891f28dac6273186edf1a4c5e3f045d5b01dbcac7400d27aaf91b7e76e8dce007c7b2fdf136c11ea78206ad00bdf9db46bc
+  languageName: node
+  linkType: hard
+
+"mdast-util-phrasing@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "mdast-util-phrasing@npm:4.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/bf6c31d51349aa3d74603d5e5a312f59f3f65662ed16c58017169a5fb0f84ca98578f626c5ee9e4aa3e0a81c996db8717096705521bddb4a0185f98c12c9b42f
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-hast@npm:^13.0.0":
+  version: 13.2.0
+  resolution: "mdast-util-to-hast@npm:13.2.0"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    "@ungap/structured-clone": "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    trim-lines: "npm:^3.0.0"
+    unist-util-position: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/9ee58def9287df8350cbb6f83ced90f9c088d72d4153780ad37854f87144cadc6f27b20347073b285173b1649b0723ddf0b9c78158608a804dcacb6bda6e1816
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-markdown@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "mdast-util-to-markdown@npm:2.1.2"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-phrasing: "npm:^4.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/4649722a6099f12e797bd8d6469b2b43b44e526b5182862d9c7766a3431caad2c0112929c538a972f214e63c015395e5d3f54bd81d9ac1b16e6d8baaf582f749
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-util-to-string@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+  checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
+  languageName: node
+  linkType: hard
+
 "merge2@npm:^1.3.0":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"micromark-core-commonmark@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-core-commonmark@npm:2.0.2"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-destination: "npm:^2.0.0"
+    micromark-factory-label: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-factory-title: "npm:^2.0.0"
+    micromark-factory-whitespace: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-html-tag-name: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/87c7a75cd339189eb6f1d6323037f7d108d1331d953b84fe839b37fd385ee2292b27222327c1ceffda46ba5d5d4dee703482475e5ee8744be40c9e308d8acb77
+  languageName: node
+  linkType: hard
+
+"micromark-factory-destination@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-destination@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bbafcf869cee5bf511161354cb87d61c142592fbecea051000ff116068dc85216e6d48519d147890b9ea5d7e2864a6341c0c09d9948c203bff624a80a476023c
+  languageName: node
+  linkType: hard
+
+"micromark-factory-label@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-label@npm:2.0.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/0137716b4ecb428114165505e94a2f18855c8bbea21b07a8b5ce514b32a595ed789d2b967125718fc44c4197ceaa48f6609d58807a68e778138d2e6b91b824e8
+  languageName: node
+  linkType: hard
+
+"micromark-factory-space@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-space@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f9ed43f1c0652d8d898de0ac2be3f77f776fffe7dd96bdbba1e02d7ce33d3853c6ff5daa52568fc4fa32cdf3a62d86b85ead9b9189f7211e1d69ff2163c450fb
+  languageName: node
+  linkType: hard
+
+"micromark-factory-title@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-title@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/e72fad8d6e88823514916890099a5af20b6a9178ccf78e7e5e05f4de99bb8797acb756257d7a3a57a53854cb0086bf8aab15b1a9e9db8982500dd2c9ff5948b6
+  languageName: node
+  linkType: hard
+
+"micromark-factory-whitespace@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-factory-whitespace@npm:2.0.1"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/20a1ec58698f24b766510a309b23a10175034fcf1551eaa9da3adcbed3e00cd53d1ebe5f030cf873f76a1cec3c34eb8c50cc227be3344caa9ed25d56cf611224
+  languageName: node
+  linkType: hard
+
+"micromark-util-character@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "micromark-util-character@npm:2.1.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/d3fe7a5e2c4060fc2a076f9ce699c82a2e87190a3946e1e5eea77f563869b504961f5668d9c9c014724db28ac32fa909070ea8b30c3a39bd0483cc6c04cc76a1
+  languageName: node
+  linkType: hard
+
+"micromark-util-chunked@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-chunked@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/b68c0c16fe8106949537bdcfe1be9cf36c0ccd3bc54c4007003cb0984c3750b6cdd0fd77d03f269a3382b85b0de58bde4f6eedbe7ecdf7244759112289b1ab56
+  languageName: node
+  linkType: hard
+
+"micromark-util-classify-character@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-classify-character@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/8a02e59304005c475c332f581697e92e8c585bcd45d5d225a66c1c1b14ab5a8062705188c2ccec33cc998d33502514121478b2091feddbc751887fc9c290ed08
+  languageName: node
+  linkType: hard
+
+"micromark-util-combine-extensions@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-combine-extensions@npm:2.0.1"
+  dependencies:
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/f15e282af24c8372cbb10b9b0b3e2c0aa681fea0ca323a44d6bc537dc1d9382c819c3689f14eaa000118f5a163245358ce6276b2cda9a84439cdb221f5d86ae7
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-numeric-character-reference@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "micromark-util-decode-numeric-character-reference@npm:2.0.2"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/9c8a9f2c790e5593ffe513901c3a110e9ec8882a08f466da014112a25e5059b51551ca0aeb7ff494657d86eceb2f02ee556c6558b8d66aadc61eae4a240da0df
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-string@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-decode-string@npm:2.0.1"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/f24d75b2e5310be6e7b6dee532e0d17d3bf46996841d6295f2a9c87a2046fff4ab603c52ab9d7a7a6430a8b787b1574ae895849c603d262d1b22eef71736b5cb
+  languageName: node
+  linkType: hard
+
+"micromark-util-encode@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-encode@npm:2.0.1"
+  checksum: 10c0/b2b29f901093845da8a1bf997ea8b7f5e061ffdba85070dfe14b0197c48fda64ffcf82bfe53c90cf9dc185e69eef8c5d41cae3ba918b96bc279326921b59008a
+  languageName: node
+  linkType: hard
+
+"micromark-util-html-tag-name@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-html-tag-name@npm:2.0.1"
+  checksum: 10c0/ae80444db786fde908e9295f19a27a4aa304171852c77414516418650097b8afb401961c9edb09d677b06e97e8370cfa65638dde8438ebd41d60c0a8678b85b9
+  languageName: node
+  linkType: hard
+
+"micromark-util-normalize-identifier@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-normalize-identifier@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/5299265fa360769fc499a89f40142f10a9d4a5c3dd8e6eac8a8ef3c2e4a6570e4c009cf75ea46dce5ee31c01f25587bde2f4a5cc0a935584ae86dd857f2babbd
+  languageName: node
+  linkType: hard
+
+"micromark-util-resolve-all@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-resolve-all@npm:2.0.1"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/bb6ca28764696bb479dc44a2d5b5fe003e7177aeae1d6b0d43f24cc223bab90234092d9c3ce4a4d2b8df095ccfd820537b10eb96bb7044d635f385d65a4c984a
+  languageName: node
+  linkType: hard
+
+"micromark-util-sanitize-uri@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-sanitize-uri@npm:2.0.1"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/60e92166e1870fd4f1961468c2651013ff760617342918e0e0c3c4e872433aa2e60c1e5a672bfe5d89dc98f742d6b33897585cf86ae002cda23e905a3c02527c
+  languageName: node
+  linkType: hard
+
+"micromark-util-subtokenize@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "micromark-util-subtokenize@npm:2.0.3"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/75501986ecb02a6f06c0f3e58b584ae3ff3553b520260e8ce27d2db8c79b8888861dd9d3b26e30f5c6084fddd90f96dc3ff551f02c2ac4d669ebe920e483b6d6
+  languageName: node
+  linkType: hard
+
+"micromark-util-symbol@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-symbol@npm:2.0.1"
+  checksum: 10c0/f2d1b207771e573232436618e78c5e46cd4b5c560dd4a6d63863d58018abbf49cb96ec69f7007471e51434c60de3c9268ef2bf46852f26ff4aacd10f9da16fe9
+  languageName: node
+  linkType: hard
+
+"micromark-util-types@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-types@npm:2.0.1"
+  checksum: 10c0/872ec9334bb42afcc91c5bed8b7ee03b75654b36c6f221ab4d2b1bb0299279f00db948bf38ec6bc1ec03d0cf7842c21ab805190bf676157ba587eb0386d38b71
+  languageName: node
+  linkType: hard
+
+"micromark@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "micromark@npm:4.0.1"
+  dependencies:
+    "@types/debug": "npm:^4.0.0"
+    debug: "npm:^4.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/b5d950c84664ce209575e5a54946488f0a1e1240d080544e657b65074c9b08208a5315d9db066b93cbc199ec05f68552ba8b09fd5e716c726f4a4712275a7c5c
   languageName: node
   linkType: hard
 
@@ -4099,6 +4712,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-entities@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "parse-entities@npm:4.0.2"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+    character-reference-invalid: "npm:^2.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    is-alphanumerical: "npm:^2.0.0"
+    is-decimal: "npm:^2.0.0"
+    is-hexadecimal: "npm:^2.0.0"
+  checksum: 10c0/a13906b1151750b78ed83d386294066daf5fb559e08c5af9591b2d98cc209123103016a01df776f65f8219ad26652d6d6b210d0974d452049cddfc53a8916c34
+  languageName: node
+  linkType: hard
+
 "parse-json@npm:^5.0.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
@@ -4198,6 +4826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"property-information@npm:^6.0.0":
+  version: 6.5.0
+  resolution: "property-information@npm:6.5.0"
+  checksum: 10c0/981e0f9cc2e5acdb414a6fd48a99dd0fd3a4079e7a91ab41cf97a8534cf43e0e0bc1ffada6602a1b3d047a33db8b5fc2ef46d863507eda712d5ceedac443f0ef
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.3.0
   resolution: "punycode@npm:2.3.0"
@@ -4242,6 +4877,27 @@ __metadata:
   version: 19.0.0
   resolution: "react-is@npm:19.0.0"
   checksum: 10c0/d1be8e8500cf04f76df71942a21ef3a71266397a383d7ec8885f35190df818d35c65efd35aed7be47a89ad99aaff2c52e0c4e39e8930844a6b997622e50625a8
+  languageName: node
+  linkType: hard
+
+"react-markdown@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "react-markdown@npm:9.0.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    devlop: "npm:^1.0.0"
+    hast-util-to-jsx-runtime: "npm:^2.0.0"
+    html-url-attributes: "npm:^3.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-rehype: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    vfile: "npm:^6.0.0"
+  peerDependencies:
+    "@types/react": ">=18"
+    react: ">=18"
+  checksum: 10c0/3a3895dbd56647bc864b8da46dd575e71a9e609eb1e43fea8e8e6209d86e208eddd5b07bf8d7b5306a194b405440760a8d134aebd5a4ce5dc7dee4299e84db96
   languageName: node
   linkType: hard
 
@@ -4316,6 +4972,31 @@ __metadata:
     es-errors: "npm:^1.3.0"
     set-function-name: "npm:^2.0.2"
   checksum: 10c0/e1a7c7dc42cc91abf73e47a269c4b3a8f225321b7f617baa25821f6a123a91d23a73b5152f21872c566e699207e1135d075d2251cd3e84cc96d82a910adf6020
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-parse@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/6eed15ddb8680eca93e04fcb2d1b8db65a743dcc0023f5007265dda558b09db595a087f622062ccad2630953cd5cddc1055ce491d25a81f3317c858348a8dd38
+  languageName: node
+  linkType: hard
+
+"remark-rehype@npm:^11.0.0":
+  version: 11.1.1
+  resolution: "remark-rehype@npm:11.1.1"
+  dependencies:
+    "@types/hast": "npm:^3.0.0"
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-hast: "npm:^13.0.0"
+    unified: "npm:^11.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/68f986e8ee758d415e93babda2a0d89477c15b7c200edc23b8b1d914dd6e963c5fc151a11cbbbcfa7dd237367ff3ef86e302be90f31f37a17b0748668bd8c65b
   languageName: node
   linkType: hard
 
@@ -4694,6 +5375,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"space-separated-tokens@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "space-separated-tokens@npm:2.0.2"
+  checksum: 10c0/6173e1d903dca41dcab6a2deed8b4caf61bd13b6d7af8374713500570aa929ff9414ae09a0519f4f8772df993300305a395d4871f35bc4ca72b6db57e1f30af8
+  languageName: node
+  linkType: hard
+
 "streamsearch@npm:^1.1.0":
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
@@ -4804,6 +5492,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stringify-entities@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "stringify-entities@npm:4.0.4"
+  dependencies:
+    character-entities-html4: "npm:^2.0.0"
+    character-entities-legacy: "npm:^3.0.0"
+  checksum: 10c0/537c7e656354192406bdd08157d759cd615724e9d0873602d2c9b2f6a5c0a8d0b1d73a0a08677848105c5eebac6db037b57c0b3a4ec86331117fa7319ed50448
+  languageName: node
+  linkType: hard
+
 "strip-bom@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
@@ -4815,6 +5513,15 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"style-to-object@npm:^1.0.0":
+  version: 1.0.8
+  resolution: "style-to-object@npm:1.0.8"
+  dependencies:
+    inline-style-parser: "npm:0.2.4"
+  checksum: 10c0/daa6646b1ff18258c0ca33ed281fbe73485c8391192db1b56ce89d40c93ea64507a41e8701d0dadfe771bc2f540c46c9b295135f71584c8e5cb23d6a19be9430
   languageName: node
   linkType: hard
 
@@ -4893,6 +5600,20 @@ __metadata:
   version: 3.0.1
   resolution: "totalist@npm:3.0.1"
   checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
+  languageName: node
+  linkType: hard
+
+"trim-lines@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "trim-lines@npm:3.0.1"
+  checksum: 10c0/3a1611fa9e52aa56a94c69951a9ea15b8aaad760eaa26c56a65330dc8adf99cb282fc07cc9d94968b7d4d88003beba220a7278bbe2063328eb23fb56f9509e94
+  languageName: node
+  linkType: hard
+
+"trough@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "trough@npm:2.2.0"
+  checksum: 10c0/58b671fc970e7867a48514168894396dd94e6d9d6456aca427cc299c004fe67f35ed7172a36449086b2edde10e78a71a284ec0076809add6834fb8f857ccb9b0
   languageName: node
   linkType: hard
 
@@ -5099,12 +5820,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unified@npm:^11.0.0":
+  version: 11.0.5
+  resolution: "unified@npm:11.0.5"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    bail: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    extend: "npm:^3.0.0"
+    is-plain-obj: "npm:^4.0.0"
+    trough: "npm:^2.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/53c8e685f56d11d9d458a43e0e74328a4d6386af51c8ac37a3dcabec74ce5026da21250590d4aff6733ccd7dc203116aae2b0769abc18cdf9639a54ae528dfc9
+  languageName: node
+  linkType: hard
+
+"unist-util-is@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "unist-util-is@npm:6.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/9419352181eaa1da35eca9490634a6df70d2217815bb5938a04af3a662c12c5607a2f1014197ec9c426fbef18834f6371bfdb6f033040fa8aa3e965300d70e7e
+  languageName: node
+  linkType: hard
+
+"unist-util-position@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-position@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/dde3b31e314c98f12b4dc6402f9722b2bf35e96a4f2d463233dd90d7cde2d4928074a7a11eff0a5eb1f4e200f27fc1557e0a64a7e8e4da6558542f251b1b7400
+  languageName: node
+  linkType: hard
+
+"unist-util-stringify-position@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unist-util-stringify-position@npm:4.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/dfe1dbe79ba31f589108cb35e523f14029b6675d741a79dea7e5f3d098785045d556d5650ec6a8338af11e9e78d2a30df12b1ee86529cded1098da3f17ee999e
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "unist-util-visit-parents@npm:6.0.1"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/51b1a5b0aa23c97d3e03e7288f0cdf136974df2217d0999d3de573c05001ef04cccd246f51d2ebdfb9e8b0ed2704451ad90ba85ae3f3177cf9772cef67f56206
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-visit@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10c0/51434a1d80252c1540cce6271a90fd1a106dbe624997c09ed8879279667fb0b2d3a685e02e92bf66598dcbe6cdffa7a5f5fb363af8fdf90dda6c855449ae39a5
+  languageName: node
+  linkType: hard
+
 "uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
+  languageName: node
+  linkType: hard
+
+"vfile-message@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "vfile-message@npm:4.0.2"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/07671d239a075f888b78f318bc1d54de02799db4e9dce322474e67c35d75ac4a5ac0aaf37b18801d91c9f8152974ea39678aa72d7198758b07f3ba04fb7d7514
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "vfile@npm:6.0.3"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
   languageName: node
   linkType: hard
 
@@ -5275,5 +6079,12 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "zwitch@npm:2.0.4"
+  checksum: 10c0/3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e
   languageName: node
   linkType: hard


### PR DESCRIPTION
This will be useful for attribute descriptions on wallet pages, as it allows them to focus on content alone while the Markdown rendering takes care of presentation concerns.

Currently, page contents has been limited to either basic text, either fully-specified and styled JSX components. Markdown provides a happy middle. For example, it allows **emphasis**, lists, links, and such basic markup without needing to write custom JSX components for each attribute.

This is PR 2️⃣.

Previous PRs this one sits on top of:
* #56