### PR TITLE
Use SSH authentication when pushing Helios checkpoint

### DIFF
--- a/.github/workflows/helios-refresh.yaml
+++ b/.github/workflows/helios-refresh.yaml
@@ -19,6 +19,11 @@ jobs:
         env:
           GIT_USERNAME: walletbeat-bot
           GIT_EMAIL: walletbeat-bot@users.noreply.github.com
+          GIT_REMOTE_URL: git@github.com:walletbeat/walletbeat.git
+          GIT_REMOTE_BRANCH: beta
+          GIT_SSH_AUTHENTICATION_KEY_TYPE: ed25519
+          GIT_SSH_AUTHENTICATION_KEY_PUBLIC: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILCBvEBIVY5uNBq0a1sqOKojgI/pReRR4PtDQXiWnj6U walletbeat-bot@walletbeat.eth'
+          GIT_SSH_AUTHENTICATION_KEY_PRIVATE: ${{ secrets.WALLETBEAT_BOT_GIT_SSH_AUTHENTICATION_KEY_PRIVATE }}
           GIT_SSH_SIGNING_KEY_TYPE: ed25519
           GIT_SSH_SIGNING_KEY_PUBLIC: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBw+NZEg1p71wrjIngH8PZQ1GDeACirHUjposkeYdurM walletbeat-bot@walletbeat.eth'
           GIT_SSH_SIGNING_KEY_PRIVATE: ${{ secrets.WALLETBEAT_BOT_GIT_SSH_SIGNING_KEY_PRIVATE }}

--- a/deploy/helios/helios-checkpoint-push.sh
+++ b/deploy/helios/helios-checkpoint-push.sh
@@ -5,6 +5,16 @@
 set -euo pipefail
 set +x
 
+if [[ -z "${GIT_REMOTE_URL:-}" ]]; then
+	echo 'Missing GIT_REMOTE_URL' >&2
+	exit 1
+fi
+
+if [[ -z "${GIT_REMOTE_BRANCH:-}" ]]; then
+	echo 'Missing GIT_REMOTE_BRANCH' >&2
+	exit 1
+fi
+
 HELIOS_CHECKPOINT='deploy/helios/data/checkpoint'
 if ! git status --porcelain "$HELIOS_CHECKPOINT" | grep -qF "$HELIOS_CHECKPOINT"; then
 	echo 'Checkpoint is unchanged.' >&2
@@ -12,4 +22,4 @@ if ! git status --porcelain "$HELIOS_CHECKPOINT" | grep -qF "$HELIOS_CHECKPOINT"
 fi
 echo 'Pushing updated checkpoint file.' >&2
 git commit "$HELIOS_CHECKPOINT" -m 'Automated checkpoint update.'
-git push
+git push "$GIT_REMOTE_URL" "$GIT_REMOTE_BRANCH"

--- a/deploy/setup-git.sh
+++ b/deploy/setup-git.sh
@@ -13,6 +13,21 @@ if [[ -z "${GIT_EMAIL:-}" ]]; then
 	exit 1
 fi
 
+if [[ -z "${GIT_SSH_AUTHENTICATION_KEY_TYPE:-}" ]]; then
+	echo 'Missing GIT_SSH_AUTHENTICATION_KEY_TYPE' >&2
+	exit 1
+fi
+
+if [[ -z "${GIT_SSH_AUTHENTICATION_KEY_PUBLIC:-}" ]]; then
+	echo 'Missing GIT_SSH_AUTHENTICATION_KEY_PUBLIC' >&2
+	exit 1
+fi
+
+if [[ -z "${GIT_SSH_AUTHENTICATION_KEY_PRIVATE:-}" ]]; then
+	echo 'Missing GIT_SSH_AUTHENTICATION_KEY_PRIVATE' >&2
+	exit 1
+fi
+
 if [[ -z "${GIT_SSH_SIGNING_KEY_TYPE:-}" ]]; then
 	echo 'Missing GIT_SSH_SIGNING_KEY_TYPE' >&2
 	exit 1
@@ -30,16 +45,26 @@ fi
 
 mkdir -p "${HOME}/.ssh"
 chmod 700 "${HOME}/.ssh"
-echo "$GIT_SSH_SIGNING_KEY_PRIVATE" > "$HOME/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}"
-echo "$GIT_SSH_SIGNING_KEY_PUBLIC" > "$HOME/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}.pub"
-chmod 600 "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}" "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}.pub"
+echo "$GIT_SSH_AUTHENTICATION_KEY_PRIVATE" > "$HOME/.ssh/id_${GIT_SSH_AUTHENTICATION_KEY_TYPE}_authentication"
+echo "$GIT_SSH_AUTHENTICATION_KEY_PUBLIC" > "$HOME/.ssh/id_${GIT_SSH_AUTHENTICATION_KEY_TYPE}_authentication.pub"
+chmod 600 "${HOME}/.ssh/id_${GIT_SSH_AUTHENTICATION_KEY_TYPE}_authentication" "${HOME}/.ssh/id_${GIT_SSH_AUTHENTICATION_KEY_TYPE}_authentication.pub"
+echo "$GIT_SSH_SIGNING_KEY_PRIVATE" > "$HOME/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing"
+echo "$GIT_SSH_SIGNING_KEY_PUBLIC" > "$HOME/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing.pub"
+chmod 600 "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing" "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing.pub"
 
 git config --global user.name "$GIT_USERNAME"
 git config --global user.email "$GIT_EMAIL"
 git config --global gpg.format ssh
-git config --global user.signingKey "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}.pub"
+git config --global user.signingKey "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing.pub"
 git config --global commit.gpgSign true
+if [[ ! -f "${HOME}/.ssh/config" ]] || ( ! grep -qF "Host github.com" "${HOME}/.ssh/config" ); then
+  echo "Host github.com" >> "${HOME}/.ssh/config"
+  echo "  IdentityFile ${HOME}/.ssh/id_${GIT_SSH_AUTHENTICATION_KEY_TYPE}_authentication" >> "${HOME}/.ssh/config"
+fi
+if [[ ! -f "${HOME}/.ssh/known_hosts" ]] || ( ! grep -qF "github.com" "${HOME}/.ssh/known_hosts" ); then
+  ssh-keyscan github.com >> "${HOME}/.ssh/known_hosts"
+fi
 if [[ ! -f "${HOME}/.ssh/allowed_signers" ]] || ( ! grep -qF "${GIT_EMAIL}" "${HOME}/.ssh/allowed_signers" ); then
-  echo "${GIT_EMAIL} namespaces=\"git\" $(cat "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}.pub")" >> "${HOME}/.ssh/allowed_signers"
+  echo "${GIT_EMAIL} namespaces=\"git\" $(cat "${HOME}/.ssh/id_${GIT_SSH_SIGNING_KEY_TYPE}_signing.pub")" >> "${HOME}/.ssh/allowed_signers"
 fi
 git config --global gpg.ssh.allowedSignersFile "${HOME}/.ssh/allowed_signers"


### PR DESCRIPTION
CI needs to be able to push updated Helios checkpoints every so often (about once a week at least). To avoid human intervention, commits should be fully automated and thereby exempt from PR review requirements. To that end, CI needs to auth itself over SSH as a GitHub user that has the bypass permission on the `beta` branch protection rule. This PR fixes that.