### PR TITLE
Enable subresource integrity (SRI)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -54,6 +54,7 @@
 		"jiffyscan",
 		"jiojosbg",
 		"KEEPKEY",
+		"kindspells",
 		"Kleptography",
 		"LDJSON",
 		"lifi",
@@ -131,6 +132,7 @@
 		"public/**/*.svg",
 		"node_modules/**",
 		"src/legacy/**",
+		"src/generated/**",
 		"pnpm-lock.yaml"
 	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 dist/
+src/generated/
 
 # Generated types
 .astro/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,13 @@
 // @ts-check
 import { defineConfig } from 'astro/config'
+import { resolve } from 'node:path'
 
 import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
+import { shield } from '@kindspells/astro-shield'
+
+const rootDir = new URL('.', import.meta.url).pathname
+const modulePath = resolve(rootDir, 'src', 'generated', 'sriHashes.mjs')
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,7 +16,13 @@ export default defineConfig({
 	output: 'static',
 	integrations: [
 		react(),
-		sitemap(), // Adds sitemap integration
+		sitemap(),
+		shield({
+			sri: {
+				enableMiddleware: true,
+				hashesModule: modulePath,
+			},
+		}),
 	],
 	vite: {
 		ssr: {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 	"devDependencies": {
 		"@astrojs/check": "^0.9.4",
 		"@fleek-platform/cli": "^3.8.2",
+		"@kindspells/astro-shield": "^1.7.1",
 		"@types/classnames": "^2.3.4",
 		"cspell": "^8.17.3",
 		"eslint": "^9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@fleek-platform/cli':
         specifier: ^3.8.2
         version: 3.8.2(@types/node@22.13.1)(typescript@5.7.3)
+      '@kindspells/astro-shield':
+        specifier: ^1.7.1
+        version: 1.7.1(astro@5.2.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.3)(sass-embedded@1.85.1)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))
       '@types/classnames':
         specifier: ^2.3.4
         version: 2.3.4
@@ -1363,6 +1366,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kindspells/astro-shield@1.7.1':
+    resolution: {integrity: sha512-8M6rbXNp1v7CbwIjDXJzlgnPuYHmqTLGAiiMK738AhYE191uWGi6mzEhQEW9U4agDzi6Cq6+WFjJ/ZavYDz4pg==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      astro: ^4.0.0
 
   '@mui/core-downloads-tracker@6.4.3':
     resolution: {integrity: sha512-hlyOzo2ObarllAOeT1ZSAusADE5NZNencUeIvXrdQ1Na+FL1lcznhbxfV5He1KqGiuR8Az3xtCUcYKwMVGFdzg==}
@@ -7390,6 +7399,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@kindspells/astro-shield@1.7.1(astro@5.2.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.3)(sass-embedded@1.85.1)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0))':
+    dependencies:
+      astro: 5.2.5(@types/node@22.13.1)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.34.3)(sass-embedded@1.85.1)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
 
   '@mui/core-downloads-tracker@6.4.3': {}
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,21 +56,6 @@ import ThemeRegistry from '@/components/ThemeRegistry/ThemeRegistry'
 		<ThemeRegistry>
 			<slot />
 		</ThemeRegistry>
-
-		<!-- Plausible -->
-		<script
-			is:inline
-			src="https://plausible.io/js/script.js"
-			async
-			defer
-			data-domain="walletbeat.fyi"></script>
-		<script is:inline id="plausible-init">
-			window.plausible =
-				window.plausible ||
-				function () {
-					;(window.plausible.q = window.plausible.q || []).push(arguments)
-				}
-		</script>
 	</body>
 </html>
 


### PR DESCRIPTION
This adds sha256 integrity hashes to all scripts and stylesheets. This ensures that if a webpage's HTML code can be served with integrity, then the external resources it depends on also are.

As part of this change, delete Plausible analytics, since this is an external resource.