### PR TITLE
Fix MetaMask wallet name.

### DIFF
--- a/src/data/data.ts
+++ b/src/data/data.ts
@@ -35,7 +35,7 @@ import { welldone } from './wallets/welldone';
 import { zerion } from './wallets/zerion';
 
 export const wallets: Record<string, Info> = {
-  Metamask: metamask,
+  MetaMask: metamask,
   Uniswap: uniswap,
   Coinbase: coinbase,
   Rainbow: rainbow,


### PR DESCRIPTION
From `Metamask` to `MetaMask`.

This is a standalone PR which applies to the non-beta site.

h/t @Montoya
Fixes #62