### PR TITLE
Harmonize VSCode formatting configs with rest of the codebase.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,15 @@
 {
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.detectIndentation": false,
-  "editor.tabSize": 4,
+  "editor.tabSize": 2,
   "[jsonc]": {
-    "editor.defaultFormatter": "vscode.json-language-features"
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }
 }


### PR DESCRIPTION
Sets preferences in VSCode settings to match what the ESLint config requires and the indent size specified in `.editorconfig`.