### PR TITLE
Add EIP-7702 tracker page skeleton

### DIFF
--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -12,6 +12,7 @@ import { nconsigny } from '../contributors/nconsigny';
 import { polymutex } from '../contributors/polymutex';
 import { cure53 } from '../entities/cure53';
 import { diligence } from '../entities/diligence';
+import { metamask7702DelegatorContract } from '../wallet-contracts/metamask-7702-delegator';
 
 export const metamask: SoftwareWallet = {
   metadata: {
@@ -32,7 +33,9 @@ export const metamask: SoftwareWallet = {
   features: {
     accountSupport: {
       defaultAccountType: AccountType.eoa,
-      eip7702: notSupported,
+      eip7702: supported({
+        contract: metamask7702DelegatorContract,
+      }),
       eoa: supported({
         canExportPrivateKey: true,
         keyDerivation: {

--- a/data/wallet-contracts/ambire-account.ts
+++ b/data/wallet-contracts/ambire-account.ts
@@ -2,6 +2,7 @@ import type { SmartWalletContract } from '@/schema/contracts';
 import { featureSupported } from '@/schema/features/support';
 
 export const ambireAccountContract: SmartWalletContract = {
+  name: 'Ambire Smart Account',
   address: '0x0f2aa7bcda3d9d210df69a394b6965cb2566c828',
   eip7702Delegatable: false,
   methods: {

--- a/data/wallet-contracts/ambire-delegator.ts
+++ b/data/wallet-contracts/ambire-delegator.ts
@@ -2,6 +2,7 @@ import type { SmartWalletContract } from '@/schema/contracts';
 import { featureSupported } from '@/schema/features/support';
 
 export const ambireDelegatorContract: SmartWalletContract = {
+  name: 'Ambire Delegator',
   address: '0x5a7fc11397e9a8ad41bf10bf13f22b0a63f96f6d',
   eip7702Delegatable: true,
   methods: {

--- a/data/wallet-contracts/metamask-7702-delegator.ts
+++ b/data/wallet-contracts/metamask-7702-delegator.ts
@@ -2,6 +2,7 @@ import type { SmartWalletContract } from '@/schema/contracts';
 import { featureSupported } from '@/schema/features/support';
 
 export const metamask7702DelegatorContract: SmartWalletContract = {
+  name: 'MetaMask 7702 Delegator',
   address: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
   eip7702Delegatable: true,
   methods: {

--- a/src/components/CriteriaPage.tsx
+++ b/src/components/CriteriaPage.tsx
@@ -65,6 +65,15 @@ export const walletNavigationGroups: NavigationGroup[] = Object.values(
                 id: attr.id,
               }),
             ),
+            ...(walletType === WalletType.SOFTWARE
+              ? [
+                  {
+                    title: 'EIP-7702 tracker',
+                    id: 'eip-7702-tracker',
+                    href: `/${walletTypeToUrlSlug(walletType)}/7702`,
+                  },
+                ]
+              : []),
           ],
         },
       ],

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -3,6 +3,7 @@ import { LuGithub } from 'react-icons/lu';
 
 import { walletNavigationGroups } from '@/components/CriteriaPage';
 import { navigationAbout } from '@/components/navigation';
+import { repositoryUrl } from '@/constants';
 import { NavigationPageLayout } from '@/layouts/NavigationPageLayout';
 import { ExternalLink } from '@/ui/atoms/ExternalLink';
 import WalletTable from '@/ui/organisms/WalletTable';
@@ -41,7 +42,7 @@ export const HomePage: FC<{ selectedGroupId?: string }> = ({ selectedGroupId }) 
                 <div className='flex flex-row gap-2 items-center' key='repo'>
                   <LuGithub />
                   <ExternalLink
-                    url='https://github.com/walletbeat/walletbeat'
+                    url={repositoryUrl}
                     defaultLabel='GitHub Repository'
                     style={{
                       fontWeight: 500,
@@ -60,7 +61,7 @@ export const HomePage: FC<{ selectedGroupId?: string }> = ({ selectedGroupId }) 
             <p className='text-secondary'>
               We welcome contributions via the{' '}
               <ExternalLink
-                url='https://github.com/walletbeat/walletbeat'
+                url={repositoryUrl}
                 defaultLabel='GitHub Repository'
                 style={{
                   fontWeight: 500,

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -3,7 +3,7 @@ import HelpCenterIcon from '@mui/icons-material/HelpCenter';
 import HomeIcon from '@mui/icons-material/Home';
 import { LuBadgeCheck, LuBuilding2, LuGithub } from 'react-icons/lu';
 
-import { betaSiteRoot, repositoryUrl } from '@/constants';
+import { betaSiteRoot, repositoryUrl, socialChannel } from '@/constants';
 import type { NavigationLinkItem } from '@/ui/organisms/Navigation';
 
 export const navigationHome: NavigationLinkItem = {
@@ -45,7 +45,7 @@ export const navigationFarcasterChannel: NavigationLinkItem = {
   id: 'farcaster-channel',
   icon: <ForumIcon />,
   title: 'Discuss on Farcaster',
-  href: 'https://warpcast.com/~/channel/walletbeat',
+  href: socialChannel,
 };
 
 export const scrollPastHeaderPixels = 16;

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -3,7 +3,7 @@ import HelpCenterIcon from '@mui/icons-material/HelpCenter';
 import HomeIcon from '@mui/icons-material/Home';
 import { LuBadgeCheck, LuBuilding2, LuGithub } from 'react-icons/lu';
 
-import { betaSiteRoot } from '@/constants';
+import { betaSiteRoot, repositoryUrl } from '@/constants';
 import type { NavigationLinkItem } from '@/ui/organisms/Navigation';
 
 export const navigationHome: NavigationLinkItem = {
@@ -38,7 +38,7 @@ export const navigationRepository: NavigationLinkItem = {
   id: 'code-repository',
   icon: <LuGithub />,
   title: 'Contribute on GitHub',
-  href: 'https://github.com/walletbeat/walletbeat',
+  href: repositoryUrl,
 };
 
 export const navigationFarcasterChannel: NavigationLinkItem = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,8 @@ export const betaSiteRoot = '';
  * versus the main branch.
  */
 export const betaImagesRoot = '/images';
+
+/**
+ * URL to the project repository.
+ */
+export const repositoryUrl = 'https://github.com/walletbeat/walletbeat';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,3 +16,8 @@ export const betaImagesRoot = '/images';
  * URL to the project repository.
  */
 export const repositoryUrl = 'https://github.com/walletbeat/walletbeat';
+
+/**
+ * URL to the project's social channel.
+ */
+export const socialChannel = 'https://farcaster.xyz/~/channel/walletbeat';

--- a/src/pages/about/_AboutPage.tsx
+++ b/src/pages/about/_AboutPage.tsx
@@ -11,7 +11,7 @@ import {
   navigationHome,
   navigationRepository,
 } from '@/components/navigation';
-import { betaSiteRoot } from '@/constants';
+import { betaSiteRoot, repositoryUrl } from '@/constants';
 import { NavigationPageLayout } from '@/layouts/NavigationPageLayout';
 import { ExternalLink } from '@/ui/atoms/ExternalLink';
 import { IconLink } from '@/ui/atoms/IconLink';
@@ -69,19 +69,11 @@ function AboutContents(): React.JSX.Element {
       <Typography variant='body1'>
         Walletbeat is committed to transparency. Contributors reveal their affiliation and / or
         shares in wallet companies. It is an{' '}
-        <IconLink
-          IconComponent={GitHubIcon}
-          href='https://github.com/walletbeat/walletbeat'
-          target='_blank'
-        >
+        <IconLink IconComponent={GitHubIcon} href={repositoryUrl} target='_blank'>
           open-source project
         </IconLink>{' '}
         licensed under the Free and Open-Source MIT license. Discussions are held on the{' '}
-        <IconLink
-          IconComponent={ForumIcon}
-          href='https://warpcast.com/~/channel/walletbeat'
-          target='_blank'
-        >
+        <IconLink IconComponent={ForumIcon} href={repositoryUrl} target='_blank'>
           public /walletbeat Farcaster channel
         </IconLink>
         .
@@ -141,11 +133,7 @@ function AboutContents(): React.JSX.Element {
       <Typography variant='body1'>
         Wallets listed on Walletbeat do not represent an endorsement and is for informational
         purposes only. If you find that something is wrong, please help Walletbeat by{' '}
-        <IconLink
-          IconComponent={GitHubIcon}
-          href='https://github.com/walletbeat/walletbeat'
-          target='_blank'
-        >
+        <IconLink IconComponent={GitHubIcon} href={repositoryUrl} target='_blank'>
           contributing
         </IconLink>
         !

--- a/src/pages/faq/_FrequentlyAskedQuestionsPage.tsx
+++ b/src/pages/faq/_FrequentlyAskedQuestionsPage.tsx
@@ -2,6 +2,7 @@ import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import { Divider, Typography } from '@mui/material';
 import React from 'react';
 
+import { repositoryUrl } from '@/constants';
 import { NavigationPageLayout } from '@/layouts/NavigationPageLayout';
 import { type NonEmptyArray, nonEmptyConcat, nonEmptyMap } from '@/types/utils/non-empty';
 import FrequentlyAskedQuestion from '@/ui/molecules/FrequentlyAskedQuestion';
@@ -272,7 +273,7 @@ const frequentlyAskedQuestions: NonEmptyArray<FAQEntry> = [
 			process a lot.
 
 			If you would like to help with this, please
-			[contribute to our repository!](https://github.com/walletbeat/walletbeat).
+			[contribute to our repository!](${repositoryUrl}).
 		`,
   },
 ];

--- a/src/pages/wallet/7702.astro
+++ b/src/pages/wallet/7702.astro
@@ -1,0 +1,28 @@
+---
+import { NavigationPageLayout } from '@/layouts/NavigationPageLayout';
+import Layout from '../../layouts/Layout.astro';
+import { walletNavigationGroups } from '@/components/CriteriaPage';
+import { navigationAbout } from '@/components/navigation';
+import { Eip7702Adoption } from '@/ui/organisms/Eip7702Adoption';
+---
+
+<Layout
+  metadata={{
+    title: 'Walletbeat - EIP-7702 wallet adoption',
+  }}
+>
+  <NavigationPageLayout
+    groups={[
+      ...walletNavigationGroups,
+      {
+        id: 'about',
+        items: [navigationAbout],
+        overflow: false,
+      },
+    ]}
+    selectedGroupId='wallet'
+    selectedItemId='eip-7702-tracker'
+  >
+    <Eip7702Adoption />
+  </NavigationPageLayout>
+</Layout>

--- a/src/schema/contracts.ts
+++ b/src/schema/contracts.ts
@@ -9,6 +9,9 @@ export type EVMAddress = `0x${Lowercase<string>}`;
  * delegated via EIP-7702.
  */
 export interface SmartWalletContract {
+  /** A human-readable name for the contract. */
+  name: string;
+
   /** The address of the smart wallet contract. */
   address: EVMAddress;
 

--- a/src/schema/entity.ts
+++ b/src/schema/entity.ts
@@ -84,7 +84,7 @@ export interface Entity<Ts extends EntityType[] = []> {
   twitter: DomainUrl<'x.com'> | { type: 'NO_TWITTER_URL' };
 
   /** The Farcaster profile name of the entity, as a Warpcast URL, if any. */
-  farcaster: DomainUrl<'warpcast.com'> | { type: 'NO_FARCASTER_PROFILE' };
+  farcaster: DomainUrl<'warpcast.com' | 'farcaster.xyz'> | { type: 'NO_FARCASTER_PROFILE' };
 }
 
 type EntityWithType<T extends EntityType> = Entity & Entity<[T]>;

--- a/src/schema/url.ts
+++ b/src/schema/url.ts
@@ -35,7 +35,8 @@ export function getDomain(url: Url): string {
 const wellKnownDomainsToLabels: Record<string, string> = {
   'crunchbase.com': 'Crunchbase',
   'github.com': 'GitHub',
-  'warpcast.com': 'Warpcast',
+  'warpcast.com': 'Farcaster',
+  'farcaster.xyz': 'Farcaster',
 };
 
 function getDefaultUrlLabel(url: string): string {

--- a/src/ui/molecules/attributes/UnratedAttribute.tsx
+++ b/src/ui/molecules/attributes/UnratedAttribute.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@mui/material';
 
+import { repositoryUrl } from '@/constants';
 import { Rating, type Value } from '@/schema/attributes';
 import type { UnratedAttributeProps } from '@/types/content/unrated-attribute';
 
@@ -17,7 +18,7 @@ export function UnratedAttribute<V extends Value>({
       </Typography>
       <Typography>
         Please help us by contributing your knowledge on{' '}
-        <ExternalLink url='https://github.com/walletbeat/walletbeat' rel=''>
+        <ExternalLink url={repositoryUrl} rel=''>
           our repository
         </ExternalLink>
         !

--- a/src/ui/organisms/Eip7702Adoption.tsx
+++ b/src/ui/organisms/Eip7702Adoption.tsx
@@ -1,0 +1,87 @@
+import type React from 'react';
+import { LuGithub } from 'react-icons/lu';
+
+import { ExternalLink } from '../atoms/ExternalLink';
+import Eip7702Table from './Eip7702Table';
+
+export function Eip7702Adoption(): React.JSX.Element {
+  return (
+    <div className='max-w-screen-xl 3xl:max-w-screen-2xl mx-auto w-full'>
+      <div className='flex flex-col lg:mt-10 gap-4'>
+        <div className='px-8 py-6 flex justify-between items-start flex-wrap relative flex-col md:flex-row'>
+          <div className='flex flex-col gap-4 py-8 flex-1'>
+            <h1 className='text-4xl font-extrabold text-accent'>EIP-7702 Adoption Tracker</h1>
+            <p className='text-secondary'>
+              Which wallets implement{' '}
+              <ExternalLink
+                url='https://eip.tools/eip/7702'
+                defaultLabel='EIP-7702'
+                style={{
+                  fontWeight: 500,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                }}
+              />
+              ? How compliant and standardized is their implementation? Which new 7702-enabled
+              features does each wallet support?
+            </p>
+            <p className='text-secondary'>
+              Inspired by{' '}
+              <ExternalLink
+                url='https://swiss-knife.xyz/7702beat'
+                defaultLabel='7702 Beat'
+                style={{
+                  fontWeight: 500,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                }}
+              />
+              , from the great folks at{' '}
+              <ExternalLink
+                url='https://swiss-knife.xyz'
+                defaultLabel='Swiss-Knife.xyz'
+                style={{
+                  fontWeight: 500,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                }}
+              />
+              . Also check out{' '}
+              <ExternalLink
+                url='https://www.bundlebear.com/eip7702-authorized-contracts/all'
+                defaultLabel="BundleBear's EIP-7702 contract tracker"
+                style={{
+                  fontWeight: 500,
+                  color: 'var(--text-primary)',
+                  fontSize: '0.9rem',
+                }}
+              />
+              !
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className='w-full flex flex-col gap-2 p-4 md:p-8'>
+        <Eip7702Table />
+      </div>
+      <div className='flex gap-2'>
+        Incorrect data? Submit a PR:
+        <div className='bg-primary border px-2 py-1 rounded-md hover:bg-primary'>
+          <div className='flex flex-row gap-2 items-center' key='repo'>
+            <LuGithub />
+            <ExternalLink
+              url='https://github.com/walletbeat/walletbeat'
+              defaultLabel='GitHub Repository'
+              style={{
+                fontWeight: 500,
+                color: 'var(--text-primary)',
+                fontSize: '0.9rem',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/organisms/Eip7702Adoption.tsx
+++ b/src/ui/organisms/Eip7702Adoption.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
 import { LuGithub } from 'react-icons/lu';
 
+import { repositoryUrl } from '@/constants';
+
 import { ExternalLink } from '../atoms/ExternalLink';
 import Eip7702Table from './Eip7702Table';
 
@@ -71,7 +73,7 @@ export function Eip7702Adoption(): React.JSX.Element {
           <div className='flex flex-row gap-2 items-center' key='repo'>
             <LuGithub />
             <ExternalLink
-              url='https://github.com/walletbeat/walletbeat'
+              url={repositoryUrl}
               defaultLabel='GitHub Repository'
               style={{
                 fontWeight: 500,

--- a/src/ui/organisms/Eip7702Table.tsx
+++ b/src/ui/organisms/Eip7702Table.tsx
@@ -4,7 +4,6 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
-  type Row,
   useReactTable,
 } from '@tanstack/react-table';
 import React from 'react';
@@ -27,7 +26,7 @@ import { isNonEmptyArray, nonEmptyGet, setContains, setItems } from '@/types/uti
 import { cx } from '@/utils/cx';
 
 import { ExternalLink } from '../atoms/ExternalLink';
-import { EipStandardTag } from './WalletTable';
+import { EipStandardTag, walletNameCell } from './WalletTable';
 
 enum WalletTypeFor7702 {
   EIP7702 = 'EIP7702',
@@ -115,43 +114,6 @@ const softwareWalletData: TableRow[] = Object.values(ratedSoftwareWallets)
   })
   .sort((a, b) => a.sortPriority - b.sortPriority);
 
-// Create a reusable cell renderer for wallet name columns
-function createWalletNameCell(): ({ row }: { row: Row<TableRow> }) => React.ReactNode {
-  const createCell = ({ row }: { row: Row<TableRow> }): React.ReactNode => {
-    // Regular row rendering with logo
-    const walletId = row.original.wallet.metadata.id;
-    const logoPath = `/images/wallets/${walletId}.${row.original.wallet.metadata.iconExtension}`;
-    const defaultLogo = '/images/wallets/default.svg';
-    const walletUrl = `/${walletId}`;
-
-    return (
-      <div className='flex items-center'>
-        {/* Wallet Logo */}
-        <div className='flex-shrink-0 mr-3'>
-          <img
-            src={logoPath}
-            alt=''
-            className='w-6 h-6 object-contain'
-            onError={e => {
-              // Fallback for missing logos
-              e.currentTarget.src = defaultLogo;
-            }}
-          />
-        </div>
-        {/* Wallet Name */}
-        <a
-          href={walletUrl}
-          className='text-base font-medium hover:text-blue-600 hover:underline cursor-pointer'
-        >
-          {row.original.wallet.metadata.displayName}
-        </a>
-      </div>
-    );
-  };
-
-  return createCell;
-}
-
 interface WalletTypeCell {
   typeString: string;
   hasSmartWallet: boolean;
@@ -171,7 +133,7 @@ export default function Eip7702Table(): React.JSX.Element {
     {
       id: 'wallet',
       header: 'Wallet',
-      cell: createWalletNameCell(),
+      cell: walletNameCell<TableRow>,
     },
   );
   const walletTypeColumn = columnHelper.display({

--- a/src/ui/organisms/Eip7702Table.tsx
+++ b/src/ui/organisms/Eip7702Table.tsx
@@ -1,0 +1,329 @@
+import {
+  type CellContext,
+  type ColumnDef,
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  type Row,
+  useReactTable,
+} from '@tanstack/react-table';
+import React from 'react';
+
+import { eip7702 } from '@/data/eips/eip-7702';
+import { erc4337 } from '@/data/eips/erc-4337';
+import { ratedSoftwareWallets } from '@/data/software-wallets';
+import type { SmartWalletContract } from '@/schema/contracts';
+import { AccountType, isAccountTypeSupported } from '@/schema/features/account-support';
+import { refs } from '@/schema/reference';
+import { isLabeledUrl } from '@/schema/url';
+import type { Variant } from '@/schema/variants';
+import {
+  getVariantResolvedWallet,
+  getWalletVariants,
+  type RatedWallet,
+  walletSupportedAccountTypes,
+} from '@/schema/wallet';
+import { isNonEmptyArray, nonEmptyGet, setContains, setItems } from '@/types/utils/non-empty';
+import { cx } from '@/utils/cx';
+
+import { ExternalLink } from '../atoms/ExternalLink';
+import { EipStandardTag } from './WalletTable';
+
+enum WalletTypeFor7702 {
+  EIP7702 = 'EIP7702',
+  NON_7702_SMART_WALLET = 'NON_7702_SMART_WALLET',
+  NON_7702_EOA = 'NON_7702_EOA',
+  OTHER = 'OTHER',
+}
+
+// TableRow interface for better type safety
+interface TableRow {
+  id: string;
+  name: string;
+  wallet: RatedWallet;
+  typeFor7702: WalletTypeFor7702;
+  contract: SmartWalletContract | 'UNKNOWN' | 'NONE';
+  sortPriority: number;
+}
+
+// Create software wallet table data
+const softwareWalletData: TableRow[] = Object.values(ratedSoftwareWallets)
+  .map(wallet => {
+    const accountTypes = walletSupportedAccountTypes(wallet, 'ALL_VARIANTS');
+    const hasErc4337 =
+      accountTypes !== null && setContains<AccountType>(accountTypes, AccountType.rawErc4337);
+    const hasEip7702 =
+      accountTypes !== null && setContains<AccountType>(accountTypes, AccountType.eip7702);
+    const hasEoa =
+      accountTypes !== null &&
+      (hasEip7702 || setContains<AccountType>(accountTypes, AccountType.eoa));
+    const typeFor7702 = hasEip7702
+      ? WalletTypeFor7702.EIP7702
+      : hasErc4337
+        ? WalletTypeFor7702.NON_7702_SMART_WALLET
+        : hasEoa
+          ? WalletTypeFor7702.NON_7702_EOA
+          : WalletTypeFor7702.OTHER;
+    const contract = ((): TableRow['contract'] => {
+      for (const variant of setItems<Variant>(getWalletVariants(wallet))) {
+        const variantWallet = getVariantResolvedWallet(wallet, variant);
+
+        if (variantWallet === null || variantWallet.features.accountSupport === null) {
+          continue;
+        }
+
+        if (isAccountTypeSupported(variantWallet.features.accountSupport.eip7702)) {
+          return variantWallet.features.accountSupport.eip7702.contract;
+        }
+
+        if (isAccountTypeSupported(variantWallet.features.accountSupport.rawErc4337)) {
+          return variantWallet.features.accountSupport.rawErc4337.contract;
+        }
+      }
+
+      return 'NONE';
+    })();
+
+    const sortPriority = ((): number => {
+      switch (typeFor7702) {
+        case WalletTypeFor7702.EIP7702:
+          return 0;
+        case WalletTypeFor7702.NON_7702_SMART_WALLET:
+          return 1;
+        case WalletTypeFor7702.NON_7702_EOA:
+          return 2;
+        case WalletTypeFor7702.OTHER:
+          return 3;
+      }
+    })();
+
+    return {
+      id: wallet.metadata.id,
+      name: wallet.metadata.displayName,
+      wallet,
+      sortPriority,
+      typeFor7702,
+      contract,
+    };
+  })
+  .sort((a, b) => a.sortPriority - b.sortPriority);
+
+// Create a reusable cell renderer for wallet name columns
+function createWalletNameCell(): ({ row }: { row: Row<TableRow> }) => React.ReactNode {
+  const createCell = ({ row }: { row: Row<TableRow> }): React.ReactNode => {
+    // Regular row rendering with logo
+    const walletId = row.original.wallet.metadata.id;
+    const logoPath = `/images/wallets/${walletId}.${row.original.wallet.metadata.iconExtension}`;
+    const defaultLogo = '/images/wallets/default.svg';
+    const walletUrl = `/${walletId}`;
+
+    return (
+      <div className='flex items-center'>
+        {/* Wallet Logo */}
+        <div className='flex-shrink-0 mr-3'>
+          <img
+            src={logoPath}
+            alt=''
+            className='w-6 h-6 object-contain'
+            onError={e => {
+              // Fallback for missing logos
+              e.currentTarget.src = defaultLogo;
+            }}
+          />
+        </div>
+        {/* Wallet Name */}
+        <a
+          href={walletUrl}
+          className='text-base font-medium hover:text-blue-600 hover:underline cursor-pointer'
+        >
+          {row.original.wallet.metadata.displayName}
+        </a>
+      </div>
+    );
+  };
+
+  return createCell;
+}
+
+interface WalletTypeCell {
+  typeString: string;
+  hasSmartWallet: boolean;
+}
+
+type CellValue = string | WalletTypeCell;
+
+export default function Eip7702Table(): React.JSX.Element {
+  const columnHelper = createColumnHelper<TableRow>();
+  const rankColumn = columnHelper.display({
+    id: 'rank',
+    header: '#',
+    cell: ({ row }): React.ReactNode => row.index + 1,
+  });
+  const walletNameColumn = columnHelper.accessor(
+    (row: TableRow): CellValue => row.wallet.metadata.displayName,
+    {
+      id: 'wallet',
+      header: 'Wallet',
+      cell: createWalletNameCell(),
+    },
+  );
+  const walletTypeColumn = columnHelper.display({
+    id: 'type',
+    header: 'Type',
+    cell: (info: CellContext<TableRow, unknown>): React.ReactNode => {
+      switch (info.row.original.typeFor7702) {
+        case WalletTypeFor7702.EIP7702:
+          return (
+            <div className='mt-1 flex flex-wrap gap-1'>
+              <EipStandardTag standard={eip7702} usePrefix={true} />
+            </div>
+          );
+        case WalletTypeFor7702.NON_7702_SMART_WALLET:
+          return (
+            <div className='mt-1 flex flex-wrap gap-1'>
+              <EipStandardTag standard={erc4337} usePrefix={true} />
+            </div>
+          );
+        case WalletTypeFor7702.NON_7702_EOA:
+          return <span>Non-7702 EOA</span>;
+        case WalletTypeFor7702.OTHER:
+          return <span>Non-7702</span>;
+      }
+    },
+  });
+  const walletContractColumn = columnHelper.display({
+    id: 'contract',
+    header: 'Contract',
+    cell: (info: CellContext<TableRow, unknown>): React.ReactNode => {
+      if (info.row.original.contract === 'NONE') {
+        return <span style={{ opacity: 0.5 }}>N/A</span>;
+      }
+
+      const contract = info.row.original.contract;
+
+      if (contract === 'UNKNOWN') {
+        return <span style={{ opacity: 1 }}>Unknown - Send PR!</span>;
+      }
+
+      return (
+        <ExternalLink
+          url={`https://etherscan.io/address/${contract.address}`}
+          defaultLabel={contract.name}
+        />
+      );
+    },
+  });
+  const walletContractSource = columnHelper.display({
+    id: 'contract-source',
+    header: 'Source',
+    cell: (info: CellContext<TableRow, unknown>): React.ReactNode => {
+      if (info.row.original.contract === 'NONE') {
+        return <span style={{ opacity: 0.5 }}>N/A</span>;
+      }
+
+      const contract = info.row.original.contract;
+
+      if (contract === 'UNKNOWN') {
+        return null;
+      }
+
+      if (!contract.sourceCode.available) {
+        return <span style={{ color: 'var(--color-error)' }}>Unavailable</span>;
+      }
+
+      const sourceRefs = refs(contract.sourceCode);
+      const sourceUrl = isNonEmptyArray(sourceRefs)
+        ? nonEmptyGet(nonEmptyGet(sourceRefs).urls)
+        : `https://etherscan.io/address/${contract.address}#code`;
+      const rawUrl = isLabeledUrl(sourceUrl) ? sourceUrl.url : sourceUrl;
+
+      return <ExternalLink url={rawUrl} defaultLabel='Available' />;
+    },
+  });
+  const walletTransactionBatchingColumn = columnHelper.display({
+    id: 'transaction-batching',
+    header: 'Batching',
+    cell: (info: CellContext<TableRow, unknown>): React.ReactNode => {
+      if (info.row.original.contract === 'NONE') {
+        return <span style={{ opacity: 0.5 }}>N/A</span>;
+      }
+
+      return <span style={{ opacity: 0.5 }}>Coming soon</span>;
+    },
+  });
+  const columns: Array<ColumnDef<TableRow, CellValue>> = [
+    rankColumn,
+    walletNameColumn,
+    walletTypeColumn,
+    walletContractColumn,
+    walletContractSource,
+    walletTransactionBatchingColumn,
+  ];
+
+  // Create table
+  const table = useReactTable({
+    data: softwareWalletData,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  // Render table body based on active tab
+  const renderTableBody = (): React.ReactNode => {
+    return table.getRowModel().rows.map(row => {
+      return (
+        <tr key={row.id} className={'dark:bg-[#141414] dark:hover:bg-[#1a1a1a]'}>
+          {row.getVisibleCells().map(cell => (
+            <td
+              key={cell.id}
+              className={cx(
+                'px-4 py-2 dark:text-gray-200',
+                cell.column.id === 'rank' ? 'text-center' : '',
+              )}
+            >
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </td>
+          ))}
+        </tr>
+      );
+    });
+  };
+
+  return (
+    <div className='overflow-x-auto'>
+      <div className='overflow-x-auto'>
+        <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700 bg-background'>
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => (
+              <tr className='bg-tertiary' key={headerGroup.id}>
+                {headerGroup.headers.map(header => {
+                  const headerContent = header.column.columnDef.header;
+
+                  return (
+                    <th
+                      key={header.id}
+                      className={cx(
+                        'px-4 py-2 text-[14px] text-secondary',
+                        header.column.id === 'rank' ? 'text-center' : 'text-left',
+                        header.column.id === 'wallet'
+                          ? 'font-bold'
+                          : header.column.id === 'type'
+                            ? 'font-semibold'
+                            : 'font-normal',
+                      )}
+                    >
+                      {headerContent !== undefined &&
+                        flexRender(headerContent, header.getContext())}
+                    </th>
+                  );
+                })}
+              </tr>
+            ))}
+          </thead>
+          <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
+            {renderTableBody()}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/organisms/Eip7702Table.tsx
+++ b/src/ui/organisms/Eip7702Table.tsx
@@ -294,40 +294,35 @@ export default function Eip7702Table(): React.JSX.Element {
 
   return (
     <div className='overflow-x-auto'>
-      <div className='overflow-x-auto'>
-        <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700 bg-background'>
-          <thead>
-            {table.getHeaderGroups().map(headerGroup => (
-              <tr className='bg-tertiary' key={headerGroup.id}>
-                {headerGroup.headers.map(header => {
-                  const headerContent = header.column.columnDef.header;
+      <table className='min-w-full divide-y divide-gray-200 dark:divide-gray-700 bg-background'>
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr className='bg-tertiary' key={headerGroup.id}>
+              {headerGroup.headers.map(header => {
+                const headerContent = header.column.columnDef.header;
 
-                  return (
-                    <th
-                      key={header.id}
-                      className={cx(
-                        'px-4 py-2 text-[14px] text-secondary',
-                        header.column.id === 'rank' ? 'text-center' : 'text-left',
-                        header.column.id === 'wallet'
-                          ? 'font-bold'
-                          : header.column.id === 'type'
-                            ? 'font-semibold'
-                            : 'font-normal',
-                      )}
-                    >
-                      {headerContent !== undefined &&
-                        flexRender(headerContent, header.getContext())}
-                    </th>
-                  );
-                })}
-              </tr>
-            ))}
-          </thead>
-          <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>
-            {renderTableBody()}
-          </tbody>
-        </table>
-      </div>
+                return (
+                  <th
+                    key={header.id}
+                    className={cx(
+                      'px-4 py-2 text-[14px] text-secondary',
+                      header.column.id === 'rank' ? 'text-center' : 'text-left',
+                      header.column.id === 'wallet'
+                        ? 'font-bold'
+                        : header.column.id === 'type'
+                          ? 'font-semibold'
+                          : 'font-normal',
+                    )}
+                  >
+                    {headerContent !== undefined && flexRender(headerContent, header.getContext())}
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody className='divide-y divide-gray-200 dark:divide-gray-700'>{renderTableBody()}</tbody>
+      </table>
     </div>
   );
 }

--- a/src/ui/organisms/Eip7702Table.tsx
+++ b/src/ui/organisms/Eip7702Table.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { eip7702 } from '@/data/eips/eip-7702';
 import { erc4337 } from '@/data/eips/erc-4337';
 import { ratedSoftwareWallets } from '@/data/software-wallets';
-import type { SmartWalletContract } from '@/schema/contracts';
+import type { EVMAddress, SmartWalletContract } from '@/schema/contracts';
 import { AccountType, isAccountTypeSupported } from '@/schema/features/account-support';
 import { refs } from '@/schema/reference';
 import { isLabeledUrl } from '@/schema/url';
@@ -44,6 +44,13 @@ interface TableRow {
   typeFor7702: WalletTypeFor7702;
   contract: SmartWalletContract | 'UNKNOWN' | 'NONE';
   sortPriority: number;
+}
+
+function walletContractUrl(contractAddress: EVMAddress, anchor?: string): string {
+  return (
+    `https://etherscan.io/address/${contractAddress}` +
+    (anchor !== undefined && anchor !== '' ? `#${anchor}` : '')
+  );
 }
 
 // Create software wallet table data
@@ -206,10 +213,7 @@ export default function Eip7702Table(): React.JSX.Element {
       }
 
       return (
-        <ExternalLink
-          url={`https://etherscan.io/address/${contract.address}`}
-          defaultLabel={contract.name}
-        />
+        <ExternalLink url={walletContractUrl(contract.address)} defaultLabel={contract.name} />
       );
     },
   });
@@ -234,7 +238,7 @@ export default function Eip7702Table(): React.JSX.Element {
       const sourceRefs = refs(contract.sourceCode);
       const sourceUrl = isNonEmptyArray(sourceRefs)
         ? nonEmptyGet(nonEmptyGet(sourceRefs).urls)
-        : `https://etherscan.io/address/${contract.address}#code`;
+        : walletContractUrl(contract.address, 'code');
       const rawUrl = isLabeledUrl(sourceUrl) ? sourceUrl.url : sourceUrl;
 
       return <ExternalLink url={rawUrl} defaultLabel='Available' />;

--- a/src/ui/organisms/WalletTable.tsx
+++ b/src/ui/organisms/WalletTable.tsx
@@ -339,7 +339,13 @@ function createWalletNameCell(): ({ row }: { row: Row<TableRow> }) => React.Reac
 }
 
 // Helper function for EIP standards with hover preview (non-link version)
-function EipStandardTag({ standard }: { standard: Eip }): React.ReactElement {
+export function EipStandardTag({
+  standard,
+  usePrefix,
+}: {
+  standard: Eip;
+  usePrefix: boolean;
+}): React.ReactElement {
   const [isTagHovered, setIsTagHovered] = useState<boolean>(false);
   const [isModalHovered, setIsModalHovered] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -389,7 +395,8 @@ function EipStandardTag({ standard }: { standard: Eip }): React.ReactElement {
         onMouseEnter={handleTagMouseEnter}
         onMouseLeave={handleTagMouseLeave}
       >
-        #{standard.number}
+        {usePrefix ? `${standard.prefix}-` : '#'}
+        {standard.number}
       </span>
       {isHovered && anchorEl !== null && (
         <EipPreviewModal
@@ -764,9 +771,9 @@ export default function WalletTable(): React.ReactElement {
 
               // Add Markdown-style links for ERC standards
               if (std === SmartWalletStandard.ERC_4337) {
-                return <EipStandardTag key={std} standard={erc4337} />;
+                return <EipStandardTag key={std} usePrefix={false} standard={erc4337} />;
               } else if (std === SmartWalletStandard.ERC_7702) {
-                return <EipStandardTag key={std} standard={eip7702} />;
+                return <EipStandardTag key={std} usePrefix={false} standard={eip7702} />;
               } else {
                 return null; // Return null for other standards like 'OTHER'
               }

--- a/src/ui/organisms/WalletTable.tsx
+++ b/src/ui/organisms/WalletTable.tsx
@@ -302,40 +302,40 @@ const hardwareWalletData: TableRow[] = Object.values(ratedHardwareWallets)
   .sort((a, b) => a.name.localeCompare(b.name));
 
 // Create a reusable cell renderer for wallet name columns
-function createWalletNameCell(): ({ row }: { row: Row<TableRow> }) => React.ReactNode {
-  const createCell = ({ row }: { row: Row<TableRow> }): React.ReactNode => {
-    // Regular row rendering with logo
-    const walletId = row.original.wallet.metadata.id;
-    const logoPath = `/images/wallets/${walletId}.${row.original.wallet.metadata.iconExtension}`;
-    const defaultLogo = '/images/wallets/default.svg';
-    const walletUrl = `/${walletId}`;
+export function walletNameCell<T extends { wallet: RatedWallet }>({
+  row,
+}: {
+  row: Row<T>;
+}): React.ReactNode {
+  // Regular row rendering with logo
+  const walletId = row.original.wallet.metadata.id;
+  const logoPath = `/images/wallets/${walletId}.${row.original.wallet.metadata.iconExtension}`;
+  const defaultLogo = '/images/wallets/default.svg';
+  const walletUrl = `/${walletId}`;
 
-    return (
-      <div className='flex items-center'>
-        {/* Wallet Logo */}
-        <div className='flex-shrink-0 mr-3'>
-          <img
-            src={logoPath}
-            alt=''
-            className='w-6 h-6 object-contain'
-            onError={e => {
-              // Fallback for missing logos
-              e.currentTarget.src = defaultLogo;
-            }}
-          />
-        </div>
-        {/* Wallet Name */}
-        <a
-          href={walletUrl}
-          className='text-base font-medium hover:text-blue-600 hover:underline cursor-pointer'
-        >
-          {row.original.wallet.metadata.displayName}
-        </a>
+  return (
+    <div className='flex items-center'>
+      {/* Wallet Logo */}
+      <div className='flex-shrink-0 mr-3'>
+        <img
+          src={logoPath}
+          alt=''
+          className='w-6 h-6 object-contain'
+          onError={e => {
+            // Fallback for missing logos
+            e.currentTarget.src = defaultLogo;
+          }}
+        />
       </div>
-    );
-  };
-
-  return createCell;
+      {/* Wallet Name */}
+      <a
+        href={walletUrl}
+        className='text-base font-medium hover:text-blue-600 hover:underline cursor-pointer'
+      >
+        {row.original.wallet.metadata.displayName}
+      </a>
+    </div>
+  );
 }
 
 // Helper function for EIP standards with hover preview (non-link version)
@@ -736,7 +736,7 @@ export default function WalletTable(): React.ReactElement {
     {
       id: 'wallet',
       header: 'Wallet',
-      cell: createWalletNameCell(),
+      cell: walletNameCell<TableRow>,
     },
   );
   const walletTypeColumn = columnHelper.display({


### PR DESCRIPTION
This is the start of a dedicated EIP-7702 tracker page, as per promised in the [EF Pectra Proactive grant proposal](https://github.com/walletbeat/walletbeat/blob/beta/governance/grants/2025-02-ethereum-foundation-pectra-proactive-grant-round/proposal.md).

There should be more added here over time, such as transaction batching support, and other features that EIP-7702 enables. For now, this PR is just about setting the skeleton for the page.