### PR TITLE
Implement Privacy Pools as a token transfer technology.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -171,6 +171,8 @@
 		"Qwen",
 		"R1",
 		"Rabby",
+		"ragequit",
+		"ragequitting",
 		"Railgun",
 		"redelegation",
 		"renderable",

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -359,6 +359,7 @@ export const ambire: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/coinbase.ts
+++ b/data/software-wallets/coinbase.ts
@@ -124,6 +124,7 @@ export const coinbase: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -306,6 +306,7 @@ export const daimo: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.PAYMENTS,

--- a/data/software-wallets/elytro.ts
+++ b/data/software-wallets/elytro.ts
@@ -88,6 +88,7 @@ export const elytro: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/family.ts
+++ b/data/software-wallets/family.ts
@@ -84,6 +84,7 @@ export const family: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -105,6 +105,7 @@ export const frame: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -116,6 +116,7 @@ export const metamask: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -116,6 +116,7 @@ export const nufi: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -91,6 +91,7 @@ export const phantom: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -229,6 +229,7 @@ export const rabby: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -99,6 +99,7 @@ export const rainbow: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -93,6 +93,7 @@ export const safe: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -88,6 +88,7 @@ export const zerion: SoftwareWallet = {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
 				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
 			},
 		},
 		profile: WalletProfile.GENERIC,

--- a/src/schema/features/privacy/transaction-privacy.ts
+++ b/src/schema/features/privacy/transaction-privacy.ts
@@ -1,5 +1,6 @@
 import type { Entity } from '@/schema/entity'
 import type { WithRef } from '@/schema/reference'
+import { Enum } from '@/utils/enum'
 
 import type { Support, Supported } from '../support'
 import type { FeeDisplay } from '../transparency/fee-display'
@@ -8,25 +9,14 @@ import type { MultiAddressHandling, MultiAddressPolicy } from './data-collection
 export enum PrivateTransferTechnology {
 	STEALTH_ADDRESSES = 'stealthAddresses',
 	TORNADO_CASH_NOVA = 'tornadoCashNova',
+	PRIVACY_POOLS = 'privacyPools',
 }
 
-/** Type predicate for `PrivateTransferTechnology`. */
-export function isPrivateTransferTechnology(obj: unknown): obj is PrivateTransferTechnology {
-	if (typeof obj !== 'string') {
-		return false
-	}
-
-	switch (obj) {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Safe because this is exactly what we are trying to establish
-		case PrivateTransferTechnology.STEALTH_ADDRESSES:
-			return true
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Safe because this is exactly what we are trying to establish
-		case PrivateTransferTechnology.TORNADO_CASH_NOVA:
-			return true
-		default:
-			return false
-	}
-}
+export const privateTransferTechnology = new Enum<PrivateTransferTechnology>({
+	[PrivateTransferTechnology.STEALTH_ADDRESSES]: true,
+	[PrivateTransferTechnology.TORNADO_CASH_NOVA]: true,
+	[PrivateTransferTechnology.PRIVACY_POOLS]: true,
+})
 
 export type FungibleTokenTransferMode =
 	/**
@@ -71,8 +61,11 @@ export type TransactionPrivacy = {
 	/** Support for Tornado Cash Nova. */
 	[PrivateTransferTechnology.TORNADO_CASH_NOVA]: Support<TornadoCashNovaSupport>
 
+	/** Support for Privacy Pools. */
+	[PrivateTransferTechnology.PRIVACY_POOLS]: Support<PrivacyPoolsSupport>
+
 	// TODO: Add other forms of transaction privacy here,
-	// e.g. Privacy Pools, Railgun, etc.
+	// e.g. Railgun, etc.
 } & IfDefaultTransferMode<
 	PrivateTransferTechnology.STEALTH_ADDRESSES,
 	{
@@ -83,6 +76,12 @@ export type TransactionPrivacy = {
 		PrivateTransferTechnology.TORNADO_CASH_NOVA,
 		{
 			[PrivateTransferTechnology.TORNADO_CASH_NOVA]: Supported<TornadoCashNovaSupport>
+		}
+	> &
+	IfDefaultTransferMode<
+		PrivateTransferTechnology.PRIVACY_POOLS,
+		{
+			[PrivateTransferTechnology.PRIVACY_POOLS]: Supported<PrivacyPoolsSupport>
 		}
 	>
 
@@ -284,3 +283,126 @@ export type TornadoCashNovaSupport = WithRef<
 		  }
 	)
 >
+
+type PrivacyPoolsWithdrawalWithRelayer = {
+	/** Who is the default relayer? */
+	defaultRelayer: Entity | 'NO_DEFAULT_RELAYER'
+
+	/**
+	 * Can the relayer endpoint be customized?
+	 */
+	customizableRelayer: Support
+
+	/**
+	 * Can the relayer learn the user's IP address?
+	 */
+	relayerLearnsUserIpAddress: boolean
+} & ( // Either there is a default relayer...
+	| { defaultRelayer: Entity }
+	// Or customizable relayers must be supported.
+	| { customizableRelayer: Supported }
+)
+
+interface PrivacyPoolsCapabilitiesBase {
+	/**
+	 * Does the wallet support the Ethereum mainnet pool for Ether?
+	 */
+	etherL1Pool: Support
+
+	/**
+	 * Does the wallet support the Ethereum mainnet pool for USDC?
+	 */
+	usdcL1Pool: Support
+
+	/**
+	 * Does the wallet support ragequitting?
+	 * https://docs.privacypools.com/protocol/ragequit
+	 */
+	ragequit: Support
+
+	/**
+	 * Does the wallet support the ability to import deposit data
+	 * that has been exported from other wallets?
+	 */
+	importDeposits: Support
+
+	/**
+	 * Does the wallet support withdrawals without a relayer?
+	 */
+	withdrawalWithRelayer: Support<PrivacyPoolsWithdrawalWithRelayer>
+
+	/**
+	 * Does the wallet support withdrawals without a relayer?
+	 */
+	withdrawalWithoutRelayer: Support
+
+	/**
+	 * Does the wallet warn when doing multiple Privacy Pools operations
+	 * in quick succession, potentially leading to time-based correlation?
+	 */
+	warnAboutSuccessiveOperations: Support
+}
+
+type PrivacyPoolsCapabilities = PrivacyPoolsCapabilitiesBase &
+	// At least Ether or USDC must be supported.
+	({ etherL1Pool: Supported } | { usdcL1Pool: Supported }) &
+	// At least one form of withdrawal must be supported.
+	(| { withdrawalWithRelayer: Supported<PrivacyPoolsWithdrawalWithRelayer> }
+		| { withdrawalWithoutRelayer: Supported }
+	)
+
+interface PrivacyPoolsDepositsDataCustodian {
+	/** Who is the custodian? */
+	custodian: Entity
+
+	/**
+	 * If stored with a custodian. is there any user flow where this
+	 * custodian can learn the raw (decrypted) deposit data?
+	 */
+	custodianCanLearnDepositData: boolean
+
+	/**
+	 * If stored with a custodian, does the custodian learn the
+	 * user's IP address?
+	 */
+	custodianCanLearnUserIpAddress: boolean
+}
+
+type PrivacyPoolsDepositData = {
+	/** Can you export unencrypted deposit data out of the wallet? */
+	exportable: Support
+} & (
+	| { type: 'LOCAL_ONLY' }
+	| ({ type: 'CUSTODIAN_ONLY' } & PrivacyPoolsDepositsDataCustodian)
+	| ({
+			type: 'CUSTODIAN_OR_LOCAL'
+
+			/**
+			 * Does the user have to explicitly choose to use a custodian,
+			 * or is a custodian used by default?
+			 */
+			useOfCustodian: 'BY_DEFAULT' | 'OPT_IN'
+
+			/** Can you export unencrypted deposit data out of the wallet? */
+			exportable: Support<{
+				/**
+				 * When exporting deposit data, does the wallet require
+				 * information from the custodian before the export can be done?
+				 */
+				exportFunctionDependsOnCustodian: boolean
+			}>
+	  } & PrivacyPoolsDepositsDataCustodian)
+)
+
+/**
+ * Support data for Privacy Pools.
+ */
+export type PrivacyPoolsSupport = WithRef<{
+	/** What subset of the protocol does the wallet support? */
+	capabilities: PrivacyPoolsCapabilities
+
+	/**
+	 * How is deposit data handled?
+	 */
+	depositData: PrivacyPoolsDepositData
+}>

--- a/src/ui/molecules/attributes/privacy/PrivateTransfersDetails.tsx
+++ b/src/ui/molecules/attributes/privacy/PrivateTransfersDetails.tsx
@@ -8,8 +8,8 @@ import {
 	worstPrivateTransfersPrivacyLevel,
 } from '@/schema/attributes/privacy/private-transfers'
 import {
-	isPrivateTransferTechnology,
 	PrivateTransferTechnology,
+	privateTransferTechnology,
 } from '@/schema/features/privacy/transaction-privacy'
 import type { PrivateTransfersDetailsProps } from '@/types/content/private-transfers-details'
 import { assertNonEmptyArray } from '@/types/utils/non-empty'
@@ -25,11 +25,15 @@ function privateTransferTechnologyName(tech: PrivateTransferTechnology): string 
 			return 'stealth addresses'
 		case PrivateTransferTechnology.TORNADO_CASH_NOVA:
 			return 'Tornado Cash Nova'
+		case PrivateTransferTechnology.PRIVACY_POOLS:
+			return 'Privacy Pools'
 	}
 }
 
 function privateTransferLevelToIcon(level: PrivateTransfersPrivacyLevel): string {
 	switch (level) {
+		case PrivateTransfersPrivacyLevel.NOT_FULLY_IMPLEMENTED:
+			return ratingToIcon(Rating.FAIL)
 		case PrivateTransfersPrivacyLevel.NOT_PRIVATE:
 			return ratingToIcon(Rating.FAIL)
 		case PrivateTransfersPrivacyLevel.CHAIN_DATA_PRIVATE:
@@ -83,10 +87,10 @@ export function PrivateTransfersDetails({
 					)}
 					{value.defaultFungibleTokenTransferMode === 'EXPLICIT_CHOICE' &&
 						' Users must explicitly select private token transfers in order to transact privately.'}
-					{isPrivateTransferTechnology(value.defaultFungibleTokenTransferMode) &&
+					{privateTransferTechnology.is(value.defaultFungibleTokenTransferMode) &&
 						value.perTechnology.size === 1 &&
 						' Token transfers are private by default.'}
-					{isPrivateTransferTechnology(value.defaultFungibleTokenTransferMode) &&
+					{privateTransferTechnology.is(value.defaultFungibleTokenTransferMode) &&
 						value.perTechnology.size > 1 &&
 						` Token transfers use ${privateTransferTechnologyName(value.defaultFungibleTokenTransferMode)} by default.`}
 					{worstLevel !== PrivateTransfersPrivacyLevel.FULLY_PRIVATE && (

--- a/src/utils/enum.ts
+++ b/src/utils/enum.ts
@@ -1,0 +1,36 @@
+import {
+	assertNonEmptyArray,
+	type NonEmptyArray,
+	type NonEmptySet,
+	nonEmptySetFromArray,
+	setContains,
+} from '@/types/utils/non-empty'
+
+/**
+ * Helper class for enums.
+ */
+export class Enum<E extends string> {
+	/** A complete list of enum values. */
+	public readonly items: NonEmptyArray<E>
+
+	/** A complete set of enum values. */
+	public readonly set: NonEmptySet<E>
+
+	constructor(record: Record<E, true>) {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Safe because we know all keys are E.
+		this.items = assertNonEmptyArray<E>(Object.keys(record) as E[])
+		this.set = nonEmptySetFromArray<E>(this.items)
+	}
+
+	/**
+	 * @returns Whether the given object is an enum value.
+	 */
+	public is(obj: unknown): obj is E {
+		if (typeof obj !== 'string') {
+			return false
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Safe because this is exactly what we are trying to establish
+		return setContains(this.set, obj as E)
+	}
+}


### PR DESCRIPTION
Updates issue #192.

There are lots of small checks that the code for Privacy Pools verifies:

- Are both Ether and ERC-20 supported?
- Does the wallet implement ragequitting?
- Can you import deposit data from other wallets or past deposits?
- Can you permissionlessly export deposit data?
- Can you withdraw with a custom relayer?
- Does the default withdrawal relayer learn your IP?
- Is deposit data stored locally, or with a custodian?
- If with a custodian, does that custodian get to learn your IP, or do they get to learn your raw deposit data?
- Does the wallet warn you if you try to do too many deposit or withdrawals in a short period of time (reducing your anonset)?

Failing some of these checks is critical (for example, not being able to permissionlessly export your deposit data means you are locked into using the wallet), while others are only a partial failure (the withdrawal relayer learning your IP is an important privacy leak, but no user data gets leaked onchain).