### PR TITLE
fix: Remove gapAngle so pie chart slices are better aligned

### DIFF
--- a/src/ui/molecules/RatingDetailModal.tsx
+++ b/src/ui/molecules/RatingDetailModal.tsx
@@ -113,7 +113,7 @@ export function RatingDetailContent<Vs extends ValueSet>({
     const centerX = 150;
     const centerY = 150;
     const radius = 120;
-    const gapAngle = 2; // Gap in degrees
+    const gapAngle = 0; // Gap in degrees
     const sliceAngle = 360 / attributeCount - gapAngle;
 
     return mapNonExemptGroupAttributes(evalGroup, (evalAttr, i) => {

--- a/src/ui/molecules/wallet/heading/EvaluatedGroupOverview.tsx
+++ b/src/ui/molecules/wallet/heading/EvaluatedGroupOverview.tsx
@@ -56,7 +56,7 @@ export function EvaluatedGroupOverview<Vs extends ValueSet>({
     const centerX = 150;
     const centerY = 150;
     const radius = 120;
-    const gapAngle = 2; // Gap in degrees
+    const gapAngle = 0; // Gap in degrees
     const sliceAngle = 360 / attributeCount - gapAngle;
 
     return mapNonExemptGroupAttributes(evalGroup, (evalAttr, i) => {

--- a/src/ui/organisms/PizzaSliceChart.tsx
+++ b/src/ui/organisms/PizzaSliceChart.tsx
@@ -47,7 +47,7 @@ export const PizzaSliceChart = <Vs extends ValueSet>({
     const centerX = 50;
     const centerY = 50;
     const radius = 45;
-    const gapAngle = 2; // Gap in degrees
+    const gapAngle = 0; // Gap in degrees
     const precision = 4; // Number of decimal places to round coordinates to
 
     const sliceAngle = 360 / attributeCount - gapAngle;


### PR DESCRIPTION
## What it solves

Small but annoying detail 😅 

- Sets the `gapAngle` to 0 so the pie slices are visually aligned

## Screenshots

Before:
<img width="280" alt="Screenshot 2025-06-30 at 15 33 54" src="https://github.com/user-attachments/assets/a6240075-2efe-4e1e-8491-c676ea5dc86e" />

After:
<img width="266" alt="Screenshot 2025-06-30 at 15 34 06" src="https://github.com/user-attachments/assets/ec6d549b-b122-4e84-8e0a-0a69e4a28646" />
