### PR TITLE
Update Ambire Entry

### DIFF
--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -4,9 +4,9 @@ export const ambire: Info = {
   url: 'https://ambire.com',
   submittedByName: '@jordan-enev',
   submittedByUrl: 'https://github.com/jordan-enev',
-  updatedAt: '11/12/2023',
-  updatedByName: '@jordan-enev',
-  updatedByUrl: 'https://github.com/jordan-enev',
+  updatedAt: '24/01/2025',
+  updatedByName: '@superKalo',
+  updatedByUrl: 'https://github.com/superkalo',
   browser: {
     accountType: '4337',
     chainCompatibility: {

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -10,7 +10,7 @@ export const ambire: Info = {
   mobile: {
     accountType: '4337',
     chainCompatibility: {
-      configurable: false,
+      configurable: true,
       autoswitch: true,
       ethereum: true,
       optimism: true,

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -37,9 +37,9 @@ export const ambire: Info = {
     securityFeatures: {
       multisig: false,
       MPC: false,
-      keyRotation: true,
-      transactionScanning: false,
-      limitsAndTimelocks: true,
+      keyRotation: false,
+      transactionScanning: true,
+      limitsAndTimelocks: false,
       hardwareWalletSupport: true,
     },
     availableTestnets: {

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -7,7 +7,7 @@ export const ambire: Info = {
   updatedAt: '11/12/2023',
   updatedByName: '@jordan-enev',
   updatedByUrl: 'https://github.com/jordan-enev',
-  mobile: {
+  browser: {
     accountType: '4337',
     chainCompatibility: {
       configurable: true,
@@ -51,55 +51,6 @@ export const ambire: Info = {
       injected: true,
       embedded: false,
       inappBrowser: false,
-    },
-    modularity: {
-      modularity: false,
-    },
-  },
-  browser: {
-    accountType: '4337',
-    chainCompatibility: {
-      configurable: false,
-      autoswitch: true,
-      ethereum: true,
-      optimism: true,
-      arbitrum: true,
-      base: true,
-      polygon: true,
-      gnosis: true,
-      bnbSmartChain: true,
-      avalanche: true,
-    },
-    ensCompatibility: {
-      mainnet: true,
-      subDomains: true,
-      offchain: false,
-      L2s: false,
-      customDomains: false,
-      freeUsernames: false,
-    },
-    backupOptions: {
-      cloud: true,
-      local: true,
-      socialRecovery: true,
-    },
-    securityFeatures: {
-      multisig: false,
-      MPC: false,
-      keyRotation: false,
-      transactionScanning: false,
-      limitsAndTimelocks: true,
-      hardwareWalletSupport: true,
-    },
-    availableTestnets: {
-      availableTestnets: true,
-    },
-    license: 'OPEN_SOURCE',
-    connectionMethods: {
-      walletConnect: true,
-      injected: false,
-      embedded: true,
-      inappBrowser: true,
     },
     modularity: {
       modularity: false,

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -25,9 +25,9 @@ export const ambire: Info = {
       mainnet: true,
       subDomains: true,
       offchain: false,
-      L2s: false,
-      customDomains: false,
-      freeUsernames: false,
+      L2s: true,
+      customDomains: true,
+      freeUsernames: true,
     },
     backupOptions: {
       cloud: true,

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -50,7 +50,7 @@ export const ambire: Info = {
       walletConnect: false,
       injected: true,
       embedded: false,
-      inappBrowser: true,
+      inappBrowser: false,
     },
     modularity: {
       modularity: false,

--- a/src/data/wallets/ambire.ts
+++ b/src/data/wallets/ambire.ts
@@ -30,9 +30,9 @@ export const ambire: Info = {
       freeUsernames: true,
     },
     backupOptions: {
-      cloud: true,
+      cloud: false,
       local: true,
-      socialRecovery: true,
+      socialRecovery: false,
     },
     securityFeatures: {
       multisig: false,


### PR DESCRIPTION
Hey, we noticed the Ambire entry is outdated. My changes reflect the latest developments for Ambire:

The following information is valid for our flagship product: Ambire v2, the browser extension. Updates:

- Changed: I left only the browser extension, Ambire v2, our flagship product. The mobile app is yet to be migrated to v2.
- Changed: Ambire is configurable.
- Changed: ENS, The only thing that Ambire does not allow yet is getting a free (offchain) ENS inside the wallet.
- Changed: Backup, 1/3: Manual key backup is currently available.
- Changed: Security, 2/6: Hardware and scanning available.
- Changed: Connection, only Injected supported.
- Changed: Devices, 1/3: Browser extension.

And one question: our extension supports both EOA and 4337. I saw that for `type,` I can add only 1 value. Is there a way I can add both for our entry?