### PR TITLE
Exempt most attributes by type rather than variant

### DIFF
--- a/src/schema/attributes/ecosystem/browser-integration.ts
+++ b/src/schema/attributes/ecosystem/browser-integration.ts
@@ -17,6 +17,7 @@ import {
   type Support,
 } from '@/schema/features/support';
 import { popRefs, type WithRef } from '@/schema/reference';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 import { commaListFormat } from '@/types/utils/text';
 
@@ -163,7 +164,7 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
     ),
   },
   evaluate: (features: ResolvedFeatures): Evaluation<BrowserIntegrationValue> => {
-    if (features.variant !== Variant.BROWSER) {
+    if (features.type !== WalletType.SOFTWARE || features.variant !== Variant.BROWSER) {
       return exempt(
         browserIntegration,
         sentence('Only browser-based wallets are rated on their browser integration support.'),

--- a/src/schema/attributes/ecosystem/chain-abstraction.ts
+++ b/src/schema/attributes/ecosystem/chain-abstraction.ts
@@ -12,7 +12,7 @@ import type {
 } from '@/schema/features/ecosystem/chain-abstraction';
 import { featureSupported, isSupported, notSupported, supported } from '@/schema/features/support';
 import { mergeRefs, refs } from '@/schema/reference';
-import { variantToWalletType, WalletType } from '@/schema/wallet-types';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -493,7 +493,7 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
     ),
   },
   evaluate: (features: ResolvedFeatures): Evaluation<ChainAbstractionValue> => {
-    if (variantToWalletType(features.variant) !== WalletType.SOFTWARE) {
+    if (features.type !== WalletType.SOFTWARE) {
       return exempt(
         chainAbstraction,
         sentence('Only software wallets are expected to deal with chain abstraction.'),

--- a/src/schema/attributes/privacy/hardware-privacy.ts
+++ b/src/schema/attributes/privacy/hardware-privacy.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/features/privacy/hardware-privacy';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -89,7 +89,7 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<HardwarePrivacyValue>>) =>
     pickWorstRating<HardwarePrivacyValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<HardwarePrivacyValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(hardwarePrivacy, sentence('Only rated for hardware wallets'), brand, {
         phoningHome: HardwarePrivacyType.FAIL,
         inspectableRemoteCalls: HardwarePrivacyType.FAIL,

--- a/src/schema/attributes/security/bug-bounty-program.ts
+++ b/src/schema/attributes/security/bug-bounty-program.ts
@@ -11,7 +11,8 @@ import {
   BugBountyProgramType,
 } from '@/schema/features/security/bug-bounty-program';
 import { popRefs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -241,7 +242,7 @@ export const bugBountyProgram: Attribute<BugBountyProgramValue> = {
   evaluate: (features: ResolvedFeatures): Evaluation<BugBountyProgramValue> => {
     // This attribute is only applicable for hardware wallets
     // For software wallets, we exempt them from this attribute
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         bugBountyProgram,
         sentence('This attribute is only applicable for hardware wallets.'),

--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/attributes';
 import type { ResolvedFeatures } from '@/schema/features';
 import { isSupported, type Support } from '@/schema/features/support';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content';
 import { chainVerificationDetailsContent } from '@/types/content/chain-verification-details';
 import { isNonEmptyArray, type NonEmptyArray, nonEmptyEntries } from '@/types/utils/non-empty';
@@ -131,7 +131,7 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
     ),
   },
   evaluate: (features: ResolvedFeatures): Evaluation<ChainVerificationValue> => {
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type === WalletType.HARDWARE) {
       return exempt(
         chainVerification,
         sentence('This attribute is not applicable for hardware wallets.'),

--- a/src/schema/attributes/security/firmware.ts
+++ b/src/schema/attributes/security/firmware.ts
@@ -4,7 +4,7 @@ import type { ResolvedFeatures } from '@/schema/features';
 import { type FirmwareSupport, FirmwareType } from '@/schema/features/security/firmware';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -93,7 +93,7 @@ export const firmware: Attribute<FirmwareValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<FirmwareValue>>) =>
     pickWorstRating<FirmwareValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<FirmwareValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(firmware, sentence('Firmware is only rated for hardware wallets'), brand, {
         silentUpdateProtection: FirmwareType.FAIL,
         firmwareOpenSource: FirmwareType.FAIL,

--- a/src/schema/attributes/security/hardware-wallet-dapp-signing.ts
+++ b/src/schema/attributes/security/hardware-wallet-dapp-signing.ts
@@ -23,7 +23,8 @@ import {
   supportsAnyDataExtraction,
 } from '@/schema/features/security/hardware-wallet-dapp-signing';
 import { refs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -352,7 +353,7 @@ export const hardwareWalletDappSigning: Attribute<HardwareWalletDappSigningValue
   evaluate: (features: ResolvedFeatures): Evaluation<HardwareWalletDappSigningValue> => {
     // For hardware wallets themselves:
     // This evaluates the hardware wallet's own dApp signing capabilities
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type === WalletType.HARDWARE) {
       // Check if dApp signing feature exists
       if (features.security.hardwareWalletDappSigning === null) {
         return unrated(hardwareWalletDappSigning, brand, {

--- a/src/schema/attributes/security/hardware-wallet-support.ts
+++ b/src/schema/attributes/security/hardware-wallet-support.ts
@@ -10,7 +10,8 @@ import { AccountType, supportsOnlyAccountType } from '@/schema/features/account-
 import { HardwareWalletType } from '@/schema/features/security/hardware-wallet-support';
 import { isSupported } from '@/schema/features/support';
 import { popRefs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -156,7 +157,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
   },
   evaluate: (features: ResolvedFeatures): Evaluation<HardwareWalletSupportValue> => {
     // If this is a hardware wallet, mark as exempt since hardware wallets inherently support themselves
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type === WalletType.HARDWARE) {
       return exempt(
         hardwareWalletSupport,
         sentence(

--- a/src/schema/attributes/security/keys-handling.ts
+++ b/src/schema/attributes/security/keys-handling.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/features/security/keys-handling';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -89,7 +89,7 @@ export const keysHandling: Attribute<KeysHandlingValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<KeysHandlingValue>>) =>
     pickWorstRating<KeysHandlingValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<KeysHandlingValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         keysHandling,
         sentence(

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -11,7 +11,8 @@ import {
   type PasskeyVerificationSupport,
 } from '@/schema/features/security/passkey-verification';
 import { popRefs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -309,7 +310,7 @@ export const passkeyImplementation: Attribute<PasskeyImplementationValue> = {
     pickWorstRating<PasskeyImplementationValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<PasskeyImplementationValue> => {
     // Hardware wallets don't use passkeys
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type === WalletType.HARDWARE) {
       return exempt(
         passkeyImplementation,
         sentence(

--- a/src/schema/attributes/security/security-audits.ts
+++ b/src/schema/attributes/security/security-audits.ts
@@ -9,7 +9,8 @@ import {
 import type { ResolvedFeatures } from '@/schema/features';
 import { type SecurityAudit, securityAuditId } from '@/schema/features/security/security-audits';
 import { mergeRefs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 import { securityAuditsDetailsContent } from '@/types/content/security-audits-details';
 import { daysSince } from '@/types/date';
@@ -199,7 +200,7 @@ export const securityAudits: Attribute<SecurityAuditsValue> = {
     ],
   },
   evaluate: (features: ResolvedFeatures): Evaluation<SecurityAuditsValue> => {
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type === WalletType.HARDWARE) {
       return exempt(
         securityAudits,
         sentence('This attribute is not applicable to hardware wallets.'),

--- a/src/schema/attributes/security/software-hw-integration.ts
+++ b/src/schema/attributes/security/software-hw-integration.ts
@@ -10,7 +10,8 @@ import { AccountType, supportsOnlyAccountType } from '@/schema/features/account-
 import { HardwareWalletType } from '@/schema/features/security/hardware-wallet-support';
 import { isSupported } from '@/schema/features/support';
 import { mergeRefs, refs } from '@/schema/reference';
-import { type AtLeastOneVariant, Variant } from '@/schema/variants';
+import { type AtLeastOneVariant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating } from '../common';
@@ -196,7 +197,7 @@ export const softwareHWIntegration: Attribute<SoftwareHWIntegrationValue> = {
   },
   evaluate: (features: ResolvedFeatures): Evaluation<SoftwareHWIntegrationValue> => {
     // For hardware wallets, this evaluation doesn't apply
-    if (features.variant === Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return {
         value: {
           id: 'exempt_hardware_wallet',

--- a/src/schema/attributes/security/supply-chain-diy.ts
+++ b/src/schema/attributes/security/supply-chain-diy.ts
@@ -15,6 +15,7 @@ import {
 import { popRefs } from '@/schema/reference';
 import { Variant } from '@/schema/variants';
 import type { WalletMetadata } from '@/schema/wallet';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -111,7 +112,7 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
     return null;
   },
   evaluate: (features: ResolvedFeatures): Evaluation<SupplyChainDIYValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         supplyChainDIY,
         sentence(

--- a/src/schema/attributes/security/supply-chain-factory.ts
+++ b/src/schema/attributes/security/supply-chain-factory.ts
@@ -15,6 +15,7 @@ import {
 import { popRefs } from '@/schema/reference';
 import { Variant } from '@/schema/variants';
 import type { WalletMetadata } from '@/schema/wallet';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -134,7 +135,7 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
     return null;
   },
   evaluate: (features: ResolvedFeatures): Evaluation<SupplyChainFactoryValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         supplyChainFactory,
         sentence(

--- a/src/schema/attributes/security/user-safety.ts
+++ b/src/schema/attributes/security/user-safety.ts
@@ -9,7 +9,7 @@ import type { ResolvedFeatures } from '@/schema/features';
 import { type UserSafetySupport, UserSafetyType } from '@/schema/features/security/user-safety';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -148,7 +148,7 @@ Rating thresholds: PASS if >=11/16 criteria pass, PARTIAL if >=6/16 pass, else F
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<UserSafetyValue>>) =>
     pickWorstRating<UserSafetyValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<UserSafetyValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         userSafety,
         sentence(

--- a/src/schema/attributes/self-sovereignty/interoperability.ts
+++ b/src/schema/attributes/self-sovereignty/interoperability.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/features/self-sovereignty/interoperability';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -80,7 +80,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<InteroperabilityValue>>) =>
     pickWorstRating<InteroperabilityValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<InteroperabilityValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(interoperability, sentence('Only rated for hardware wallets'), brand, {
         thirdPartyCompatibility: InteroperabilityType.FAIL,
         noSupplierLinkage: InteroperabilityType.FAIL,

--- a/src/schema/attributes/transparency/maintenance.ts
+++ b/src/schema/attributes/transparency/maintenance.ts
@@ -7,7 +7,7 @@ import {
 } from '@/schema/features/transparency/maintenance';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -97,7 +97,7 @@ export const maintenance: Attribute<MaintenanceValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<MaintenanceValue>>) =>
     pickWorstRating<MaintenanceValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<MaintenanceValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(
         maintenance,
         sentence('These attributes only refer to hardware wallet maintenance'),

--- a/src/schema/attributes/transparency/reputation.ts
+++ b/src/schema/attributes/transparency/reputation.ts
@@ -4,7 +4,7 @@ import type { ResolvedFeatures } from '@/schema/features';
 import { type ReputationSupport, ReputationType } from '@/schema/features/transparency/reputation';
 import { popRefs } from '@/schema/reference';
 import type { AtLeastOneVariant } from '@/schema/variants';
-import { Variant } from '@/schema/variants';
+import { WalletType } from '@/schema/wallet-types';
 import { markdown, paragraph, sentence } from '@/types/content';
 
 import { exempt, pickWorstRating, unrated } from '../common';
@@ -94,7 +94,7 @@ export const reputation: Attribute<ReputationValue> = {
   aggregate: (perVariant: AtLeastOneVariant<Evaluation<ReputationValue>>) =>
     pickWorstRating<ReputationValue>(perVariant),
   evaluate: (features: ResolvedFeatures): Evaluation<ReputationValue> => {
-    if (features.variant !== Variant.HARDWARE) {
+    if (features.type !== WalletType.HARDWARE) {
       return exempt(reputation, sentence('Only rated for hardware wallets'), brand, {
         originalProduct: ReputationType.FAIL,
         availability: ReputationType.FAIL,

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -39,6 +39,7 @@ import {
   type Variant,
   type VariantFeature,
 } from './variants';
+import { variantToWalletType, type WalletType } from './wallet-types';
 
 /**
  * A set of features about any type of wallet.
@@ -214,8 +215,17 @@ export type WalletEmbeddedFeatures = WalletBaseFeatures & {};
  * All features are resolved to a single variant here.
  */
 export interface ResolvedFeatures {
-  /** The wallet variant which was used to resolve the feature tree. */
+  /**
+   * The wallet variant which was used to resolve the feature tree.
+   */
   variant: Variant;
+
+  /**
+   * The type of the wallet.
+   * This is a shorthand for `variantToWalletType(variant)`, meant to be used
+   * for easy filtering in attribute evaluation code.
+   */
+  type: WalletType;
 
   /** The profile of the wallet. */
   profile: WalletProfile;
@@ -288,6 +298,7 @@ export function resolveFeatures(features: WalletBaseFeatures, variant: Variant):
 
   return {
     variant,
+    type: variantToWalletType(variant),
     profile: features.profile,
     security: {
       scamAlerts: softwareFeat(features => features.security.scamAlerts),


### PR DESCRIPTION
This simplifies such exemption code a bit as the `WalletType` enum is a narrower version of `Variant`.

Updates issue #181.