### PR TITLE
WIP: Implement orderflow transparency attribute

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -326,7 +326,7 @@ export const ambire: SoftwareWallet = {
 							byEntity: ambireEntity,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+								[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,
 								multiAddress: {
@@ -343,7 +343,7 @@ export const ambire: SoftwareWallet = {
 							byEntity: pimlico,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+								[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,
 								multiAddress: {
@@ -357,7 +357,7 @@ export const ambire: SoftwareWallet = {
 							byEntity: biconomy,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+								[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,
 								multiAddress: {

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -246,7 +246,7 @@ export const daimo: SoftwareWallet = {
 							byEntity: pimlico,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+								[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,
 								multiAddress: {
@@ -270,7 +270,7 @@ export const daimo: SoftwareWallet = {
 							byEntity: daimoInc,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+								[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 								[PersonalInfo.PSEUDONYM]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -229,7 +229,7 @@ export const rabby: SoftwareWallet = {
 								dataCollection: {
 									[PersonalInfo.CEX_ACCOUNT]: CollectionPolicy.NEVER, // There appears to be code to link to a Coinbase account but no way to reach it from the UI?
 									[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-									[WalletInfo.MEMPOOL_TRANSACTIONS]: CollectionPolicy.ALWAYS,
+									[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.ALWAYS,
 									[WalletInfo.USER_ACTIONS]: CollectionPolicy.ALWAYS, // Matomo analytics
 									[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
 									endpoint: RegularEndpoint,

--- a/src/schema/attributes/transparency/orderflow-transparency.ts
+++ b/src/schema/attributes/transparency/orderflow-transparency.ts
@@ -1,0 +1,743 @@
+import { exampleNodeCompany } from '@/data/entities/example'
+import {
+	type Attribute,
+	type Evaluation,
+	exampleRating,
+	Rating,
+	type Value,
+} from '@/schema/attributes'
+import type { Entity } from '@/schema/entity'
+import type { ResolvedFeatures } from '@/schema/features'
+import {
+	collectedByDefault,
+	type Collection,
+	CollectionPolicy,
+	type DataCollection,
+	type DataCollectionByEntity,
+	dataCollectionForAllSupportedFlows,
+	DataCollectionPurpose,
+	dataCollectionPurposeToText,
+	type Endpoint,
+	endpointRunsVerifiedCode,
+	isSecureEnclaveEndpoint,
+	qualifiedDataCollection,
+	RegularEndpoint,
+	UserFlow,
+	type UserInfo,
+	WalletInfo,
+} from '@/schema/features/privacy/data-collection'
+import { WalletProfile } from '@/schema/features/profile'
+import {
+	isTransactionHandlingSecureEndpoint,
+	type OrderflowDisclosures,
+	OrderflowDisclosureType,
+	orderflowDisclosureType,
+	type TransactionHandlingSecureEndpoint,
+} from '@/schema/features/transparency/orderflow'
+import { refs } from '@/schema/reference'
+import type { AtLeastOneVariant } from '@/schema/variants'
+import { markdown, paragraph, sentence } from '@/types/content'
+import {
+	nonEmptyFirst,
+	type NonEmptySet,
+	nonEmptySet,
+	setContains,
+	setItems,
+	setSize,
+	setUnion,
+} from '@/types/utils/non-empty'
+
+import { exempt, pickWorstRating, unrated } from '../common'
+
+const brand = 'attributes.transparency.orderflow_transparency'
+
+interface EntityDisclosureInfo {
+	entity: Entity
+	disclosures: NonEmptySet<OrderflowDisclosureType>
+}
+
+export type OrderflowTransparencyValue = Value & {
+	entityInfo: Map<string, EntityDisclosureInfo>
+	__brand: 'attributes.transparency.orderflow_transparency'
+}
+
+function userInfoRequiresDisclosure(collection: Collection<UserInfo>): boolean {
+	const qualifiedCollection = qualifiedDataCollection(collection)
+
+	for (const infoRequiringDisclosure of [
+		WalletInfo.TRANSACTION_INTENT,
+		WalletInfo.TRANSACTION_DATA,
+	]) {
+		if (collectedByDefault(qualifiedCollection[infoRequiringDisclosure])) {
+			return true
+		}
+	}
+
+	return false
+}
+
+function dataCollectionPurposeRequiresDisclosure(
+	dataCollectionPurpose: DataCollectionPurpose,
+): boolean {
+	switch (dataCollectionPurpose) {
+		case DataCollectionPurpose.SWAP_QUOTE:
+			return true
+		case DataCollectionPurpose.TRANSACTION_BROADCAST:
+			return true
+		case DataCollectionPurpose.TRANSACTION_SIMULATION:
+			return true
+		default:
+			return false
+	}
+}
+
+/** Returns whether a given endpoint requires disclosure. */
+function endpointRequiresDisclosure(endpoint: Endpoint): boolean {
+	if (!isSecureEnclaveEndpoint(endpoint)) {
+		// Not running in an enclave, so can't prove what the endpoint is doing.
+		return true
+	}
+
+	if (!endpointRunsVerifiedCode(endpoint)) {
+		// Running in an enclave but not verifiably.
+		return true
+	}
+
+	if (!isTransactionHandlingSecureEndpoint(endpoint)) {
+		return true
+	}
+
+	if (endpoint.exportsNonIncludedTransactionData) {
+		// Non-included transaction data is exported out of the enclave, so the
+		// fact that it is running in an enclave provides no user benefit.
+		return true
+	}
+
+	if (endpoint.externalLogging.type === 'UNKNOWN' || endpoint.externalLogging.type === 'YES') {
+		// The endpoint may log transaction data, effectively exfiltrating them.
+		return true
+	}
+
+	if (!endpoint.provablyFairOrdering) {
+		// Ordering is not provably fair, so some foul play is still possible,
+		// and disclosure is required.
+		return true
+	}
+
+	if (endpoint.canGenerateOwnTransactions) {
+		// The endpoint can generate its own frontrunning transactions, so the
+		// possibility of frontrunning still exists and thus disclosure is still
+		// required.
+		return true
+	}
+
+	// Endpoint acts in a verifiable, provably-fair manner, does not generate
+	// frontrunning transactions, and does not export transaction data prior to
+	// inclusion. No disclosure required.
+	return false
+}
+
+function compareProminentDisclosureTypes(
+	disclosureType1: OrderflowDisclosureType,
+	disclosureType2: OrderflowDisclosureType,
+): number {
+	const disclosureProminence = (disclosureType: OrderflowDisclosureType): number => {
+		switch (disclosureType) {
+			case OrderflowDisclosureType.NOT_DISCLOSED:
+				return 0
+			case OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING:
+				return 1
+			case OrderflowDisclosureType.DISCLOSED_DURING_TRANSACTION_FLOW:
+				return 2
+		}
+	}
+
+	return disclosureProminence(disclosureType1) - disclosureProminence(disclosureType2)
+}
+
+function mostProminentDisclosure(
+	entityDisclosureInfo: EntityDisclosureInfo,
+): OrderflowDisclosureType {
+	return nonEmptyFirst(
+		setItems(entityDisclosureInfo.disclosures),
+		compareProminentDisclosureTypes,
+		true,
+	)
+}
+
+function completeDataCollection(dataCollection: Partial<DataCollection>): DataCollection {
+	return {
+		[UserFlow.NATIVE_SWAP]: dataCollection[UserFlow.NATIVE_SWAP] ?? { collected: [] },
+		[UserFlow.DAPP_CONNECTION]: dataCollection[UserFlow.DAPP_CONNECTION] ?? { collected: [] },
+		[UserFlow.SEND]: dataCollection[UserFlow.SEND] ?? { collected: [] },
+		[UserFlow.TRANSACTION]: dataCollection[UserFlow.TRANSACTION] ?? { collected: [] },
+		[UserFlow.UNCLASSIFIED]: dataCollection[UserFlow.UNCLASSIFIED] ?? { collected: [] },
+		[UserFlow.ONBOARDING]: dataCollection[UserFlow.ONBOARDING] ?? {
+			collected: [],
+			publishedOnchain: 'NO_DATA_PUBLISHED_ONCHAIN',
+		},
+	}
+}
+
+function evaluateOrderflowTransparency(
+	walletProfile: WalletProfile,
+	dataCollection: DataCollection,
+	orderflowDisclosures: OrderflowDisclosures,
+): Evaluation<OrderflowTransparencyValue> {
+	if (walletProfile === WalletProfile.PAYMENTS) {
+		return exempt(
+			orderflowTransparency,
+			sentence(`
+				{{WALLET_NAME}} is a payments-focused wallet, which is not susceptible to
+				MEV or frontrunning. As such, it does not need orderflow disclosures.
+			`),
+			brand,
+			{ entityInfo: new Map() },
+		)
+	}
+
+	if (
+		dataCollection[UserFlow.NATIVE_SWAP] === 'FLOW_NOT_SUPPORTED' &&
+		dataCollection[UserFlow.TRANSACTION] === 'FLOW_NOT_SUPPORTED'
+	) {
+		return exempt(
+			orderflowTransparency,
+			sentence(`
+			{{WALLET_NAME}} does not support MEV-susceptible transaction types, so no disclosures are required.
+		`),
+			brand,
+			{ entityInfo: new Map() },
+		)
+	}
+
+	const dataCollectionByEntities = dataCollectionForAllSupportedFlows(dataCollection)
+
+	if (dataCollectionByEntities === null) {
+		return unrated(orderflowTransparency, brand, { entityInfo: new Map() })
+	}
+
+	const references = refs(orderflowDisclosures)
+	const entityInfo = new Map<string, EntityDisclosureInfo>()
+
+	for (const disclosureType of orderflowDisclosureType.items) {
+		const entitiesForDisclosureType: Entity[] | undefined = orderflowDisclosures[disclosureType]
+
+		if (entitiesForDisclosureType === undefined) {
+			continue
+		}
+
+		for (const entity of entitiesForDisclosureType) {
+			const entityDisclosureInfo = entityInfo.get(entity.id)
+
+			if (entityDisclosureInfo === undefined) {
+				entityInfo.set(entity.id, {
+					entity,
+					disclosures: nonEmptySet<OrderflowDisclosureType>(disclosureType),
+				})
+			} else {
+				entityDisclosureInfo.disclosures = setUnion([
+					entityDisclosureInfo.disclosures,
+					nonEmptySet<OrderflowDisclosureType>(disclosureType),
+				])
+			}
+		}
+	}
+	const entitiesNeedingDisclosure = new Map<string, DataCollectionByEntity[]>()
+
+	for (const dataCollectionByEnt of dataCollectionByEntities) {
+		if (!userInfoRequiresDisclosure(dataCollectionByEnt.dataCollection)) {
+			for (const purpose of dataCollectionByEnt.purposes) {
+				if (dataCollectionPurposeRequiresDisclosure(purpose)) {
+					throw new Error(
+						`Wallet sends data to ${dataCollectionByEnt.byEntity.name} for the purpose of ${dataCollectionPurposeToText(purpose)}, which inherently requires disclosing transaction intent and/or transaction data. Please adjust the entry.`,
+					)
+				}
+			}
+			continue
+		}
+
+		if (!endpointRequiresDisclosure(dataCollectionByEnt.dataCollection.endpoint)) {
+			continue
+		}
+
+		if (!entityInfo.has(dataCollectionByEnt.byEntity.id)) {
+			throw new Error(
+				`Wallet's dataCollection lists entity ${dataCollectionByEnt.byEntity.name} which can learn of user's transaction data or intent, so it should be listed in orderflowDisclosures as well.`,
+			)
+		}
+
+		let byEntRequiringDisclosure: DataCollectionByEntity[] | undefined =
+			entitiesNeedingDisclosure.get(dataCollectionByEnt.byEntity.id)
+
+		if (byEntRequiringDisclosure === undefined) {
+			byEntRequiringDisclosure = []
+			entitiesNeedingDisclosure.set(dataCollectionByEnt.byEntity.id, byEntRequiringDisclosure)
+		}
+
+		byEntRequiringDisclosure.push(dataCollectionByEnt)
+	}
+
+	if (entitiesNeedingDisclosure.size === 0) {
+		if (orderflowDisclosures.localOnly) {
+			return {
+				value: {
+					id: 'local_only',
+					displayName: 'Local-only wallet',
+					entityInfo,
+					rating: Rating.PASS,
+					shortExplanation: sentence(`
+						{{WALLET_NAME}} does not send your transaction data to any external provider.
+					`),
+					__brand: brand,
+				},
+				details: markdown(`
+					{{WALLET_NAME}} does not send transaction data to any external provider.
+					Therefore, there are no disclosures it could make about how your
+					transaction data is handled.
+				`),
+				references,
+			}
+		}
+
+		if (dataCollection[UserFlow.NATIVE_SWAP] !== 'FLOW_NOT_SUPPORTED') {
+			throw new Error(
+				'Wallet has a built-in swap feature (`UserFlow.NATIVE_SWAP`), which inherently requires getting swap quote data from somewhere (`WalletInfo.TRANSACTION_INTENT`). Please ensure this is reflected in the data collected by entities.',
+			)
+		}
+
+		if (dataCollection[UserFlow.TRANSACTION] !== 'FLOW_NOT_SUPPORTED') {
+			throw new Error(
+				'Wallet has a transaction flow (`UserFlow.TRANSACTION`) and is not local-only (`orderflowDisclosures.localOnly: false`), which inherently means that at least some external RPC provider must be relied upon to broadcast transaction data to the mempool (`WalletInfo.TRANSACTION_DATA`). Please ensure this is reflected in the data collected by entities.',
+			)
+		}
+
+		throw new Error('Unimplemented case') // Wallet doesn't support swaps or even transactions?
+	}
+
+	let leastProminentRequiredDisclosure: OrderflowDisclosureType | null = null
+
+	for (const [entityId, entityDisclosureInfo] of entityInfo.entries()) {
+		const entityDataCollection = entitiesNeedingDisclosure.get(entityId)
+
+		if (entityDataCollection === undefined) {
+			throw new Error(
+				`Wallet has entity ${entityDisclosureInfo.entity.name} listed in orderflowDisclosures but no corresponding data for this entity in dataCollection (or the data for this entity is missing some of the information it collects, such as WalletInfo.TRANSACTION_DATA).`,
+			)
+		}
+
+		if (
+			setContains<OrderflowDisclosureType>(
+				entityDisclosureInfo.disclosures,
+				OrderflowDisclosureType.NOT_DISCLOSED,
+			) &&
+			setSize(entityDisclosureInfo.disclosures) > 1
+		) {
+			throw new Error(
+				`Entity ${entityDisclosureInfo.entity.name} is declared as being both undisclosed and disclosed.`,
+			)
+		}
+
+		if (leastProminentRequiredDisclosure === null) {
+			leastProminentRequiredDisclosure = mostProminentDisclosure(entityDisclosureInfo)
+		} else {
+			leastProminentRequiredDisclosure = nonEmptyFirst(
+				[leastProminentRequiredDisclosure, mostProminentDisclosure(entityDisclosureInfo)],
+				compareProminentDisclosureTypes,
+			)
+		}
+	}
+
+	if (leastProminentRequiredDisclosure === null) {
+		throw new Error('Unreachable')
+	}
+
+	switch (leastProminentRequiredDisclosure) {
+		case OrderflowDisclosureType.NOT_DISCLOSED:
+			return {
+				value: {
+					id: 'lacking_disclosures',
+					displayName: 'Non-transparent orderflow practices',
+					entityInfo,
+					rating: Rating.FAIL,
+					shortExplanation: sentence(`
+						{{WALLET_NAME}} does not fully disclose who gets to see your
+						transactions before they land onchain.
+					`),
+					__brand: brand,
+				},
+				details: markdown(`
+					{{WALLET_NAME}} send transaction data to one or more external
+					providers before your transaction is included onchain, putting
+					them in a position to be able to extract MEV from this data.
+					However, {{WALLET_NAME}} does not disclose this transparently.
+				`),
+				howToImprove: markdown(`
+					Because MEV is a fee being taken from the user, disclosures should
+					be at least as prominent as transaction fees during the transaction
+					flow.
+				`),
+				references,
+			}
+		case OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING:
+			if (orderflowDisclosures.singleTransactionTypeUseCase) {
+				return {
+					value: {
+						id: 'single_transaction_type_disclosed_during_onboarding',
+						displayName: 'Onboarding-time orderflow disclosures',
+						entityInfo,
+						rating: Rating.PASS,
+						shortExplanation: sentence(`
+							{{WALLET_NAME}} discloses who gets to see your transactions
+							before they land onchain as part of user onboarding.
+						`),
+						__brand: brand,
+					},
+					details: markdown(`
+						{{WALLET_NAME}} send transaction data to one or more external
+						providers before your transaction is included onchain, putting
+						them in a position to be able to extract MEV from this data.
+						{{WALLET_NAME}} discloses this information transparently during
+						onboarding. As all transactions' orderflow goes through the same
+						entities, disclosing this at transaction time would be overly
+						repetitive to the user.
+					`),
+					references,
+				}
+			}
+
+			return {
+				value: {
+					id: 'onboarding_only_disclosures',
+					displayName: 'Semi-transparent orderflow disclosures',
+					entityInfo,
+					rating: Rating.PARTIAL,
+					shortExplanation: sentence(`
+						{{WALLET_NAME}} discloses who gets to see your transactions
+						before they land onchain as part of user onboarding only.
+					`),
+					__brand: brand,
+				},
+				details: markdown(`
+					{{WALLET_NAME}} send transaction data to one or more external
+					providers before your transaction is included onchain, putting
+					them in a position to be able to extract MEV from this data.
+					{{WALLET_NAME}} makes this information available as part of the
+					user onboarding flow, but not the transaction flow.
+				`),
+				howToImprove: markdown(`
+					Because MEV is a fee being taken from the user, disclosures should
+					be at least as prominent as transaction fees during the transaction
+					flow.
+				`),
+				references,
+			}
+		case OrderflowDisclosureType.DISCLOSED_DURING_TRANSACTION_FLOW:
+			return {
+				value: {
+					id: 'proper_disclosures',
+					displayName: 'Transparent orderflow disclosures',
+					entityInfo,
+					rating: Rating.PASS,
+					shortExplanation: sentence(`
+						{{WALLET_NAME}} fully discloses who gets to see your transactions
+						before they land onchain.
+					`),
+					__brand: brand,
+				},
+				details: markdown(`
+					{{WALLET_NAME}} send transaction data to one or more external
+					providers before your transaction is included onchain, putting
+					them in a position to be able to extract MEV from this data.
+					{{WALLET_NAME}} makes this information transparent as part of
+					the transaction flow.
+				`),
+				references,
+			}
+	}
+}
+
+export const orderflowTransparency: Attribute<OrderflowTransparencyValue> = {
+	id: 'orderflowTransparency',
+	icon: '\u{1f500}', // Shuffle Tracks, symbolizing frontrunning. Other ideas: ⚗️ (extract), 🗜️ (squeeze), ✂️ (take a cut), 💳 (skim fees)
+	displayName: 'Orderflow transparency',
+	wording: {
+		midSentenceName: 'orderflow transparency',
+	},
+	question: sentence(`
+		Does the wallet clearly disclose which entities may monetize your orderflow?
+	`),
+	why: markdown(`
+		[Payment for order flow (PFOF)](https://en.wikipedia.org/wiki/Payment_for_order_flow)
+		is the practice of stockbroker selling customer trade information to a market maker
+		who can extract profit from it. In the Ethereum world,
+		[Maximal Extractable Value (MEV)](https://ethereum.org/developers/docs/mev/) refers
+		to a similar revenue stream for entities that are part of the block-building supply
+		chain. These actors can profit from knowledge about upcoming transactions prior to
+		their inclusion onchain. For this reason, wallet developers have an incentive to
+		have their users' transactions go through these actors from who they can get a
+		kickback, some of which may be shared with the user in the form of MEV rebates.
+
+		Orderflow transparency helps wallet users understand who they are selling or
+		giving away their valuable transaction orderflow data to, and what compensation
+		they are getting from it.
+	`),
+	methodology: markdown(`
+		Wallets are evaluated based on how transparently they disclose the set of
+		entities that they transmit MEV-susceptible transaction data to, and the
+		share of the kickbacks that the user will receive as a result of sending
+		this information.
+
+		To be recognized as transparently disclosing orderflow practices,
+		wallets must disclose which entities may obtain information about user
+		transaction intent as part of the transaction flow, prior to onchain
+		transaction inclusion. A link to these entities' privacy policy or
+		similar public document describing their transaction data handling
+		practices must be included.
+
+		Note that this disclosure must recursively include all entities which
+		*may* profit from orderflow, not just those who are *known to*.
+		This includes services for swap quotes, cross-chain bridge quotes,
+		transaction simulation services, transaction scam detection services, etc.
+
+		Since MEV extraction is often a form of fee-taking from the user,
+		such disclosures must be at least as visually prominent and accessible
+		as the way the wallet displays transaction fees.
+
+		**Exemptions**:
+
+		- Transactions that have no MEV value do not need disclosures.
+			This includes simple token transfers, SIWE signature requests,
+			ERC-20 token approvals, as well as non-financial transactions
+			such as ENS record updates or multisig key rotation transactions.
+		- Wallets which _only_ ever deal with one transaction type (e.g.
+			trading-focused wallets that only support swaps) may provide a single
+			disclosure upfront as part of user onboarding, rather than on each
+			transaction.
+		- Disclosures are not required if a wallet locally verifies that an
+			entity **cannot** use transaction data for profit or user data mining.
+			For example, a wallet may locally verify that the scam transaction
+			detection service it is connecting to is running in a secure enclave,
+			and is running code which has been audited to ensure that transaction
+			data never leaks out of the enclave. If such verification is successful,
+			then no disclosure is needed.
+		- If a wallet only works purely locally (e.g. using a user's own node),
+			then no disclosure is needed.
+	`),
+	ratingScale: {
+		display: 'fail-pass',
+		exhaustive: true,
+		fail: [
+			exampleRating(
+				paragraph(`
+					The wallet sends transactions to an RPC service provider for transaction inclusion
+					and does not disclose the ability for that provider to frontrun the transaction.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.GENERIC,
+					completeDataCollection({
+						[UserFlow.NATIVE_SWAP]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: RegularEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.NOT_DISCLOSED]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: false,
+						localOnly: false,
+					},
+				).value,
+			),
+		],
+		partial: [
+			exampleRating(
+				paragraph(`
+					During the user onboarding flow, the wallet discloses all entities
+					to which user transaction data is sent, along with links to their
+					respective privacy policies or data handling practices. However,
+					this information is not shown during the transaction flow.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.GENERIC,
+					completeDataCollection({
+						[UserFlow.NATIVE_SWAP]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: RegularEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: false,
+						localOnly: false,
+					},
+				).value,
+			),
+		],
+		pass: [
+			exampleRating(
+				paragraph(`
+					The wallet discloses all entities to which user transaction data is
+					sent, along with links to their respective privacy policies or data
+					handling practices. This disclosure is visible on the transaction
+					approval screen with the same level of visual prominence as the
+					transaction fee.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.GENERIC,
+					completeDataCollection({
+						[UserFlow.NATIVE_SWAP]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: RegularEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.DISCLOSED_DURING_TRANSACTION_FLOW]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: false,
+						localOnly: false,
+					},
+				).value,
+			),
+			exampleRating(
+				paragraph(`
+					The wallet only supports one transaction type (e.g. token swaps),
+					and the set of entities to which transaction data is sent never
+					changes. The wallet provides a disclosure of these entities and
+					links to their privacy policies as a dedicated step of the user
+					onboarding flow.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.GENERIC,
+					completeDataCollection({
+						[UserFlow.NATIVE_SWAP]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: RegularEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: true,
+						localOnly: false,
+					},
+				).value,
+			),
+			exampleRating(
+				paragraph(`
+					The wallet only supports transaction types which are not susceptible
+					to MEV, such as peer-to-peer payments or non-financial transactions.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.PAYMENTS,
+					completeDataCollection({
+						[UserFlow.TRANSACTION]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: RegularEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: false,
+						localOnly: false,
+					},
+				).value,
+			),
+			exampleRating(
+				paragraph(`
+					The wallet sends transaction intent and transaction data exclusively
+					to services which run in verifiable secure environments, which the
+					wallet verifies. These services are verified to act in a provably
+					fair manner, cannot generate transactions on their own, and do not
+					export transaction data prior to onchain inclusion.
+				`),
+				evaluateOrderflowTransparency(
+					WalletProfile.PAYMENTS,
+					completeDataCollection({
+						[UserFlow.TRANSACTION]: {
+							collected: [
+								{
+									byEntity: exampleNodeCompany,
+									dataCollection: {
+										[WalletInfo.TRANSACTION_DATA]: CollectionPolicy.BY_DEFAULT,
+										endpoint: {
+											type: 'SECURE_ENCLAVE',
+											endToEndEncryption: { type: 'TERMINATED_INSIDE_ENCLAVE' },
+											externalLogging: { type: 'NO' },
+											verifiability: {
+												clientVerification: {
+													type: 'VERIFIED',
+													ref: 'https://some-repository.devnull',
+												},
+												reproducibleBuilds: true,
+												sourceAvailable: true,
+											},
+											canGenerateOwnTransactions: false,
+											exportsNonIncludedTransactionData: false,
+											provablyFairOrdering: true,
+										} as TransactionHandlingSecureEndpoint,
+									},
+									purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
+								},
+							],
+						},
+					}),
+					{
+						[OrderflowDisclosureType.NOT_DISCLOSED]: [exampleNodeCompany],
+						singleTransactionTypeUseCase: false,
+						localOnly: false,
+					},
+				).value,
+			),
+		],
+	},
+	evaluate: (features: ResolvedFeatures): Evaluation<OrderflowTransparencyValue> => {
+		if (features.transparency.orderflow === null || features.privacy.dataCollection === null) {
+			return unrated(orderflowTransparency, brand, { entityInfo: new Map() })
+		}
+
+		return evaluateOrderflowTransparency(
+			features.profile,
+			features.privacy.dataCollection,
+			features.transparency.orderflow,
+		)
+	},
+	aggregate: (perVariant: AtLeastOneVariant<Evaluation<OrderflowTransparencyValue>>) =>
+		pickWorstRating<OrderflowTransparencyValue>(perVariant),
+}

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -34,6 +34,7 @@ import type { BasicOperationFees } from './features/transparency/fee-display'
 import type { LicenseWithRef } from './features/transparency/license'
 import type { MaintenanceSupport } from './features/transparency/maintenance'
 import type { Monetization } from './features/transparency/monetization'
+import type { OrderflowDisclosures } from './features/transparency/orderflow'
 import type { ReputationSupport } from './features/transparency/reputation'
 import type { WithRef } from './reference'
 import {
@@ -142,6 +143,12 @@ export type WalletSoftwareFeatures = WalletBaseFeatures & {
 	selfSovereignty: WalletBaseFeatures['selfSovereignty'] & {
 		/** Describes the set of options for submitting transactions. */
 		transactionSubmission: VariantFeature<TransactionSubmission>
+	}
+
+	/** Transparency features. */
+	transparency: {
+		/** How well the wallet discloses who gets access to user orderflow data. */
+		orderflow: VariantFeature<OrderflowDisclosures>
 	}
 
 	/** Ecosystem features. */
@@ -270,6 +277,7 @@ export interface ResolvedFeatures {
 		operationFees: ResolvedFeature<BasicOperationFees>
 		reputation: ResolvedFeature<ReputationSupport>
 		maintenance: ResolvedFeature<MaintenanceSupport>
+		orderflow: ResolvedFeature<OrderflowDisclosures>
 	}
 	chainAbstraction: ResolvedFeature<ChainAbstraction>
 	chainConfigurability: ResolvedFeature<ChainConfigurability>
@@ -413,6 +421,10 @@ export function resolveFeatures(
 			maintenance: hardwareFeat(
 				'transparency.maintenance',
 				features => features.transparency.maintenance,
+			),
+			orderflow: softwareFeat(
+				'transparency.orderflow',
+				features => features.transparency.orderflow,
 			),
 		},
 		chainAbstraction: softwareFeat('chainAbstraction', features => features.chainAbstraction),

--- a/src/schema/features/privacy/data-collection.ts
+++ b/src/schema/features/privacy/data-collection.ts
@@ -157,109 +157,178 @@ export const RegularEndpoint = {
 } as const
 
 /**
+ * Represents a server endpoint running in a secure enclave (TEE).
+ */
+export interface SecureEnclaveEndpoint {
+	/**
+	 * The server is running in a secure enclave.
+	 */
+	type: 'SECURE_ENCLAVE'
+
+	/**
+	 * Whether the software running within the enclave is verifiable
+	 * by the client.
+	 */
+	verifiability: WithRef<{
+		/**
+		 * Whether the source code of the server software is available.
+		 */
+		sourceAvailable: boolean
+
+		/**
+		 * Whether the source code of the server software can be reproducibly
+		 * built.
+		 */
+		reproducibleBuilds: boolean
+
+		/**
+		 * How the client verifies that the endpoint is running in a secure enclave.
+		 */
+		clientVerification:
+			| {
+					/** The client does not do any verification. */
+					type: 'NOT_VERIFIED'
+			  }
+			| {
+					/**
+					 * The client claims to verify but has not made the source code that
+					 * does this available.
+					 */
+					type: 'VERIFIED_BUT_NO_SOURCE_AVAILABLE'
+			  }
+			| MustRef<{
+					/**
+					 * The client verifies this. Must also come with a code reference.
+					 */
+					type: 'VERIFIED'
+			  }>
+	}>
+
+	/**
+	 * Whether the endpoint running in a secure enclave logs anything
+	 * outside of the enclave, thereby removing the privacy advantage
+	 * of enclaves.
+	 */
+	externalLogging:
+		| {
+				/**
+				 * It is not known whether the software running within the enclave
+				 * logs any data externally.
+				 */
+				type: 'UNKNOWN'
+		  }
+		| {
+				/**
+				 * This server software is known to log data externally to the
+				 * enclave.
+				 */
+				type: 'YES'
+		  }
+		| {
+				/**
+				 * This server software does not log data externally to the
+				 * enclave.
+				 */
+				type: 'NO'
+		  }
+
+	/**
+	 * Info about the use of end-to-end encryption to the endpoint.
+	 * In most cases, this means where does the TLS handshake happens?
+	 * If this does not happen within the enclave (such as if terminated
+	 * at the load balancer level), then the connection is susceptible to
+	 * be man-in-the-middle'd.
+	 */
+	endToEndEncryption:
+		| {
+				/** No end-to-end encryption (really? in this day and age?) */
+				type: 'NONE'
+		  }
+		| {
+				/**
+				 * End-to-end encryption terminated outside of the enclave,
+				 * for example at the load balancer level.
+				 */
+				type: 'TERMINATED_OUT_OF_ENCLAVE'
+		  }
+		| {
+				/** End-to-end encryption terminated inside the enclave. */
+				type: 'TERMINATED_INSIDE_ENCLAVE'
+		  }
+}
+
+/**
  * The environment in which the server endpoint is running.
  * A server can either be running as a regular server (`RegularEndpoint`),
  * or in a secure enclave which potentially gives it more privacy properties.
  */
-export type Endpoint =
-	| typeof RegularEndpoint
-	| {
-			/**
-			 * The server is running in a secure enclave.
-			 */
-			type: 'SECURE_ENCLAVE'
+export type Endpoint = typeof RegularEndpoint | SecureEnclaveEndpoint
 
-			/**
-			 * Whether the software running within the enclave is verifiable
-			 * by the client.
-			 */
-			verifiability: WithRef<{
-				/**
-				 * Whether the source code of the server software is available.
-				 */
-				sourceAvailable: boolean
+/** Type predicate for SecureEnclaveEndpoint. */
+export function isSecureEnclaveEndpoint(endpoint: Endpoint): endpoint is SecureEnclaveEndpoint {
+	return endpoint.type === 'SECURE_ENCLAVE'
+}
 
-				/**
-				 * Whether the source code of the server software can be reproducibly
-				 * built.
-				 */
-				reproducibleBuilds: boolean
+/**
+ * Does the given endpoint run verifiable code?
+ */
+export function endpointRunsVerifiableCode(endpoint: Endpoint): boolean {
+	if (!isSecureEnclaveEndpoint(endpoint)) {
+		return false
+	}
 
-				/**
-				 * How the client verifies that the endpoint is running in a secure enclave.
-				 */
-				clientVerification:
-					| {
-							/** The client does not do any verification. */
-							type: 'NOT_VERIFIED'
-					  }
-					| {
-							/**
-							 * The client claims to verify but has not made the source code that
-							 * does this available.
-							 */
-							type: 'VERIFIED_BUT_NO_SOURCE_AVAILABLE'
-					  }
-					| MustRef<{
-							/**
-							 * The client verifies this. Must also come with a code reference.
-							 */
-							type: 'VERIFIED'
-					  }>
-			}>
+	if (!endpoint.verifiability.sourceAvailable) {
+		return false // No source, obviously not verifiable.
+	}
 
-			/**
-			 * Whether the endpoint running in a secure enclave logs anything
-			 * outside of the enclave, thereby removing the privacy advantage
-			 * of enclaves.
-			 */
-			externalLogging:
-				| {
-						/**
-						 * It is not known whether the software running within the enclave
-						 * logs any data externally.
-						 */
-						type: 'UNKNOWN'
-				  }
-				| {
-						/**
-						 * This server software is known to log data externally to the
-						 * enclave.
-						 */
-						type: 'YES'
-				  }
-				| {
-						/**
-						 * This server software does not log data externally to the
-						 * enclave.
-						 */
-						type: 'NO'
-				  }
+	if (!endpoint.verifiability.reproducibleBuilds) {
+		return false // No reproducible builds means any attestation data is not meaningful.
+	}
 
-			/**
-			 * Info about the use of end-to-end encryption to the endpoint.
-			 * In most cases, this means where does the TLS handshake happens?
-			 * If this does not happen within the enclave (such as if terminated
-			 * at the load balancer level), then the connection is susceptible to
-			 * be man-in-the-middle'd.
-			 */
-			endToEndEncryption:
-				| {
-						/** No end-to-end encryption (really? in this day and age?) */
-						type: 'NONE'
-				  }
-				| {
-						/**
-						 * End-to-end encryption terminated outside of the enclave,
-						 * for example at the load balancer level.
-						 */
-						type: 'TERMINATED_OUT_OF_ENCLAVE'
-				  }
-				| {
-						/** End-to-end encryption terminated inside the enclave. */
-						type: 'TERMINATED_INSIDE_ENCLAVE'
-				  }
-	  }
+	switch (endpoint.endToEndEncryption.type) {
+		case 'NONE':
+			// No e2e encryption means a non-enclave middleman can act on the data
+			// going into the enclave, i.e. the enclave is not the only thing privy
+			// to the communication.
+			return false
+		case 'TERMINATED_OUT_OF_ENCLAVE':
+			// If e2e encryption is terminated outside the enclave, then a
+			// non-enclave middleman can act on the data going into the enclave,
+			// i.e. the enclave is not the only thing privy to the communication.
+			return false
+		case 'TERMINATED_INSIDE_ENCLAVE':
+			break // Continue
+	}
+
+	return true
+}
+
+/**
+ * Does the given endpoint run verifiable code,
+ * and does the client verify that?
+ */
+export function endpointRunsVerifiedCode(endpoint: Endpoint): boolean {
+	if (!isSecureEnclaveEndpoint(endpoint)) {
+		return false
+	}
+
+	if (!endpointRunsVerifiableCode(endpoint)) {
+		return false
+	}
+
+	switch (endpoint.verifiability.clientVerification.type) {
+		case 'NOT_VERIFIED':
+			// Client doesn't verify the server attestation.
+			return false
+		case 'VERIFIED_BUT_NO_SOURCE_AVAILABLE':
+			// Client may verify the server attestation, but we can't see the source
+			// code of that client verifying this, so cannot verify.
+			return false
+		case 'VERIFIED':
+			// Client verifies.
+			return true
+	}
+}
 
 /** Returns whether an endpoint gets to learn the user's IP address */
 export function endpointLearnsUserIpAddress(endpoint: Endpoint): 'YES' | 'NO' | 'UNVERIFIABLE' {
@@ -390,10 +459,20 @@ export enum WalletInfo {
 	ASSETS = 'assets',
 
 	/**
+	 * Non-transaction data which expresses an intent of the user to
+	 * perform a transaction in the near future.
+	 * For example, a swap quote with specific pricing/routing for a
+	 * given chain and wallet address may not be a well-formed Ethereum
+	 * transaction object, but nonetheless carries similar level of information
+	 * about the user's upcoming transaction.
+	 */
+	TRANSACTION_INTENT = 'transactionIntent',
+
+	/**
 	 * The user's wallet transactions before they are included onchain.
 	 * For example, MEV protection services usually fall under this category.
 	 */
-	MEMPOOL_TRANSACTIONS = 'mempoolTransactions',
+	TRANSACTION_DATA = 'transactionData',
 
 	/** Domain names the wallet is connected to. */
 	WALLET_CONNECTED_DOMAINS = 'walletConnectedDomains',
@@ -404,7 +483,8 @@ export const walletInfo = new Enum<WalletInfo>({
 	[WalletInfo.ACCOUNT_ADDRESS]: true,
 	[WalletInfo.BALANCE]: true,
 	[WalletInfo.ASSETS]: true,
-	[WalletInfo.MEMPOOL_TRANSACTIONS]: true,
+	[WalletInfo.TRANSACTION_INTENT]: true,
+	[WalletInfo.TRANSACTION_DATA]: true,
 	[WalletInfo.WALLET_CONNECTED_DOMAINS]: true,
 })
 
@@ -431,37 +511,39 @@ function userInfoScore(userInfo: UserInfo): number {
 			return 3
 		case WalletInfo.ACCOUNT_ADDRESS:
 			return 4
-		case WalletInfo.MEMPOOL_TRANSACTIONS:
+		case WalletInfo.TRANSACTION_INTENT:
 			return 5
-		case WalletInfo.WALLET_CONNECTED_DOMAINS:
-			return 5
-		case PersonalInfo.PSEUDONYM:
+		case WalletInfo.TRANSACTION_DATA:
 			return 6
+		case WalletInfo.WALLET_CONNECTED_DOMAINS:
+			return 7
+		case PersonalInfo.PSEUDONYM:
+			return 8
 
 		// All the social-media-y entries are roughly the same as email.
 		case PersonalInfo.FARCASTER_ACCOUNT:
-			return 7
+			return 9
 		case PersonalInfo.X_DOT_COM_ACCOUNT:
-			return 7
+			return 9
 		case PersonalInfo.EMAIL:
-			return 7
+			return 9
 
 		case PersonalInfo.BROWSING_HISTORY_URLS:
-			return 8
-		case PersonalInfo.LEGAL_NAME:
-			return 9
-		case PersonalInfo.PHONE:
 			return 10
-		case PersonalInfo.CONTACTS:
+		case PersonalInfo.LEGAL_NAME:
 			return 11
-		case PersonalInfo.PHYSICAL_ADDRESS:
+		case PersonalInfo.PHONE:
 			return 12
-		case PersonalInfo.CEX_ACCOUNT:
+		case PersonalInfo.CONTACTS:
 			return 13
-		case PersonalInfo.FACE:
+		case PersonalInfo.PHYSICAL_ADDRESS:
 			return 14
-		case PersonalInfo.GOVERNMENT_ID:
+		case PersonalInfo.CEX_ACCOUNT:
 			return 15
+		case PersonalInfo.FACE:
+			return 16
+		case PersonalInfo.GOVERNMENT_ID:
+			return 17
 	}
 }
 
@@ -487,7 +569,9 @@ export function userInfoType(userInfo: UserInfo): UserInfoType {
 			return UserInfoType.WALLET_RELATED
 		case WalletInfo.ACCOUNT_ADDRESS:
 			return UserInfoType.WALLET_RELATED
-		case WalletInfo.MEMPOOL_TRANSACTIONS:
+		case WalletInfo.TRANSACTION_INTENT:
+			return UserInfoType.WALLET_RELATED
+		case WalletInfo.TRANSACTION_DATA:
 			return UserInfoType.WALLET_RELATED
 		case WalletInfo.WALLET_CONNECTED_DOMAINS:
 			return UserInfoType.WALLET_RELATED
@@ -536,7 +620,7 @@ export function userInfoName(userInfo: UserInfo) {
 			return { short: 'wallet balance', long: 'wallet assets and balances' } as const
 		case WalletInfo.ACCOUNT_ADDRESS:
 			return { short: 'wallet address', long: 'wallet address' } as const
-		case WalletInfo.MEMPOOL_TRANSACTIONS:
+		case WalletInfo.TRANSACTION_DATA:
 			return { short: 'outgoing transactions', long: 'outgoing wallet transactions' } as const
 		case WalletInfo.WALLET_CONNECTED_DOMAINS:
 			return { short: 'connected sites', long: 'wallet-connected domains' } as const
@@ -760,24 +844,26 @@ export function qualifiedDataCollection<T extends UserInfo>(
 		[WalletInfo.ACCOUNT_ADDRESS]:
 			first(
 				get(WalletInfo.ACCOUNT_ADDRESS),
-				get(WalletInfo.MEMPOOL_TRANSACTIONS),
+				get(WalletInfo.TRANSACTION_DATA),
 				get(WalletInfo.BALANCE),
 			) ?? CollectionPolicy.NEVER,
 		[WalletInfo.BALANCE]:
 			first(
 				get(WalletInfo.BALANCE),
 				get(WalletInfo.ACCOUNT_ADDRESS),
-				get(WalletInfo.MEMPOOL_TRANSACTIONS),
+				get(WalletInfo.TRANSACTION_DATA),
 			) ?? CollectionPolicy.NEVER,
 		[WalletInfo.ASSETS]:
 			first(
 				get(WalletInfo.ASSETS),
 				get(WalletInfo.ACCOUNT_ADDRESS),
 				get(WalletInfo.BALANCE),
-				get(WalletInfo.MEMPOOL_TRANSACTIONS),
+				get(WalletInfo.TRANSACTION_DATA),
 			) ?? CollectionPolicy.NEVER,
-		[WalletInfo.MEMPOOL_TRANSACTIONS]:
-			get(WalletInfo.MEMPOOL_TRANSACTIONS) ?? CollectionPolicy.NEVER,
+		[WalletInfo.TRANSACTION_INTENT]:
+			first(get(WalletInfo.TRANSACTION_INTENT), get(WalletInfo.TRANSACTION_DATA)) ??
+			CollectionPolicy.NEVER,
+		[WalletInfo.TRANSACTION_DATA]: get(WalletInfo.TRANSACTION_DATA) ?? CollectionPolicy.NEVER,
 		[WalletInfo.WALLET_CONNECTED_DOMAINS]:
 			first(get(WalletInfo.WALLET_CONNECTED_DOMAINS), get(PersonalInfo.BROWSING_HISTORY_URLS)) ??
 			CollectionPolicy.NEVER,

--- a/src/schema/features/transparency/orderflow.ts
+++ b/src/schema/features/transparency/orderflow.ts
@@ -1,0 +1,100 @@
+import type { Entity } from '@/schema/entity'
+import type { WithRef } from '@/schema/reference'
+import { Enum } from '@/utils/enum'
+
+import {
+	type Endpoint,
+	isSecureEnclaveEndpoint,
+	type SecureEnclaveEndpoint,
+} from '../privacy/data-collection'
+
+export enum OrderflowDisclosureType {
+	NOT_DISCLOSED = 'NOT_DISCLOSED',
+	DISCLOSED_DURING_TRANSACTION_FLOW = 'DISCLOSED_DURING_TRANSACTION_FLOW',
+	DISCLOSED_DURING_USER_ONBOARDING = 'DISCLOSED_DURING_USER_ONBOARDING',
+}
+
+export const orderflowDisclosureType = new Enum<OrderflowDisclosureType>({
+	[OrderflowDisclosureType.DISCLOSED_DURING_TRANSACTION_FLOW]: true,
+	[OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING]: true,
+	[OrderflowDisclosureType.NOT_DISCLOSED]: true,
+})
+
+/**
+ * Set of entities which learn the user's transaction intent and orderflow.
+ */
+export type OrderflowDisclosures = WithRef<{
+	/**
+	 * List of entities which learn the user's transaction data or intent
+	 * and which have an adequate disclosure in the transaction flow.
+	 */
+	[OrderflowDisclosureType.DISCLOSED_DURING_TRANSACTION_FLOW]?: Entity[]
+
+	/**
+	 * List of entities which learn the user's transaction data or intent
+	 * and which have an adequate disclosure in the user onboarding flow.
+	 */
+	[OrderflowDisclosureType.DISCLOSED_DURING_USER_ONBOARDING]?: Entity[]
+
+	/**
+	 * List of entities which learn the user's transaction data or intent
+	 * and which do not have any disclosure.
+	 */
+	[OrderflowDisclosureType.NOT_DISCLOSED]?: Entity[]
+
+	/**
+	 * Whether the wallet only supports one type of transaction, such that
+	 * the way orders are handled and the MEV risks of all transactions are
+	 * exactly the same across the entire user experience.
+	 * Example: A trading-focused wallet that only supports swaps and no
+	 * other transaction types.
+	 */
+	singleTransactionTypeUseCase: boolean
+
+	/**
+	 * Whether the wallet works only locally and never contacts other services,
+	 * even for transaction submission.
+	 */
+	localOnly: boolean
+}>
+
+/**
+ * A server endpoint running in a secure enclave (TEE) and that handles
+ * transaction data.
+ */
+export interface TransactionHandlingSecureEndpoint extends SecureEnclaveEndpoint {
+	/**
+	 * Does the endpoint ever export transaction data for transactions that have
+	 * yet to be included onchain?
+	 * Valid block proposals do not count, as they represent the act of
+	 * transaction inclusion itself.
+	 */
+	exportsNonIncludedTransactionData: boolean
+
+	/**
+	 * Can the endpoint generate its own transactions (true),
+	 * or are all transactions sourced from external clients?
+	 */
+	canGenerateOwnTransactions: boolean
+
+	/**
+	 * When ordering transactions in a block, is the ordering of transactions
+	 * provably fair across all transactions known to the endpoint?
+	 */
+	provablyFairOrdering: boolean
+}
+
+/** Type predicate for TransactionHandlingSecureEndpoint. */
+export function isTransactionHandlingSecureEndpoint(
+	endpoint: Endpoint,
+): endpoint is TransactionHandlingSecureEndpoint {
+	if (!isSecureEnclaveEndpoint(endpoint)) {
+		return false
+	}
+
+	return (
+		Object.hasOwn(endpoint, 'exportsNonIncludedTransactionData') &&
+		Object.hasOwn(endpoint, 'canGenerateOwnTransactions') &&
+		Object.hasOwn(endpoint, 'provablyFairOrdering')
+	)
+}

--- a/src/types/utils/non-empty.ts
+++ b/src/types/utils/non-empty.ts
@@ -243,6 +243,13 @@ export function setItems<K extends string | number | symbol>(
 }
 
 /**
+ * Number of items in the set. Guaranteed to not be zero.
+ */
+export function setSize(set: NonEmptySet<string | number | symbol>): Exclude<number, 0> {
+	return Object.entries(set).length
+}
+
+/**
  * Returns the union of one or more non-empty sets.
  */
 export function setUnion<K extends string | number | symbol>(


### PR DESCRIPTION
Work in progress. Updates issue #194.

Current thinking: the way the data collection was augmented in #267 means that a lot of the data we need for orderflow transparency is already present. The only thing it doesn't have is whether or not the wallet UI displays the disclosure.

Current methodology:

> Wallets are evaluated based on how transparently they disclose the set of
entities that they transmit MEV-susceptible transaction data to, and the
share of the kickbacks that the user will receive as a result of sending
this information.
>
> To be recognized as transparently disclosing orderflow practices,
wallets must disclose which entities may obtain information about user
transaction intent as part of the transaction flow, prior to onchain
transaction inclusion. A link to these entities' privacy policy or
similar public document describing their transaction data handling
practices must be included.
>
> Note that this disclosure must recursively include all entities which
*may* profit from orderflow, not just those who are *known to*.
This includes services for swap quotes, cross-chain bridge quotes,
transaction simulation services, transaction scam detection services, etc.
>
> Since MEV extraction is often a form of fee-taking from the user,
such disclosures must be at least as visually prominent and accessible
as the way the wallet displays transaction fees.
>
> **Exemptions**:
>
> - Transactions that have no MEV value do not need disclosures.
	  This includes simple token transfers, SIWE signature requests,
	  ERC-20 token approvals, as well as non-financial transactions
	  such as ENS record updates or multisig key rotation transactions.
> - Wallets which _only_ ever deal with one transaction type (e.g.
	  trading-focused wallets that only support swaps) may provide a single
	  disclosure upfront as part of user onboarding, rather than on each
	  transaction.
> - Disclosures are not required if a wallet locally verifies that an
	  entity **cannot** use transaction data for profit or user data mining.
	  For example, a wallet may locally verify that the scam transaction
	  detection service it is connecting to is running in a secure enclave,
	  and is running code which has been audited to ensure that transaction
	  data never leaks out of the enclave. If such verification is successful,
	  then no disclosure is needed.
> - If a wallet only works purely locally (e.g. using a user's own node),
	  then no disclosure is needed.

Still TBD: transparency around how the kickbacks from orderflow sales are distributed. Part of this is already covered under the existing wallet funding transparency attribute. More ideas welcome.