### PR TITLE
Stricter variants consistency check across feature data

### DIFF
--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -213,6 +213,8 @@ export const rabby: SoftwareWallet = {
 					],
 					onchain: {},
 				},
+				[Variant.DESKTOP]: null,
+				[Variant.MOBILE]: null,
 			},
 			privacyPolicy: 'https://rabby.io/docs/privacy',
 			transactionPrivacy: {
@@ -251,6 +253,8 @@ export const rabby: SoftwareWallet = {
 						}),
 					},
 				},
+				[Variant.BROWSER]: null,
+				[Variant.MOBILE]: null,
 			},
 			lightClient: {
 				ethereumL1: notSupported,

--- a/src/schema/features/ecosystem/integration.ts
+++ b/src/schema/features/ecosystem/integration.ts
@@ -1,4 +1,5 @@
 import {
+	type AtLeastOneTrueVariant,
 	type ResolvedFeature,
 	resolveFeature,
 	type Variant,
@@ -66,10 +67,11 @@ export const notApplicableWalletIntegration: WalletIntegration = {
 
 export function resolveWalletIntegrationFeatures(
 	walletIntegration: WalletIntegration,
+	expectedVariants: AtLeastOneTrueVariant,
 	variant: Variant,
 ): ResolvedWalletIntegration {
 	return {
 		browser: walletIntegration.browser,
-		walletCall: resolveFeature(walletIntegration.walletCall, variant),
+		walletCall: resolveFeature(walletIntegration.walletCall, expectedVariants, variant),
 	}
 }

--- a/src/schema/wallet.ts
+++ b/src/schema/wallet.ts
@@ -1,5 +1,6 @@
 import type { Paragraph, TypographicContent } from '@/types/content'
 import type { CalendarDate } from '@/types/date'
+import { prefixError } from '@/types/errors'
 import type { Dict } from '@/types/utils/dict'
 import {
 	isNonEmptyArray,
@@ -322,13 +323,17 @@ function resolveVariant(wallet: BaseWallet, variant: Variant): ResolvedWallet | 
 		return null
 	}
 
-	const resolvedFeatures = resolveFeatures(wallet.features, variant)
+	try {
+		const resolvedFeatures = resolveFeatures(wallet.features, wallet.variants, variant)
 
-	return {
-		metadata: wallet.metadata,
-		variant,
-		features: resolvedFeatures,
-		attributes: evaluateAttributes(resolvedFeatures, wallet.metadata),
+		return {
+			metadata: wallet.metadata,
+			variant,
+			features: resolvedFeatures,
+			attributes: evaluateAttributes(resolvedFeatures, wallet.metadata),
+		}
+	} catch (e) {
+		throw prefixError(`Wallet ${wallet.metadata.id}`, e)
 	}
 }
 

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,0 +1,33 @@
+/** Get the error message of an error. */
+export function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message
+	}
+
+	if (typeof error === 'string') {
+		return error
+	}
+
+	if (
+		error &&
+		typeof error === 'object' &&
+		'message' in error &&
+		error.message !== undefined &&
+		error.message !== null
+	) {
+		return getErrorMessage(error.message)
+	}
+
+	const str = String(error)
+
+	if (str === '') {
+		return '<unknown error>'
+	}
+
+	return str
+}
+
+/** Prefix an existing error with a given prefix message. */
+export function prefixError(prefix: string, e: unknown): Error {
+	return new Error(`${prefix}: ${getErrorMessage(e)}`)
+}


### PR DESCRIPTION
For wallets that have more than one variant, this PR enforces that wallet feature data has exactly that same set of variants used across all their variant-specific features.

Fix Rabby to make it pass these new checks.