### PR TITLE
Fix `<p>` margin when it comes after a bullet list in Markdown.

### DIFF
--- a/src/ui/atoms/MarkdownBase.tsx
+++ b/src/ui/atoms/MarkdownBase.tsx
@@ -57,7 +57,7 @@ const StyledMarkdown = styled(Box, {
     ${
       pSpacing === undefined
         ? ''
-        : `p + p {
+        : `p + p, ul + p {
         margin-top: ${pSpacing};
     }`
     }


### PR DESCRIPTION
Noticed this when working on the chain abstraction attribute, which has a paragraph after a list.