### PR TITLE
Avoid redirect on home page load.

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,9 +8,14 @@ import { ClientRouter } from 'astro:transitions';
 
 type Props = {
   metadata: ComponentProps<typeof Metadata>['metadata'];
+
+  /**
+   * If specified, rewrite URL to this as the page loads.
+   */
+  rewriteUrlTo?: string;
 };
 
-const { metadata } = Astro.props;
+const { metadata, rewriteUrlTo } = Astro.props;
 
 // Components
 import Metadata from '@/components/Metadata.astro';
@@ -47,6 +52,13 @@ import { NavigationStateManager } from '@/components/NavigationStateManager';
       // Run immediately
       initializeTheme();
     </script>
+    {
+      rewriteUrlTo !== undefined && (
+        <script is:inline define:vars={{ rewriteUrlTo }}>
+          history.replaceState(null, '', rewriteUrlTo);
+        </script>
+      )
+    }
   </head>
   <body>
     <ThemeRegistry>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,13 @@
-<!doctype html>
-<html lang='en'>
-  <head>
-    <meta charset='UTF-8' />
-    <meta http-equiv='refresh' content='0; URL=/wallet/summary' />
-    <link rel='canonical' href='/wallet/summary' />
-    <title>Redirecting...</title>
-    <script>
-      window.location.href = '/wallet/summary';
-    </script>
-  </head>
-  <body>
-    <p>Redirecting to <a href='/wallet/summary'>/wallet/summary</a></p>
-  </body>
-</html>
+---
+import Layout from '../layouts/Layout.astro';
+import { HomePage } from '../components/HomePage';
+---
+
+<Layout
+  metadata={{
+    title: 'Walletbeat',
+  }}
+  rewriteUrlTo='/wallet/summary/'
+>
+  <HomePage client:load selectedGroupId='wallet' />
+</Layout>


### PR DESCRIPTION
This changes the `/` page to be a duplicate of the `/wallet/summary` page. However, on load, it instantly rewrites its URL to `/wallet/summary` (without causing a reload), so that is is functionally equivalent to a redirect.

This has the advantage of:
- Ensuring that linking to the website's homepage doesn't break OpenGraph data, as a JS-based redirect does
- Avoid a flash of white from the unstyled JS redirect page during its loading.
- Being much faster to load the homepage (even faster than an HTTP-protocol-level redirect), since the page's data is sent as part of the server's first response, whereas any form of redirect requires at least one more roundtrip.

This PR is on top of #154. This is such that they can both be merged together without breaking my commit signature. To preview the diff, please only look at the latest commit in the branch.