### PR TITLE
1️⃣: More content on per-wallet page

### DIFF
--- a/src/beta/components/ThemeRegistry/theme.ts
+++ b/src/beta/components/ThemeRegistry/theme.ts
@@ -1,4 +1,5 @@
-import { createTheme, type ThemeOptions, lighten } from '@mui/material/styles';
+import { deepmerge } from '@mui/utils';
+import { createTheme, type ThemeOptions } from '@mui/material/styles';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
 /* eslint @typescript-eslint/no-magic-numbers: 0 -- A theme file will have numbers and hex codes in it, this is normal. */
@@ -152,10 +153,37 @@ const theme = createTheme(themeOptions);
 
 export default theme;
 
-export const moreColors = {
-  lightPaperBackground: lighten(theme.palette.background.paper, 0.05),
-  lighterPaperBackground: lighten(theme.palette.background.paper, 0.5),
-  lighterPrimary: lighten(theme.palette.primary.light, 0.5),
-  lightSuccess: '#B3FFC7',
-  lighterSuccess: lighten(theme.palette.success.light, 0.5),
+const subsectionThemeOptions: ThemeOptions = {
+  typography: {
+    // Top-level headers don't exist in subsections.
+    // They are for page-wide titles.
+    h1: undefined,
+    // Second-level headers also don't exist in subsection.
+    // They only make sense as top-level section headers.
+    h2: undefined,
+    // h3 is where subsection headers start to make sense.
+    h3: {
+      fontWeight: 500,
+      fontSize: '1.5rem',
+    },
+    // h4 is used inside accordion headers.
+    h4: {
+      fontWeight: 400,
+      fontSize: '0.9rem',
+    },
+    caption: {
+      fontWeight: 500,
+      fontSize: '0.75rem',
+    },
+    body1: {
+      fontWeight: 400,
+      fontSize: '0.85rem',
+    },
+    body2: {
+      fontWeight: 300,
+      fontSize: '0.8rem',
+    },
+  },
 };
+
+export const subsectionTheme = createTheme(deepmerge(themeOptions, subsectionThemeOptions));

--- a/src/beta/components/ui/atoms/Accordions.tsx
+++ b/src/beta/components/ui/atoms/Accordions.tsx
@@ -2,7 +2,7 @@ import type { NonEmptyArray } from '@/beta/types/utils/non-empty';
 import type React from 'react';
 import { useState } from 'react';
 import theme from '../../ThemeRegistry/theme';
-import { Accordion, AccordionDetails, AccordionSummary, darken } from '@mui/material';
+import { Accordion, AccordionDetails, AccordionSummary, darken, Typography } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 export interface AccordionData {
@@ -15,10 +15,12 @@ export interface AccordionData {
 export function Accordions({
   accordions,
   borderRadius,
+  summaryTypographyVariant = 'h1',
   interAccordionMargin = '1rem',
 }: {
   accordions: NonEmptyArray<AccordionData>;
   borderRadius: string;
+  summaryTypographyVariant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   interAccordionMargin?: string;
 }): React.JSX.Element {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
@@ -55,11 +57,15 @@ export function Accordions({
               id={accordion.id}
               expandIcon={<ExpandMoreIcon />}
             >
-              {accordion.summary}
+              <Typography variant={summaryTypographyVariant}>{accordion.summary}</Typography>
             </AccordionSummary>
             <AccordionDetails
               key={`${accordion.id}-details`}
               sx={{
+                paddingTop: '16px',
+                paddingBottom: '16px',
+                paddingLeft: '16px',
+                paddingRight: '16px',
                 backgroundColor: darken(theme.palette.background.paper, 0.1),
                 borderBottomLeftRadius: blankBottom ? borderRadius : '0px',
                 borderBottomRightRadius: blankBottom ? borderRadius : '0px',

--- a/src/beta/components/ui/atoms/MarkdownBase.tsx
+++ b/src/beta/components/ui/atoms/MarkdownBase.tsx
@@ -1,0 +1,62 @@
+import { Typography } from '@mui/material';
+import Link from 'next/link';
+import type React from 'react';
+import Markdown, { type Components } from 'react-markdown';
+import { ExternalLink } from './ExternalLink';
+
+/**
+ * Markdown rendering.
+ *
+ * Should not be used directly; use MarkdownBox or MarkdownTypography.
+ */
+export function MarkdownBase({
+  markdown,
+  pVariant = undefined,
+  pFontWeight = undefined,
+  pMarginTop = '0.5rem',
+  pMarginBottom = '0.5rem',
+  textColor = 'inherit',
+}: {
+  markdown: string;
+  pVariant?: React.ComponentProps<typeof Typography>['variant'];
+  pFontWeight?: React.ComponentProps<typeof Typography>['fontWeight'];
+  pMarginTop?: React.ComponentProps<typeof Typography>['marginTop'];
+  pMarginBottom?: React.ComponentProps<typeof Typography>['marginBottom'];
+  textColor?: React.ComponentProps<typeof Typography>['color'];
+}): React.JSX.Element {
+  const componentsMap: Components = {
+    a: ({ href, children }) => {
+      const hrefStr = href ?? '#';
+      if (/^[-_\w+:]/.exec(hrefStr) !== null) {
+        // External link.
+        return <ExternalLink url={hrefStr}>{children}</ExternalLink>;
+      }
+      return <Link href={hrefStr}>{children}</Link>;
+    },
+    p: ({ children }) => (
+      <Typography
+        variant={pVariant}
+        color={textColor}
+        fontWeight={pFontWeight}
+        marginTop={pMarginTop}
+        marginBottom={pMarginBottom}
+      >
+        {children}
+      </Typography>
+    ),
+    li: ({ children }) => (
+      <li>
+        <Typography
+          variant={pVariant}
+          color={textColor}
+          fontWeight={pFontWeight}
+          marginTop={pMarginTop}
+          marginBottom={pMarginBottom}
+        >
+          {children}
+        </Typography>
+      </li>
+    ),
+  };
+  return <Markdown components={componentsMap}>{markdown}</Markdown>;
+}

--- a/src/beta/components/ui/atoms/MarkdownBox.tsx
+++ b/src/beta/components/ui/atoms/MarkdownBox.tsx
@@ -1,0 +1,73 @@
+import { Box, type BoxProps, type TypographyProps } from '@mui/material';
+import type React from 'react';
+import { MarkdownBase } from './MarkdownBase';
+
+interface MarkdownBoxProps extends BoxProps {
+  children: string;
+  pTypography?: TypographyProps;
+}
+
+/**
+ * Trim longest shared whitespace prefix in all non-whitespace-only lines.
+ *
+ * Useful to make Markdown text properly indented in source code, yet
+ * rendered correctly when passed to the Markdown renderer which assumes
+ * no indentation in its input.
+ */
+function trimWhitespacePrefix(str: string): string {
+  const lines = str.split('\n');
+  let longestCommonPrefix: string | null = null;
+  for (const line of lines) {
+    if (line.trim() === '') {
+      continue; // Ignore whitespace-only lines.
+    }
+    const whitespacePrefixReg = /^\s+/.exec(line);
+    if (whitespacePrefixReg === null) {
+      return str; // No common whitespace prefix. Short circuit.
+    }
+    let whitespacePrefix = whitespacePrefixReg[0];
+    if (longestCommonPrefix === null) {
+      // First non-whitespace-only line.
+      // Set the common prefix to the current one.
+      longestCommonPrefix = whitespacePrefix;
+      continue;
+    }
+    if (whitespacePrefix.length > longestCommonPrefix.length) {
+      // Trim to match length of common prefix.
+      whitespacePrefix = whitespacePrefix.substring(0, longestCommonPrefix.length);
+    } else if (whitespacePrefix.length < longestCommonPrefix.length) {
+      // Trim to match length of current line prefix.
+      longestCommonPrefix = longestCommonPrefix.substring(0, whitespacePrefix.length);
+    }
+    if (whitespacePrefix !== longestCommonPrefix) {
+      return str; // No common whitespace prefix. Short circuit.
+    }
+  }
+  if (longestCommonPrefix === null || longestCommonPrefix === '') {
+    return str;
+  }
+  return lines
+    .map(line =>
+      line.startsWith(longestCommonPrefix) ? line.substring(longestCommonPrefix.length) : line
+    )
+    .join('\n');
+}
+
+/**
+ * Styled Markdown Box.
+ */
+export function MarkdownBox(props: MarkdownBoxProps): React.JSX.Element {
+  const { pTypography, ...boxProps } = props;
+  return (
+    <Box {...boxProps}>
+      <MarkdownBase
+        markdown={trimWhitespacePrefix(props.children)}
+        textColor={pTypography?.color}
+        pFontWeight={pTypography?.fontWeight}
+        pMarginTop={pTypography?.marginTop}
+        pMarginBottom={pTypography?.marginBottom}
+        pVariant={pTypography?.variant}
+      />
+    </Box>
+  );
+}

--- a/src/beta/components/ui/atoms/MarkdownTypography.tsx
+++ b/src/beta/components/ui/atoms/MarkdownTypography.tsx
@@ -1,0 +1,23 @@
+import type { TypographyProps } from '@mui/material';
+import type React from 'react';
+import { MarkdownBase } from './MarkdownBase';
+
+interface MarkdownTypographyProps extends TypographyProps {
+  children: string;
+}
+
+/**
+ * Styled Markdown Typography.
+ */
+export function MarkdownTypography(props: MarkdownTypographyProps): React.JSX.Element {
+  return (
+    <MarkdownBase
+      markdown={props.children.trim()}
+      textColor={props.color}
+      pFontWeight={props.fontWeight}
+      pMarginTop={props.marginTop}
+      pMarginBottom={props.marginBottom}
+      pVariant={props.variant}
+    />
+  );
+}

--- a/src/beta/components/ui/molecules/WalletRatingCell.tsx
+++ b/src/beta/components/ui/molecules/WalletRatingCell.tsx
@@ -146,16 +146,18 @@ export function WalletRatingCell<Vs extends ValueSet>({
               </Typography>
               {highlightedEvalAttr.evaluation.value.shortExplanation.render({
                 ...row.wallet.metadata,
-                prefix: ratingToIcon(highlightedEvalAttr.evaluation.value.rating) + ' ',
-                suffix:
-                  row.table.variantSelected !== null &&
-                  attributeEvaluationIsUniqueToVariant(
-                    row.wallet,
-                    row.table.variantSelected,
-                    highlightedEvalAttr.attribute
-                  )
-                    ? ` This is only the case on the ${row.table.variantSelected} version.`
-                    : '',
+                textTransform: (input: string) => {
+                  const suffix =
+                    row.table.variantSelected !== null &&
+                    attributeEvaluationIsUniqueToVariant(
+                      row.wallet,
+                      row.table.variantSelected,
+                      highlightedEvalAttr.attribute
+                    )
+                      ? ` This is only the case on the ${row.table.variantSelected} version.`
+                      : '';
+                  return `${ratingToIcon(highlightedEvalAttr.evaluation.value.rating)} ${input.trim()}${suffix}`;
+                },
                 typography: {
                   variant: 'caption',
                   lineHeight: 1.15,

--- a/src/beta/components/ui/molecules/attributes/AttributeMethodology.tsx
+++ b/src/beta/components/ui/molecules/attributes/AttributeMethodology.tsx
@@ -1,0 +1,211 @@
+import {
+  type Attribute,
+  type Evaluation,
+  type ExampleRating,
+  Rating,
+  ratingToIcon,
+  type Value,
+} from '@/beta/schema/attributes';
+import { Divider, Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import type { NonEmptyArray } from '@/beta/types/utils/non-empty';
+import React from 'react';
+import { mdSentence, type Sentence, type WithTypography } from '@/beta/types/text';
+import { styled } from '@mui/material/styles';
+
+const typographyPropsHeader: WithTypography['typography'] = {
+  variant: 'h6',
+};
+
+const typographyPropsBody: WithTypography['typography'] = {
+  variant: 'body2',
+};
+
+interface ListItemProps {
+  isFirstItem: boolean;
+  bulletText: string;
+  bulletFontSize?: string;
+  spaceBetweenItems?: string;
+}
+
+const StyledListItem = styled('li')<ListItemProps>`
+  margin-top: ${props => (props.isFirstItem ? '0px' : (props.spaceBetweenItems ?? '0px'))};
+  &::marker {
+    content: '${props => props.bulletText}  ';
+    font-size: ${props => props.bulletFontSize ?? 'inherit'};
+  }
+`;
+
+function replaceExampleRatingPrefix(
+  theWallet: string,
+  theWalletPossessive: string
+): (text: string) => string {
+  return (text: string): string => {
+    const whitespacePrefixLength = text.length - text.trimStart().length;
+    const whitespacePrefix =
+      whitespacePrefixLength === 0 ? '' : text.substring(0, whitespacePrefixLength);
+    const unprefixedText =
+      whitespacePrefixLength === 0 ? text : text.substring(whitespacePrefix.length);
+    if (unprefixedText.startsWith('The wallet ')) {
+      return `${whitespacePrefix}${theWallet}${unprefixedText.substring('The wallet '.length)}`;
+    }
+    if (unprefixedText.startsWith("The wallet's ")) {
+      return `${whitespacePrefix}${theWalletPossessive}${unprefixedText.substring("The wallet's ".length)}`;
+    }
+    throw new Error(
+      `Example ratings should always begin with the phrase "The wallet"; got: "${unprefixedText}"`
+    );
+  };
+}
+
+function ExampleRatings<V extends Value>({
+  displayOrder,
+  passExamples,
+  partialExamples,
+  failExamples,
+  exhaustive,
+}: {
+  displayOrder: 'pass-fail' | 'fail-pass';
+  passExamples: ExampleRating<V> | NonEmptyArray<ExampleRating<V>>;
+  partialExamples: ExampleRating<V> | Array<ExampleRating<V>> | undefined;
+  failExamples: ExampleRating<V> | NonEmptyArray<ExampleRating<V>>;
+  exhaustive: boolean;
+}): React.JSX.Element {
+  const renderListItem = (
+    exampleRating: ExampleRating<V>,
+    index: number,
+    rating: Rating
+  ): React.JSX.Element => (
+    // Safe to use index as key here because example ratings are static and
+    // never change order within the same rating.
+    <StyledListItem
+      key={`example-${index}`}
+      bulletText={ratingToIcon(rating)}
+      bulletFontSize="0.6rem"
+      isFirstItem={index === 0}
+      spaceBetweenItems="0.125rem"
+    >
+      {exampleRating.description.render({
+        textTransform: replaceExampleRatingPrefix('It ', 'Its '),
+        typography: typographyPropsBody,
+      })}
+    </StyledListItem>
+  );
+  const renderExamples = (
+    rating: Rating,
+    singularPreamble: Sentence,
+    pluralPreamble: Sentence,
+    exampleRatings: ExampleRating<V> | Array<ExampleRating<V>> | undefined
+  ): { key: string; element: React.JSX.Element | null } => {
+    const ratingsList: Array<ExampleRating<V>> =
+      exampleRatings === undefined
+        ? []
+        : Array.isArray(exampleRatings)
+          ? exampleRatings
+          : [exampleRatings];
+    if (ratingsList.length === 0) {
+      return { key: rating, element: null };
+    }
+    const preamble = ratingsList.length === 1 ? singularPreamble : pluralPreamble;
+    return {
+      key: rating,
+      element: (
+        <React.Fragment>
+          {preamble.render({
+            typography: typographyPropsHeader,
+          })}
+          <ul>
+            {ratingsList.map((exampleRating, index) =>
+              renderListItem(exampleRating, index, rating)
+            )}
+          </ul>
+        </React.Fragment>
+      ),
+    };
+  };
+  const passRendered = renderExamples(
+    Rating.YES,
+    mdSentence('A wallet would get a **passing** rating if...'),
+    mdSentence('A wallet would get a **passing** rating in any of these cases:'),
+    passExamples
+  );
+  const partialRendered = renderExamples(
+    Rating.PARTIAL,
+    mdSentence('A wallet would get a **partial** rating if...'),
+    mdSentence('A wallet would get a **partial** rating in any of these cases:'),
+    partialExamples
+  );
+  const failRendered = renderExamples(
+    Rating.NO,
+    mdSentence('A wallet would get a **failing** rating if...'),
+    mdSentence('A wallet would get a **failing** rating in any of these cases:'),
+    failExamples
+  );
+  const renderedExamples: Array<{ key: string; element: React.JSX.Element | null }> = (() => {
+    switch (displayOrder) {
+      case 'pass-fail':
+        return [passRendered, partialRendered, failRendered];
+      case 'fail-pass':
+        return [failRendered, partialRendered, passRendered];
+    }
+  })();
+  return (
+    <>
+      <Typography variant="h5">{exhaustive ? 'In other words' : 'A few examples'}</Typography>
+      <Box>
+        {renderedExamples.map(renderedExample =>
+          renderedExample.element === null ? null : (
+            <Box key={renderedExample.key}>{renderedExample.element}</Box>
+          )
+        )}
+      </Box>
+    </>
+  );
+}
+
+/**
+ * Explain how an attribute is evaluated.
+ * This is a wallet-agnostic, attribute-specific description.
+ * However, it can optionally take in an `Evaluation`, which is used to match
+ * a wallet's evaluation against one of the example evaluations of the
+ * attribute and highlight this example.
+ */
+export function AttributeMethodology<V extends Value>({
+  attribute,
+  evaluation = undefined,
+}: {
+  attribute: Attribute<V>;
+  evaluation?: Evaluation<V>;
+}): React.JSX.Element {
+  return (
+    <>
+      <Box key="methodology">
+        {attribute.methodology.render({
+          typography: typographyPropsBody,
+        })}
+      </Box>
+      <Divider
+        key="after-methodology"
+        sx={{
+          marginTop: '1rem',
+          marginBottom: '1rem',
+        }}
+      />
+      <Box key="example-ratings">
+        {attribute.ratingScale.display === 'simple' ? (
+          attribute.ratingScale.content.render({
+            typography: typographyPropsBody,
+          })
+        ) : (
+          <ExampleRatings
+            displayOrder={attribute.ratingScale.display}
+            passExamples={attribute.ratingScale.pass}
+            partialExamples={attribute.ratingScale.partial}
+            failExamples={attribute.ratingScale.fail}
+            exhaustive={attribute.ratingScale.exhaustive}
+          />
+        )}
+      </Box>
+    </>
+  );
+}

--- a/src/beta/components/ui/organisms/WalletAttribute.tsx
+++ b/src/beta/components/ui/organisms/WalletAttribute.tsx
@@ -15,6 +15,7 @@ import { subsectionBorderRadius, subsectionIconWidth, subsectionWeight } from '.
 import { type AccordionData, Accordions } from '../atoms/Accordions';
 import type { NonEmptyArray } from '@/beta/types/utils/non-empty';
 import { WrapRatingIcon } from '../atoms/WrapRatingIcon';
+import { AttributeMethodology } from '../molecules/attributes/AttributeMethodology';
 
 export function WalletAttribute<Vs extends ValueSet, V extends Value>({
   wallet,
@@ -70,24 +71,29 @@ export function WalletAttribute<Vs extends ValueSet, V extends Value>({
           : 'Why should I care?',
       contents: evalAttr.attribute.why.render({
         typography: {
-          fontWeight: 400,
+          variant: 'body2',
         },
       }),
+    },
+    {
+      id: `methodology-${evalAttr.attribute.id}`,
+      summary: `How is ${evalAttr.attribute.midSentenceName} evaluated?`,
+      contents: (
+        <AttributeMethodology attribute={evalAttr.attribute} evaluation={evalAttr.evaluation} />
+      ),
     },
   ];
   const howToImprove =
     override?.howToImprove !== undefined ? override.howToImprove : evalAttr.evaluation.howToImprove;
   if (howToImprove !== undefined) {
-    const isTypography = isRenderableTypography(howToImprove);
-    const renderProps = {
-      wallet,
-      value: evalAttr.evaluation.value,
-      typography: isTypography ? { fontWeight: 400 } : undefined,
-    };
     accordions.push({
       id: `how-${evalAttr.attribute.id}`,
-      summary: `What can ${wallet.metadata.displayName} do about this?`,
-      contents: howToImprove.render(renderProps),
+      summary: `What can ${wallet.metadata.displayName} do about its ${evalAttr.attribute.midSentenceName}?`,
+      contents: howToImprove.render({
+        wallet,
+        value: evalAttr.evaluation.value,
+        typography: { variant: 'body2' },
+      }),
     });
   }
   return (
@@ -106,6 +112,7 @@ export function WalletAttribute<Vs extends ValueSet, V extends Value>({
       <Accordions
         accordions={accordions}
         borderRadius={`${subsectionBorderRadius}px`}
+        summaryTypographyVariant="h4"
         interAccordionMargin="1rem"
       />
     </>

--- a/src/beta/components/ui/pages/WalletPage.tsx
+++ b/src/beta/components/ui/pages/WalletPage.tsx
@@ -19,9 +19,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { WalletIcon } from '../atoms/WalletIcon';
 import { AnchorHeader } from '../atoms/AnchorHeader';
 import { WalletAttribute } from '../organisms/WalletAttribute';
-import { blend } from '@mui/system';
+import { blend, ThemeProvider } from '@mui/system';
 import HomeIcon from '@mui/icons-material/Home';
-import theme from '@/beta/components/ThemeRegistry/theme';
+import theme, { subsectionTheme } from '@/beta/components/ThemeRegistry/theme';
 import { ratingToColor } from '@/beta/schema/attributes';
 import {
   listIconSize,
@@ -205,7 +205,6 @@ export function WalletPage({ walletName }: { walletName: WalletName }): React.JS
         caption: evalAttr.attribute.question.render({
           typography: {
             variant: 'caption',
-            fontSize: '1rem',
           },
           ...wallet.metadata,
         }),
@@ -481,35 +480,36 @@ export function WalletPage({ walletName }: { walletName: WalletName }): React.JS
                   )}
                   {section.subsections?.map(subsection => (
                     <StyledSubsection key={sectionHeaderId(subsection)} sx={subsection.sx}>
-                      <AnchorHeader
-                        key="subsectionHeader"
-                        id={sectionHeaderId(subsection) ?? undefined}
-                        sx={{ scrollMarginTop }}
-                        variant="h5"
-                        component="h3"
-                        marginBottom="0rem"
-                        onClick={e => {
-                          if (e.button === 0) {
-                            scrollToSection(richSectionToSection(subsection));
-                            e.preventDefault();
-                          }
-                        }}
-                      >
-                        {subsection.icon} {subsection.title}
-                      </AnchorHeader>
-                      {subsection.caption === null ? null : (
-                        <Box
-                          key="subsectionCaption"
-                          marginLeft={subsectionIconWidth}
-                          marginBottom="1rem"
-                          sx={{ opacity: 0.8 }}
+                      <ThemeProvider theme={subsectionTheme}>
+                        <AnchorHeader
+                          key="subsectionHeader"
+                          id={sectionHeaderId(subsection) ?? undefined}
+                          sx={{ scrollMarginTop }}
+                          variant="h3"
+                          marginBottom="0rem"
+                          onClick={e => {
+                            if (e.button === 0) {
+                              scrollToSection(richSectionToSection(subsection));
+                              e.preventDefault();
+                            }
+                          }}
                         >
-                          {subsection.caption}
-                        </Box>
-                      )}
-                      {subsection.body === null ? null : (
-                        <Box key="subsectionBody">{subsection.body}</Box>
-                      )}
+                          {subsection.icon} {subsection.title}
+                        </AnchorHeader>
+                        {subsection.caption === null ? null : (
+                          <Box
+                            key="subsectionCaption"
+                            marginLeft={subsectionIconWidth}
+                            marginBottom="1rem"
+                            sx={{ opacity: 0.8 }}
+                          >
+                            {subsection.caption}
+                          </Box>
+                        )}
+                        {subsection.body === null ? null : (
+                          <Box key="subsectionBody">{subsection.body}</Box>
+                        )}
+                      </ThemeProvider>
                     </StyledSubsection>
                   ))}
                 </StyledSection>

--- a/src/beta/schema/attributes/privacy/address-correlation.ts
+++ b/src/beta/schema/attributes/privacy/address-correlation.ts
@@ -1,5 +1,13 @@
 import type { ResolvedFeatures } from '@/beta/schema/features';
-import { Rating, type Value, type Attribute, type Evaluation } from '@/beta/schema/attributes';
+import {
+  Rating,
+  type Value,
+  type Attribute,
+  type Evaluation,
+  exampleRating,
+  exampleRatingUnimplemented,
+  type EvaluationData,
+} from '@/beta/schema/attributes';
 import { pickWorstRating, unrated } from '../common';
 import {
   compareLeakedInfo,
@@ -15,20 +23,22 @@ import {
   type Leaks,
   leaksByDefault,
 } from '@/beta/schema/features/privacy/data-collection';
-import { component, paragraph, sentence } from '@/beta/types/text';
+import {
+  component,
+  markdown,
+  paragraph,
+  type Renderable,
+  sentence,
+  type WithTypography,
+} from '@/beta/types/text';
 import type { WalletMetadata } from '@/beta/schema/wallet';
 import { AddressCorrelationDetails } from '@/beta/components/ui/molecules/attributes/privacy/AddressCorrelationDetails';
-import { exampleCex, exampleNodeCompany } from '@/beta/data/entities/example';
-import {
-  isNonEmptyArray,
-  type NonEmptyArray,
-  nonEmptyFirst,
-  nonEmptyMap,
-} from '@/beta/types/utils/non-empty';
+import { isNonEmptyArray, type NonEmptyArray, nonEmptyFirst } from '@/beta/types/utils/non-empty';
 import { type FullyQualifiedReference, refs } from '../../reference';
 
 const brand = 'attributes.privacy.address_correlation';
 export type AddressCorrelationValue = Value & {
+  worstLeak: WalletAddressLinkableBy | null;
   __brand: 'attributes.privacy.address_correlation';
 };
 
@@ -42,6 +52,7 @@ const uncorrelated: AddressCorrelationValue = {
       ${walletMetadata.displayName} keeps your wallet address private.
     `
   ),
+  worstLeak: null,
   __brand: brand,
 };
 
@@ -66,7 +77,7 @@ function linkable(
   );
   const { rating, howToImprove } = ((): {
     rating: Rating;
-    howToImprove: Evaluation<AddressCorrelationValue>['howToImprove'];
+    howToImprove: Renderable<WithTypography<EvaluationData<AddressCorrelationValue>>>;
   } => {
     const leakName = leakedInfoName(worstLeak.info).long;
     const by = worstLeak.by;
@@ -116,9 +127,9 @@ function linkable(
           rating: Rating.NO,
           howToImprove: paragraph(
             ({ wallet }) => `
-               ${wallet.metadata.displayName} should require user consent
-               before allowing personal information such as your ${leakName}
-               to be linkable to your wallet address.
+              ${wallet.metadata.displayName} should require user consent
+              before allowing personal information such as your ${leakName}
+              to be linkable to your wallet address.
             `
           ),
         };
@@ -143,6 +154,7 @@ function linkable(
           ${leakedInfoName(worstLeak.info, walletMetadata).short}.
         `;
       }),
+      worstLeak,
       __brand: brand,
     },
     details: component(AddressCorrelationDetails, { linkables }),
@@ -173,6 +185,7 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
   id: 'addressCorrelation',
   icon: '\u{1f517}', // Link
   displayName: 'Wallet address privacy',
+  midSentenceName: 'wallet address privacy',
   question: sentence(`
     Is your wallet address linkable to other information about yourself?
   `),
@@ -186,31 +199,82 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
     It is therefore important to use a wallet that does its best to protect
     your information from being linked to your wallet address.
   `),
-  explanationValues: [
-    uncorrelated,
-    linkable([
-      {
-        info: LeakedPersonalInfo.IP_ADDRESS,
-        leak: Leak.BY_DEFAULT,
-        by: exampleNodeCompany,
-        refs: [],
-      },
-    ]).value,
-    linkable(
-      nonEmptyMap(
-        [LeakedPersonalInfo.PHONE, LeakedPersonalInfo.CEX_ACCOUNT, LeakedPersonalInfo.IP_ADDRESS],
-        leakInfo => ({
-          info: leakInfo,
-          leak: Leak.BY_DEFAULT,
-          by: exampleCex,
-          refs: [],
-        })
-      )
-    ).value,
-  ],
+  methodology: markdown(`
+    In order to qualify for a perfect rating on wallet address privacy, a
+    wallet must not, *by default*, allow any third-party to link your wallet
+    address to any personal information.
+
+    As Walletbeat only considers the wallet's *default* behavior, wallets may
+    still choose to offer features that allow third-parties to link wallet
+    addresses with personal information, so long as this is done with explicit
+    user opt-in.
+
+    To determine this, Walletbeat looks at the network requests made by
+    wallets in their default configuration, and the contents of such requests.
+    If a request contains the user's wallet address, we look at whether it
+    also contains any other personal information, such as the user's name,
+    pseudonym, email address, phone number, CEX account information, etc.
+
+    Additionally, if such a request is not proxied, then it inherently reveals
+    the user's IP address and ties it with the user's wallet address, which is
+    also personal information.
+  `),
+  ratingScale: {
+    display: 'fail-pass',
+    exhaustive: false,
+    fail: [
+      exampleRating(
+        paragraph(`
+          The wallet requires user information (other than IP address and
+          pseudonyms) by default, and uploads this data to a third-party
+          or records it onchain in a publicly-viewable manner.
+        `),
+        Rating.NO
+      ),
+    ],
+    partial: [
+      exampleRating(
+        paragraph(`
+          The wallet allows a third party to learn the relationship between a
+          user's wallet address and their IP address by default. This is treated
+          as a partial rating because users may mitigate against this by forcing
+          wallet requests to be proxied on their own.
+        `),
+        (value: AddressCorrelationValue) =>
+          value.rating === Rating.PARTIAL && value.worstLeak?.info === LeakedPersonalInfo.IP_ADDRESS
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet requires the user to identify themselves via a pseudonym
+          which is sent to a third-party or recorded onchain. This is treated as
+          a partial rating because users may choose an arbitrary pseudonym for
+          each of their wallet address to mitigate this privacy issue.
+        `),
+        (value: AddressCorrelationValue) =>
+          value.rating === Rating.PARTIAL && value.worstLeak?.info === LeakedPersonalInfo.PSEUDONYM
+      ),
+    ],
+    pass: [
+      exampleRating(
+        paragraph(`
+          The wallet does not require any user information to function by
+          default, and proxies all network requests carrying the user's
+          wallet address.
+        `),
+        uncorrelated
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet relies exclusively on a user's self-hosted node,
+          involving no third parties.
+        `),
+        exampleRatingUnimplemented
+      ),
+    ],
+  },
   evaluate: (features: ResolvedFeatures): Evaluation<AddressCorrelationValue> => {
     if (features.privacy.dataCollection === null) {
-      return unrated(addressCorrelation, brand, null);
+      return unrated(addressCorrelation, brand, { worstLeak: null });
     }
     const linkables: WalletAddressLinkableBy[] = [];
     for (const collected of features.privacy.dataCollection.collectedByEntities) {

--- a/src/beta/schema/attributes/transparency/funding.ts
+++ b/src/beta/schema/attributes/transparency/funding.ts
@@ -1,14 +1,21 @@
 import type { ResolvedFeatures } from '@/beta/schema/features';
-import { Rating, type Value, type Attribute, type Evaluation } from '@/beta/schema/attributes';
+import {
+  Rating,
+  type Value,
+  type Attribute,
+  type Evaluation,
+  exampleRating,
+  exampleRatingUnimplemented,
+} from '@/beta/schema/attributes';
 import { pickWorstRating, unrated } from '../common';
 import {
   type Monetization,
   monetizationStrategies,
-  MonetizationStrategy,
+  type MonetizationStrategy,
   monetizationStrategyIsUserAligned,
   monetizationStrategyName,
 } from '@/beta/schema/features/monetization';
-import { component, paragraph, sentence } from '@/beta/types/text';
+import { component, markdown, paragraph, sentence } from '@/beta/types/text';
 import type { WalletMetadata } from '@/beta/schema/wallet';
 import { FundingDetails } from '@/beta/components/ui/molecules/attributes/transparency/FundingDetails';
 
@@ -70,6 +77,35 @@ function extractive(
   };
 }
 
+/** Wallet has no funding. */
+const noFunding: Evaluation<FundingValue> = {
+  value: {
+    id: 'noFunding',
+    rating: Rating.NO,
+    displayName: 'No funding source',
+    shortExplanation: sentence(
+      (walletMetadata: WalletMetadata) => `
+        ${walletMetadata.displayName} has no funding sources.
+      `
+    ),
+    __brand: brand,
+  },
+  details: paragraph(
+    ({ wallet }) => `
+      ${wallet.metadata.displayName} has no funding sources, making its future
+      unclear. Wallets need a consistent source of funding to ensure they keep
+      up with security vulnerabilities and ecosystem progress.
+    `
+  ),
+  howToImprove: paragraph(
+    ({ wallet }) => `
+      While most software projects inevitably start small and unfunded,
+      ${wallet.metadata.displayName} should seek a reliable source of funding
+      once feasible.
+    `
+  ),
+};
+
 /** Funding is not transparent. */
 const unclear: Evaluation<FundingValue> = {
   value: {
@@ -95,25 +131,6 @@ const unclear: Evaluation<FundingValue> = {
     `
   ),
 };
-
-/** Helper function to return a Monetization object with just one transparent strategy. */
-function oneMonetizationStrategy(strategy: MonetizationStrategy): Monetization {
-  return {
-    revenueBreakdownIsPublic: true,
-    strategies: {
-      selfFunded: strategy === MonetizationStrategy.SELF_FUNDED,
-      donations: strategy === MonetizationStrategy.DONATIONS,
-      ecosystemGrants: strategy === MonetizationStrategy.ECOSYSTEM_GRANTS,
-      publicOffering: strategy === MonetizationStrategy.PUBLIC_OFFERING,
-      ventureCapital: strategy === MonetizationStrategy.VENTURE_CAPITAL,
-      transparentConvenienceFees: strategy === MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES,
-      hiddenConvenienceFees: strategy === MonetizationStrategy.HIDDEN_CONVENIENCE_FEES,
-      governanceTokenLowFloat: strategy === MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT,
-      governanceTokenMostlyDistributed:
-        strategy === MonetizationStrategy.GOVERNANCE_TOKEN_MOSTLY_DISTRIBUTED,
-    },
-  };
-}
 
 /**
  * Funding encodes the transparency and user-alignment of the monetization
@@ -142,6 +159,7 @@ export const funding: Attribute<FundingValue> = {
   id: 'funding',
   icon: '\u{1fa99}', // Coin
   displayName: 'Funding',
+  midSentenceName: 'funding',
   question: sentence(`
     How is the wallet's development team funded?
   `),
@@ -151,19 +169,105 @@ export const funding: Attribute<FundingValue> = {
     in the ecosystem.
     This requires a reliable, transparent source of funding.
   `),
-  explanationValues: [
-    unclear.value,
-    extractive(
-      MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT,
-      monetizationStrategyName(MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT),
-      oneMonetizationStrategy(MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT)
-    ).value,
-    transparent(
-      MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES,
-      monetizationStrategyName(MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES),
-      oneMonetizationStrategy(MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES)
-    ).value,
-  ],
+  methodology: markdown(`
+    Wallets are assessed based on how sustainable, transparent, and
+    user-aligned their funding mechanisms are.
+
+    Wallets are typically funded by one or more of the following methods:
+
+    * Self-funding from developers
+    * Seeking donations from users
+    * Seeking grants from foundations
+    * Venture capital funding
+    * Charging fees on convenience functions (e.g. swapping and bridging
+      tokens)
+    * Governance tokens
+    * Commemorative NFT sales
+
+    Walletbeat looks at each funding source of funding and verifies whether
+    it is done transparently and in a user-aligned manner. In this context,
+    "user alignment" refers to whether a source of funding grows as a
+    function of the user's own goals, rather than being uncorrelated or
+    anti-correlated. For example, funding acquired through hidden swap fees
+    or governance token sales with undisclosed insider token allocations are
+    not user-aligned. Funding acquired through transparent swap fees, user
+    donations, or ecosystem grants are user-aligned.
+
+    In order to pass this criterion, wallets must have at least one source of
+    funding, and all of their sources of funding must be transparent to users.
+    Additionally, if the wallet is funded from multiple sources and some of
+    these sources are not user-aligned, the public must be able to determine
+    the proportion of each such funding source to the wallet's overall
+    revenue. Depending on the funding mechanism, this can be done through
+    publication of a revenue breakdown page, public regulatory filings,
+    or token allocation and vesting disclosures.
+  `),
+  ratingScale: {
+    display: 'fail-pass',
+    exhaustive: false,
+    fail: [
+      exampleRating(
+        paragraph(`
+          The wallet has funding but has not revealed this publicly and
+          transparently to users.
+        `),
+        unclear.value
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet does not have any funding.
+          Wallets must have sustainable funding sources in order to remain
+          secure and up-to-date.
+        `),
+        noFunding.value
+      ),
+    ],
+    partial: [
+      exampleRating(
+        paragraph(`
+          The wallet is funded from hidden swap fees. While users can look this
+          up onchain to see how much revenue the wallet is generating from this,
+          making this funding source technically transparent, it is not
+          user-aligned.
+        `),
+        exampleRatingUnimplemented
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet is funded from user-visible swap fees and governance token
+          sales with undisclosed vesting schedule. While users can use onchain
+          lookups to determine how much revenue is generated from both sources,
+          making the funding technically transparent, the undisclosed nature of
+          governance token makes makes this not user-aligned.
+        `),
+        exampleRatingUnimplemented
+      ),
+    ],
+    pass: [
+      exampleRating(
+        paragraph(`
+          The wallet is funded from user-visible swap fees and pre-disclosed
+          governance token sales.
+        `),
+        exampleRatingUnimplemented
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet is funded from venture capital and publishes regulatory
+          filings showing the amount raised in each round and the top investors
+          of each round.
+        `),
+        exampleRatingUnimplemented
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet is funded from onchain donations, onchain ecosystem
+          grants, and commemorative NFT sales.
+        `),
+        exampleRatingUnimplemented
+      ),
+    ],
+  },
   evaluate: (features: ResolvedFeatures): Evaluation<FundingValue> => {
     if (features.monetization === null) {
       return unrated(funding, brand, null);

--- a/src/beta/schema/attributes/transparency/open-source.ts
+++ b/src/beta/schema/attributes/transparency/open-source.ts
@@ -1,8 +1,14 @@
 import type { ResolvedFeatures } from '@/beta/schema/features';
 import { License, FOSS, licenseIsFOSS, licenseName } from '@/beta/schema/features/license';
-import { Rating, type Value, type Attribute, type Evaluation } from '@/beta/schema/attributes';
+import {
+  Rating,
+  type Value,
+  type Attribute,
+  type Evaluation,
+  exampleRating,
+} from '@/beta/schema/attributes';
 import { pickWorstRating, unrated } from '../common';
-import { component, paragraph, sentence } from '@/beta/types/text';
+import { component, markdown, mdParagraph, paragraph, sentence } from '@/beta/types/text';
 import type { WalletMetadata } from '@/beta/schema/wallet';
 import { LicenseDetails } from '@/beta/components/ui/molecules/attributes/transparency/LicenseDetails';
 
@@ -119,22 +125,65 @@ export const openSource: Attribute<OpenSourceValue> = {
   id: 'openSource',
   icon: '\u{2764}', // Heart
   displayName: 'Source code license',
+  midSentenceName: 'source code license',
   question: sentence(`
     Is the wallet's source code licensed under a Free and Open Source Software (FOSS) license?
   `),
-  why: paragraph(`
-    Free and Open Source Software (FOSS) licensing allows a software project's
-    source code to be freely used, modified and distributed. This allows
-    better collaboration, more transparency into the software development
-    practices that go into the project, and allows security researchers to
-    more easily identify and report security vulnerabilities.
-    In short, it turns software project into public goods.
+  why: mdParagraph(`
+    [Free and Open Source Software (FOSS) licensing](https://en.wikipedia.org/wiki/Open-source_license)
+    allows a software project's source code to be freely used, modified and
+    distributed. This allows better collaboration, more transparency into the
+    software development practices that go into the project, and allows
+    security researchers to more easily identify and report security
+    vulnerabilities. In short, it turns software projects into public goods.
   `),
-  explanationValues: [
-    open(License.APACHE_2_0).value,
-    openInTheFuture(License.BUSL_1_1).value,
-    proprietary.value,
-  ],
+  methodology: markdown(`
+    Wallets are assessed based whether the license of their source code meets
+    the [Open Source Initiative's definition of open source](https://en.wikipedia.org/wiki/The_Open_Source_Definition).
+  `),
+  ratingScale: {
+    display: 'pass-fail',
+    exhaustive: true,
+    pass: exampleRating(
+      mdParagraph(`
+        The wallet is licensed under a Free and Open Source Software (FOSS)
+        license. Examples of such licenses include
+        [MIT](https://opensource.org/license/MIT),
+        [Apache](https://opensource.org/license/apache-2-0),
+        [BSD](https://opensource.org/license/bsd-1-clause),
+        and [GPL](https://opensource.org/license/gpl-2-0).
+      `),
+      Rating.YES
+    ),
+    partial: exampleRating(
+      mdParagraph(`
+        The wallet is licensed under a license that represents a commitment to
+        switch to a Free and Open Source Software (FOSS) license by a specific
+        date. Examples of such licenses include
+        [BUSL](https://spdx.org/licenses/BUSL-1.1.html).
+      `),
+      Rating.PARTIAL
+    ),
+    fail: [
+      exampleRating(
+        paragraph(`
+          The wallet is licensed under any non-FOSS (proprietary) license.
+        `),
+        proprietary.value
+      ),
+      exampleRating(
+        paragraph(`
+          The wallet's source code repository is missing a license file.
+          The lack of a license file may be an accidental omission on the
+          wallet developers' part, but also may indicate that the wallet may
+          set its license to a proprietary license. Therefore, Walletbeat makes
+          the conservative assumption that the wallet is not be Free and Open
+          Open Source Software until it does have a valid license file.
+        `),
+        unlicensed.value
+      ),
+    ],
+  },
   evaluate: (features: ResolvedFeatures): Evaluation<OpenSourceValue> => {
     if (features.license === null) {
       return unrated(openSource, brand, { license: License.UNLICENSED_VISIBLE });

--- a/src/beta/schema/attributes/transparency/source-visibility.ts
+++ b/src/beta/schema/attributes/transparency/source-visibility.ts
@@ -18,8 +18,8 @@ const sourcePublic: Evaluation<SourceVisibilityValue> = {
     displayName: 'Source code publicly available',
     shortExplanation: sentence(
       (walletMetadata: WalletMetadata) => `
-      The source code for ${walletMetadata.displayName} is public.
-    `
+        The source code for ${walletMetadata.displayName} is public.
+      `
     ),
     __brand: brand,
   },
@@ -56,6 +56,7 @@ export const sourceVisibility: Attribute<SourceVisibilityValue> = {
   id: 'sourceVisibility',
   icon: '\u{1f35d}', // Spaghetti
   displayName: 'Source visibility',
+  midSentenceName: 'source visibility',
   question: sentence('Is the source code for the wallet visible to the public?'),
   why: paragraph(`
     When using a wallet, users are entrusting it to preserve their funds
@@ -65,7 +66,16 @@ export const sourceVisibility: Attribute<SourceVisibilityValue> = {
     security vulnerabilities and for potential malicious code.
     This improves the wallet's security and trustworthiness.
   `),
-  explanationValues: [sourcePublic.value, sourcePrivate.value],
+  methodology: sentence(`
+    Wallets are assessed based on whether or not their source code is
+    publicly visible, irrespective of the license of the source code.
+  `),
+  ratingScale: {
+    display: 'simple',
+    content: paragraph(`
+      If a wallet's source code is visible, it passes. If not, it fails.
+    `),
+  },
   evaluate: (features: ResolvedFeatures): Evaluation<SourceVisibilityValue> => {
     if (features.license === null) {
       return unrated(sourceVisibility, brand, null);

--- a/src/beta/schema/wallet.ts
+++ b/src/beta/schema/wallet.ts
@@ -7,7 +7,7 @@ import {
   type EvaluationTree,
 } from './attribute-groups';
 import { type NonEmptyArray, nonEmptyRemap } from '@/beta/types/utils/non-empty';
-import type { Paragraph, Renderable } from '@/beta/types/text';
+import type { Paragraph, Renderable, WithTypography } from '@/beta/types/text';
 import type { Url } from './url';
 import { Rating, type Attribute, type EvaluatedAttribute, type Value } from './attributes';
 import type { Dict } from '../types/utils/dict';
@@ -79,7 +79,7 @@ export interface AttributeOverride {
    * What the wallet should do to improve its rating on this attribute.
    * Overrides the eponymous field in `Evaluation`.
    */
-  howToImprove?: Renderable<{ wallet: RatedWallet }>;
+  howToImprove?: Renderable<WithTypography<{ wallet: RatedWallet }>>;
 }
 
 /** Per-wallet overrides for attributes. */


### PR DESCRIPTION
This PR expands the "how to improve" section and adds a "methodology" section.

It also refactors some existing page contents to take advantage of the newly-added markdown rendering support, and moves some styling rules for these subsections to a more central theme location.

These styling rules still need some changes as the font size is very tiny right now, but will do that in a later PR.

This is PR 1️⃣.