### PR TITLE
Add support for source-available proprietary license.

### DIFF
--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -10,6 +10,7 @@ import {
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
+import { License } from '@/schema/features/transparency/license'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -75,7 +76,23 @@ export const metamask: SoftwareWallet = {
 			},
 			walletCall: null,
 		},
-		license: null,
+		license: {
+			[Variant.BROWSER]: {
+				license: License.PROPRIETARY_SOURCE_AVAILABLE,
+				ref: {
+					explanation:
+						'The MetaMask browser extension uses a proprietary source-available license.',
+					url: 'https://github.com/MetaMask/metamask-extension/blob/main/LICENSE',
+				},
+			},
+			[Variant.MOBILE]: {
+				license: License.PROPRIETARY_SOURCE_AVAILABLE,
+				ref: {
+					explanation: 'The MetaMask mobile app uses a proprietary source-available license.',
+					url: 'https://github.com/MetaMask/metamask-mobile/blob/main/LICENSE',
+				},
+			},
+		},
 		monetization: {
 			ref: null,
 			revenueBreakdownIsPublic: false,

--- a/src/schema/features/transparency/license.ts
+++ b/src/schema/features/transparency/license.ts
@@ -13,6 +13,7 @@ export enum License {
 	MIT = 'MIT',
 	MIT_WITH_CLAUSE = 'MIT-C',
 	PROPRIETARY = '_PROPRIETARY',
+	PROPRIETARY_SOURCE_AVAILABLE = '_PROPRIETARY_SOURCE_AVAILABLE',
 	UNLICENSED_VISIBLE = '_UNLICENSED_VISIBLE',
 }
 
@@ -53,6 +54,8 @@ export function licenseName(license: License): string {
 			return 'MIT with Clause'
 		case License.PROPRIETARY:
 			return 'Proprietary'
+		case License.PROPRIETARY_SOURCE_AVAILABLE:
+			return 'Proprietary source-available'
 		case License.UNLICENSED_VISIBLE:
 			return 'Unlicensed'
 	}
@@ -75,6 +78,8 @@ export function licenseIsFOSS(license: License): FOSS {
 		case License.MIT:
 			return FOSS.FOSS
 		case License.PROPRIETARY:
+			return FOSS.NOT_FOSS
+		case License.PROPRIETARY_SOURCE_AVAILABLE:
 			return FOSS.NOT_FOSS
 		case License.UNLICENSED_VISIBLE:
 			return FOSS.NOT_FOSS
@@ -103,6 +108,8 @@ export function licenseSourceIsVisible(license: License): boolean {
 			return true
 		case License.PROPRIETARY:
 			return false
+		case License.PROPRIETARY_SOURCE_AVAILABLE:
+			return true
 		case License.UNLICENSED_VISIBLE:
 			return true
 	}
@@ -113,16 +120,17 @@ export function licenseSourceIsVisible(license: License): boolean {
  * @returns The SPDX URL of the license.
  */
 export function licenseUrl(license: License): LabeledUrl | null {
-	if (license === License.PROPRIETARY) {
-		return null
-	}
-
-	if (license === License.UNLICENSED_VISIBLE) {
-		return null
-	}
-
-	return {
-		url: `https://spdx.org/licenses/${license}.html`,
-		label: licenseName(license),
+	switch (license) {
+		case License.PROPRIETARY:
+			return null
+		case License.PROPRIETARY_SOURCE_AVAILABLE:
+			return null
+		case License.UNLICENSED_VISIBLE:
+			return null
+		default:
+			return {
+				url: `https://spdx.org/licenses/${license}.html`,
+				label: licenseName(license),
+			}
 	}
 }

--- a/src/ui/molecules/attributes/transparency/LicenseDetails.tsx
+++ b/src/ui/molecules/attributes/transparency/LicenseDetails.tsx
@@ -12,21 +12,29 @@ import type { LicenseDetailsProps } from '@/types/content/license-details'
 import { ExternalLink } from '@/ui/atoms/ExternalLink'
 
 export function LicenseDetails({ wallet, value }: LicenseDetailsProps): React.JSX.Element {
-	if (value.license === License.PROPRIETARY) {
-		return (
-			<Typography variant='body2'>
-				{wallet.metadata.displayName} is licensed under a proprietary non-open-source license.
-			</Typography>
-		)
-	}
-
-	if (value.license === License.UNLICENSED_VISIBLE) {
-		return (
-			<Typography variant='body2'>
-				{wallet.metadata.displayName} has no visible license information. Consequently, it should be
-				assumed to be proprietary (not open-source).
-			</Typography>
-		)
+	switch (value.license) {
+		case License.PROPRIETARY:
+			return (
+				<Typography variant='body2'>
+					{wallet.metadata.displayName} is licensed under a proprietary non-open-source license.
+				</Typography>
+			)
+		case License.PROPRIETARY_SOURCE_AVAILABLE:
+			return (
+				<Typography variant='body2'>
+					{wallet.metadata.displayName} is licensed under a proprietary source-available non-FOSS
+					license.
+				</Typography>
+			)
+		case License.UNLICENSED_VISIBLE:
+			return (
+				<Typography variant='body2'>
+					{wallet.metadata.displayName} has no visible license information. Consequently, it should
+					be assumed to be proprietary (not open-source).
+				</Typography>
+			)
+		default:
+		// Fallthrough.
 	}
 
 	const url = licenseUrl(value.license)


### PR DESCRIPTION
MetaMask browser extension and mobile app both use such a license.

Updates #93.
Updates #94.
Updates #256.