### PR TITLE
Stricter typechecks around `Supported<T>` types.

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -1,5 +1,6 @@
 import { jiojosbg } from '@/data/contributors/jiojosbg'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
+import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
 import {
 	Leak,
 	LeakedPersonalInfo,
@@ -183,7 +184,7 @@ export const ambire: SoftwareWallet = {
 				erc7828: notSupported,
 				erc7831: notSupported,
 			},
-			nonChainSpecificEnsResolution: supported({
+			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
 				medium: 'CHAIN_CLIENT',
 			}),
 		},

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -1,6 +1,7 @@
 import { nconsigny } from '@/data/contributors/nconsigny'
 import { polymutex } from '@/data/contributors/polymutex'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
+import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
 import {
 	Leak,
 	LeakedPersonalInfo,
@@ -75,7 +76,7 @@ export const daimo: SoftwareWallet = {
 				erc7828: notSupported,
 				erc7831: notSupported,
 			},
-			nonChainSpecificEnsResolution: supported({
+			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
 				medium: 'CHAIN_CLIENT',
 			}),
 			ref: [

--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -8,6 +8,7 @@ import {
 	type Value,
 } from '@/schema/attributes'
 import type { ResolvedFeatures } from '@/schema/features'
+import { isSupported, type Support, type Supported } from '@/schema/features/support'
 import { type ReferenceArray, refs } from '@/schema/reference'
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content'
 import type { NonEmptyArray } from '@/types/utils/non-empty'
@@ -15,19 +16,19 @@ import type { NonEmptyArray } from '@/types/utils/non-empty'
 import { type Eip, eipMarkdownLink, eipMarkdownLinkAndTitle, eipShortLabel } from '../../eips'
 import type {
 	AddressResolution,
-	AddressResolutionSupport,
+	AddressResolutionData,
 } from '../../features/privacy/address-resolution'
 import { pickWorstRating, unrated } from '../common'
 
 const brand = 'attributes.ecosystem.address_resolution'
 
 export type AddressResolutionValue = Value & {
-	addressResolution?: AddressResolution<AddressResolutionSupport>
+	addressResolution?: AddressResolution<Support<AddressResolutionData>>
 	__brand: 'attributes.ecosystem.address_resolution'
 }
 
 function getOffchainProviderInfo(
-	support: AddressResolutionSupport & { support: 'SUPPORTED'; medium: 'OFFCHAIN' },
+	support: Supported<AddressResolutionData> & { medium: 'OFFCHAIN' },
 ): { rating: Rating; offchainInfo: string; walletShould?: string } {
 	if (
 		support.offchainDataVerifiability === 'VERIFIABLE' &&
@@ -71,16 +72,16 @@ function getOffchainProviderInfo(
 }
 
 function evaluateAddressResolution(
-	addressResolution: AddressResolution<AddressResolutionSupport>,
+	addressResolution: AddressResolution<Support<AddressResolutionData>>,
 	references: ReferenceArray,
 ): Evaluation<AddressResolutionValue> {
-	const chainSpecificERCs: NonEmptyArray<[Eip, AddressResolutionSupport, string]> = [
+	const chainSpecificERCs: NonEmptyArray<[Eip, Support<AddressResolutionData>, string]> = [
 		[erc7828, addressResolution.chainSpecificAddressing.erc7828, 'user@l2chain.eth'],
 		[erc7831, addressResolution.chainSpecificAddressing.erc7831, 'user.eth:l2chain'],
 	]
 
 	for (const [erc, chainSpecificSupport, exampleAddress] of chainSpecificERCs) {
-		if (chainSpecificSupport.support !== 'SUPPORTED') {
+		if (!isSupported(chainSpecificSupport)) {
 			continue
 		}
 
@@ -438,7 +439,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 
 		// We've checked all the nulls, so recreate the object without nulls in
 		// the type description.
-		const resolvedResolution: AddressResolution<AddressResolutionSupport> = {
+		const resolvedResolution: AddressResolution<Support<AddressResolutionData>> = {
 			chainSpecificAddressing: {
 				erc7828: features.addressResolution.chainSpecificAddressing.erc7828,
 				erc7831: features.addressResolution.chainSpecificAddressing.erc7831,

--- a/src/schema/attributes/privacy/private-transfers.ts
+++ b/src/schema/attributes/privacy/private-transfers.ts
@@ -1124,7 +1124,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 		let evaluation: Evaluation<PrivateTransfersValue> | null = null
 		let atLeastOneTechnologySupported = false
 
-		const maybeEvaluateTechnology = <T>(
+		const maybeEvaluateTechnology = <T extends object>(
 			support: Support<T>,
 			evaluate: (supported: Supported<T>) => Evaluation<PrivateTransfersValue>,
 		): Evaluation<PrivateTransfersValue> | null => {

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -9,10 +9,10 @@ import type { SmartWalletContract } from '../contracts'
 import type { WithRef } from '../reference'
 import { isSupported, type NotSupported, type Support, type Supported } from './support'
 
-export type AccountTypeSupport<T> = WithRef<Support<T>>
+export type AccountTypeSupport<T extends object> = WithRef<Support<T>>
 
 /** Type predicate for AccountTypeSupported<T>. */
-export function isAccountTypeSupported<T>(
+export function isAccountTypeSupported<T extends object>(
 	accountTypeSupport: AccountTypeSupport<T>,
 ): accountTypeSupport is WithRef<Supported<T>> {
 	return isSupported<T>(accountTypeSupport)
@@ -103,7 +103,7 @@ export function supportsAccountType(
 		return false
 	}
 
-	return isSupported<Support<unknown>>(accountSupport[accountType])
+	return isSupported<Support>(accountSupport[accountType])
 }
 
 /**

--- a/src/schema/features/privacy/address-resolution.ts
+++ b/src/schema/features/privacy/address-resolution.ts
@@ -1,7 +1,7 @@
 import type { Support } from '../support'
 
 /** Which methods of address resolution a wallet supports. */
-export interface AddressResolution<ARS = AddressResolutionSupport | null> {
+export interface AddressResolution<ARS = Support<AddressResolutionData> | null> {
 	/**
 	 * Support for basic ENS lookups (ENS domain to non-chain-specific raw hex
 	 * address).
@@ -19,7 +19,7 @@ export interface AddressResolution<ARS = AddressResolutionSupport | null> {
 }
 
 /** How a wallet resolves addresses. */
-export type AddressResolutionSupport = Support<
+export type AddressResolutionData =
 	| {
 			/**
 			 * The wallet reuses its own chain client provider to look up the
@@ -47,4 +47,3 @@ export type AddressResolutionSupport = Support<
 			 */
 			offchainProviderConnection: 'DIRECT_CONNECTION' | 'UNIQUE_PROXY_CIRCUIT'
 	  }
->

--- a/src/schema/features/support.ts
+++ b/src/schema/features/support.ts
@@ -3,12 +3,24 @@ import type { NonEmptyRecord } from '@/types/utils/non-empty'
 import type { WithRef } from '../reference'
 
 /** A supported feature. */
-export type Supported<T = object> = T & {
+export type Supported<T extends object = object> = T & {
 	support: 'SUPPORTED'
 }
 
 /** The feature is supported. */
-export function supported<T = object>(supportData: T): Supported<T> {
+export function supported<T extends object = object>(supportData: T): Supported<T> {
+	if (Object.hasOwn(supportData, 'support')) {
+		throw new Error(
+			'Do not include a `support` field in the object passed to `supported(...)`; that field is implicitly added.',
+		)
+	}
+
+	if (Object.keys(supportData).length === 0) {
+		throw new Error(
+			'Please use the `featureSupported` helper rather than `supported({})` for simple features that are/are not supported',
+		)
+	}
+
 	return {
 		support: 'SUPPORTED',
 		...supportData,
@@ -37,17 +49,20 @@ export function notSupportedWithRef(withRef: WithRef<unknown>): WithRef<NotSuppo
 }
 
 /** A feature that may or may not be supported. */
-export type Support<T = object> = NotSupported | Supported<T>
+export type Support<T extends object = object> = NotSupported | Supported<T>
 
 /** Type predicate for `Supported<T>` */
-export function isSupported<T>(support: Support<T>): support is Supported<T> {
+export function isSupported<T extends object>(support: Support<T>): support is Supported<T> {
 	return support.support === 'SUPPORTED'
 }
 
 /**
  * A non-empty record where at least one member must be supported.
  */
-export type AtLeastOneSupported<K extends string, T = object> = NonEmptyRecord<K, Support<T>> &
+export type AtLeastOneSupported<K extends string, T extends object = object> = NonEmptyRecord<
+	K,
+	Support<T>
+> &
 	{
 		[V in K]: Record<V, Supported<T>> & Partial<Record<Exclude<K, V>, Support<T>>>
 	}[K]


### PR DESCRIPTION
This makes it so that `T` in `Support<T>` is always an `object`. Also enforces the use of `featureSupported` over `supported({})`.