### PR TITLE
Add wallet-connected domains and browsing history to possible data leaks

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -2,6 +2,8 @@ import { jiojosbg } from '@/data/contributors/jiojosbg'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import {
 	Leak,
+	LeakedPersonalInfo,
+	LeakedWalletInfo,
 	MultiAddressPolicy,
 	RegularEndpoint,
 } from '@/schema/features/privacy/data-collection'
@@ -282,65 +284,56 @@ export const ambire: SoftwareWallet = {
 					{
 						entity: ambireEntity,
 						leaks: {
-							cexAccount: Leak.NEVER,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
 							ref: dataLeakReferences.ambire,
-							walletAddress: Leak.ALWAYS,
 						},
 					},
 					{
 						entity: pimlico,
 						leaks: {
-							cexAccount: Leak.NEVER,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
 							ref: dataLeakReferences.pimlico,
-							walletAddress: Leak.ALWAYS,
 						},
 					},
 					{
 						entity: biconomy,
 						leaks: {
-							cexAccount: Leak.NEVER,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
 							ref: dataLeakReferences.biconomy,
-							walletAddress: Leak.ALWAYS,
 						},
 					},
 					{
 						entity: lifi,
 						leaks: {
-							cexAccount: Leak.NEVER,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.NEVER,
 							ref: dataLeakReferences.lifi,
-							walletAddress: Leak.NEVER,
 						},
 					},
 					{
 						entity: github,
 						leaks: {
-							cexAccount: Leak.NEVER,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.NEVER,
 							ref: dataLeakReferences.github,
-							walletAddress: Leak.NEVER,
 						},
 					},
 				],

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -3,6 +3,8 @@ import { polymutex } from '@/data/contributors/polymutex'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import {
 	Leak,
+	LeakedPersonalInfo,
+	LeakedWalletInfo,
 	MultiAddressPolicy,
 	RegularEndpoint,
 } from '@/schema/features/privacy/data-collection'
@@ -159,27 +161,28 @@ export const daimo: SoftwareWallet = {
 					{
 						entity: daimoInc,
 						leaks: {
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
+							[LeakedPersonalInfo.PSEUDONYM]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
-							pseudonym: Leak.ALWAYS,
 							ref: {
 								explanation:
 									'Wallet operations are routed through Daimo.com servers without proxying.',
 								url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/viemClient.ts#L35-L50',
 							},
-							walletAddress: Leak.ALWAYS,
 						},
 					},
 					{
 						entity: pimlico,
 						leaks: {
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
-							mempoolTransactions: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
@@ -190,18 +193,18 @@ export const daimo: SoftwareWallet = {
 									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/bundlerClient.ts#L131-L133',
 								],
 							},
-							walletAddress: Leak.ALWAYS,
 						},
 					},
 					{
 						entity: honeycomb,
 						leaks: {
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+							[LeakedPersonalInfo.PSEUDONYM]: Leak.ALWAYS,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
-							pseudonym: Leak.ALWAYS,
 							ref: {
 								explanation:
 									'Daimo records telemetry events to Honeycomb. This data includes your Daimo username. Since this username is also linked to your wallet address onchain, Honeycomb can associate the username they receive with your wallet address.',
@@ -209,29 +212,15 @@ export const daimo: SoftwareWallet = {
 									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/server/telemetry.ts#L101-L111',
 								],
 							},
-							walletAddress: Leak.ALWAYS,
-						},
-					},
-					{
-						entity: daimoInc,
-						leaks: {
-							endpoint: RegularEndpoint,
-							farcasterAccount: Leak.OPT_IN,
-							ref: [
-								{
-									explanation:
-										'Users may opt to link their Farcaster profile to their Daimo profile.',
-									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx#L141-L148',
-								},
-							],
 						},
 					},
 					{
 						entity: binance,
 						leaks: {
-							cexAccount: Leak.OPT_IN,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.OPT_IN,
+							[LeakedPersonalInfo.CEX_ACCOUNT]: Leak.OPT_IN,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.OPT_IN,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.OPT_IN,
 							multiAddress: {
 								type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 							},
@@ -242,14 +231,13 @@ export const daimo: SoftwareWallet = {
 									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/binanceClient.ts#L132',
 								},
 							],
-							walletAddress: Leak.OPT_IN,
 						},
 					},
 					{
 						entity: openExchangeRates,
 						leaks: {
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.ALWAYS,
 							ref: [
 								{
 									explanation:
@@ -263,10 +251,28 @@ export const daimo: SoftwareWallet = {
 						},
 					},
 					{
-						entity: merkleManufactory,
+						entity: daimoInc,
 						leaks: {
 							endpoint: RegularEndpoint,
-							ipAddress: Leak.OPT_IN,
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.OPT_IN,
+							[LeakedPersonalInfo.FARCASTER_ACCOUNT]: Leak.OPT_IN,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.OPT_IN,
+							ref: [
+								{
+									explanation:
+										'Users may opt to link their Farcaster profile to their Daimo profile.',
+									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx#L141-L148',
+								},
+							],
+						},
+					},
+					{
+						entity: merkleManufactory,
+						leaks: {
+							[LeakedPersonalInfo.IP_ADDRESS]: Leak.OPT_IN,
+							[LeakedPersonalInfo.FARCASTER_ACCOUNT]: Leak.OPT_IN,
+							[LeakedWalletInfo.WALLET_ADDRESS]: Leak.OPT_IN,
+							endpoint: RegularEndpoint,
 							ref: [
 								{
 									explanation:
@@ -278,7 +284,7 @@ export const daimo: SoftwareWallet = {
 					},
 				],
 				onchain: {
-					pseudonym: Leak.ALWAYS,
+					[LeakedPersonalInfo.PSEUDONYM]: Leak.ALWAYS,
 					ref: {
 						explanation:
 							"Creating a Daimo wallet creates a transaction publicly registering your name and address in Daimo's nameRegistry contract on Ethereum.",

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -3,6 +3,8 @@ import { polymutex } from '@/data/contributors/polymutex'
 import { AccountType } from '@/schema/features/account-support'
 import {
 	Leak,
+	LeakedPersonalInfo,
+	LeakedWalletInfo,
 	MultiAddressPolicy,
 	RegularEndpoint,
 } from '@/schema/features/privacy/data-collection'
@@ -172,10 +174,13 @@ export const rabby: SoftwareWallet = {
 							// The code refers to this by `api.rabby.io`, but Rabby is wholly owned by DeBank.
 							entity: deBank,
 							leaks: {
-								cexAccount: Leak.NEVER, // There appears to be code to link to a Coinbase account but no way to reach it from the UI?
+								[LeakedPersonalInfo.CEX_ACCOUNT]: Leak.NEVER, // There appears to be code to link to a Coinbase account but no way to reach it from the UI?
+								[LeakedPersonalInfo.IP_ADDRESS]: Leak.ALWAYS,
+								[LeakedWalletInfo.MEMPOOL_TRANSACTIONS]: Leak.ALWAYS,
+								[LeakedWalletInfo.WALLET_ACTIONS]: Leak.ALWAYS, // Matomo analytics
+								[LeakedWalletInfo.WALLET_ADDRESS]: Leak.ALWAYS,
+								[LeakedWalletInfo.WALLET_CONNECTED_DOMAINS]: Leak.ALWAYS, // Scam prevention dialog queries online service and sends domain name
 								endpoint: RegularEndpoint,
-								ipAddress: Leak.ALWAYS,
-								mempoolTransactions: Leak.ALWAYS,
 								multiAddress: {
 									type: MultiAddressPolicy.ACTIVE_ADDRESS_ONLY,
 								},
@@ -186,15 +191,20 @@ export const rabby: SoftwareWallet = {
 									},
 									{
 										explanation:
-											'Rabby uses self-hosted Matomo Analytics to track user actions. While this tracking data does not contain wallet addresses, it goes to DeBank-owned servers much like Ethereum RPC requests do. This puts DeBank in a position to link user actions with wallet addresses through IP address correlation.',
+											'Rabby uses self-hosted Matomo Analytics to track user actions within the wallet interface. While this tracking data does not contain wallet addresses, it goes to DeBank-owned servers much like Ethereum RPC requests do. This puts DeBank in a position to link user actions with wallet addresses through IP address correlation.',
 										url: 'https://github.com/search?q=repo%3ARabbyHub%2FRabby%20matomoRequestEvent&type=code',
+									},
+									{
+										explanation:
+											'Rabby checks whether the domain you are connecting your wallet to is on a scam list. It sends the domain along with Ethereum address in non-proxied HTTP requests for API methods `getOriginIsScam`, `getOriginPopularityLevel`, `getRecommendChains`, and others.',
+										label: 'Rabby API code on npmjs.com',
+										url: 'https://www.npmjs.com/package/@rabby-wallet/rabby-api?activeTab=code',
 									},
 									{
 										explanation: 'Balance refresh requests are made about the active address only.',
 										url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/background/controller/wallet.ts#L1622',
 									},
 								],
-								walletAddress: Leak.ALWAYS,
 							},
 						},
 					],

--- a/src/schema/attributes/privacy/address-correlation.ts
+++ b/src/schema/attributes/privacy/address-correlation.ts
@@ -10,7 +10,9 @@ import type { ResolvedFeatures } from '@/schema/features'
 import {
 	compareLeakedInfo,
 	type Endpoint,
+	inferEndpointLeaks,
 	inferLeaks,
+	isEndpointLeaks,
 	Leak,
 	type LeakedInfo,
 	leakedInfoName,
@@ -162,8 +164,10 @@ function isSealedSecureEnclave(endpoint?: Endpoint): boolean {
 	return true
 }
 
-export function linkableToWalletAddress(leaks: Leaks): WalletAddressLinkableTo[] {
-	const qualLeaks = inferLeaks(leaks)
+export function linkableToWalletAddress<T extends LeakedInfo>(
+	leaks: Leaks<T>,
+): WalletAddressLinkableTo[] {
+	const qualLeaks = isEndpointLeaks(leaks) ? inferEndpointLeaks(leaks) : inferLeaks(leaks)
 
 	if (!leaksByDefault(qualLeaks.walletAddress)) {
 		return []
@@ -185,7 +189,7 @@ export function linkableToWalletAddress(leaks: Leaks): WalletAddressLinkableTo[]
 			// Check if the server is running in a secure enclave with all
 			// desirable properties to shield the IP address from being a
 			// privacy leak.
-			if (isSealedSecureEnclave(leaks.endpoint)) {
+			if (isEndpointLeaks(qualLeaks) && isSealedSecureEnclave(qualLeaks.endpoint)) {
 				continue
 			}
 		}
@@ -287,7 +291,7 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 		}
 
 		const linkables: WalletAddressLinkableBy[] = []
-		const allRefs: ReferenceArray = refs(features.privacy.dataCollection.onchain)
+		const allRefs: ReferenceArray = []
 
 		for (const collected of features.privacy.dataCollection.collectedByEntities) {
 			allRefs.push(...refs(collected.leaks))
@@ -296,6 +300,8 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 				linkables.push({ by: collected.entity, ...linkable })
 			}
 		}
+
+		allRefs.push(...refs(features.privacy.dataCollection.onchain))
 
 		for (const linkable of linkableToWalletAddress({
 			...features.privacy.dataCollection.onchain,

--- a/src/schema/attributes/privacy/multi-address-correlation.ts
+++ b/src/schema/attributes/privacy/multi-address-correlation.ts
@@ -10,7 +10,7 @@ import type { ResolvedFeatures } from '@/schema/features'
 import {
 	type Endpoint,
 	type EntityData,
-	inferLeaks,
+	inferEndpointLeaks,
 	leaksByDefault,
 	type MultiAddressHandling,
 	MultiAddressPolicy,
@@ -235,9 +235,9 @@ function rateHandling(handling: MultiAddressHandling, endpoint: Endpoint): numbe
 											switch (endpoint.verifiability.clientVerification.type) {
 												case 'NOT_VERIFIED':
 													return 1
-												case 'VERIFIED':
-													return 2
 												case 'VERIFIED_BUT_NO_SOURCE_AVAILABLE':
+													return 2
+												case 'VERIFIED':
 													return 3
 											}
 									}
@@ -371,7 +371,7 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 		const allRefs: ReferenceArray = []
 
 		for (const collected of features.privacy.dataCollection.collectedByEntities) {
-			const leaks = inferLeaks(collected.leaks)
+			const leaks = inferEndpointLeaks(collected.leaks)
 
 			if (!leaksByDefault(leaks.walletAddress)) {
 				continue


### PR DESCRIPTION
Rabby leaks this, and we should take it into account.

Also update all data-leak data to use enum-style keys, and automatically classify IP addresses as leaked for entities that are behind regular (non-enclave) endpoints.