### PR TITLE
Remove the use of the expression "third party".

### DIFF
--- a/src/pages/faq/_FrequentlyAskedQuestionsPage.tsx
+++ b/src/pages/faq/_FrequentlyAskedQuestionsPage.tsx
@@ -120,7 +120,7 @@ const frequentlyAskedQuestions: NonEmptyArray<FAQEntry> = [
 			* **Objectively measurable**. It should be possible to determine
 				whether a rule is met or not without involving human judgement.
 				For example, a rule that looks at the user data exported to
-				third-party servers can be objectively measured by looking at the
+				external servers can be objectively measured by looking at the
 				wallet's source code or by analyzing the contents of wallet network
 				traffic.
 			* **Technology-neutral**. Rules should not prescribe the technology
@@ -180,11 +180,11 @@ const frequentlyAskedQuestions: NonEmptyArray<FAQEntry> = [
 				the wallet collects about you.
 			* \u{1f3f0} **Self-sovereignty** attributes determine the control and
 				ownership guarantees the wallet gives you over your account, as
-				opposed to being dependent on third-party providers to act in a
+				opposed to being dependent on external providers to act in a
 				trustworthy and reliable manner. This includes the potential for
-				your transactions being censored by third-parties, or your ability to
-				use DeFi protocols and to withdraw funds from Ethereum layer 2
-				solutions without relying on third-parties.
+				your transactions being censored by external providers, or your
+				ability to use DeFi protocols and to withdraw funds from Ethereum
+				layer 2 solutions without relying on external providers.
 			* \u{1f50d} **Transparency** attributes determine the degree of
 				public scrutiny and accountability that a wallet's software
 				development process is subject to, and whether that process is

--- a/src/schema/attributes/ecosystem/account-abstraction.ts
+++ b/src/schema/attributes/ecosystem/account-abstraction.ts
@@ -162,8 +162,8 @@ export const accountAbstraction: Attribute<AccountAbstractionValue> = {
 		User experience on Ethereum has historically suffered from the limitations of Externally-Owned Accounts (EOAs), which is the type of account most Ethereum users use today. By contrast, smart wallet accounts offer many UX and security improvements, such as the ability to:
 
 		* Batch multiple transactions, removing the need for separate "token approval" transactions before every other token operation.
-		* Pay gas fees in other tokens than Ether, or having third-parties sponsor transaction fees (with ${eipMarkdownLink(erc4337)})
-		* Delegate some operation to trusted third-parties, such as allowing onchain games to withdraw small amounts of tokens without signing pop-ups for each and every transaction.
+		* Pay gas fees in other tokens than Ether, or support sponsored transaction fees (with ${eipMarkdownLink(erc4337)})
+		* Delegate some operation to trusted provider, such as allowing onchain games to withdraw small amounts of tokens without signing pop-ups for each and every transaction.
 		* Change transaction authorization logic, enabling the use of Passkeys (and cellphone authentication methods) for signing transactions.
 		* Update the set of keys used to control the wallet, enabling the switch to quantum-resistant encryption algorithms in the future.
 		* Define account recovery rules, reducing the risk of losing access to your account when losing a private key or a device.

--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -46,9 +46,9 @@ function getOffchainProviderInfo(
 		return {
 			rating: Rating.PARTIAL,
 			offchainInfo:
-				'It relies on an offchain third-party provider to do so. The wallet verifies that the address is correct, but the offchain provider may learn your IP address.',
+				'It relies on an offchain external provider to do so. The wallet verifies that the address is correct, but the offchain provider may learn your IP address.',
 			walletShould:
-				'contact the third-party provider using traffic anonymizing techniques, such as Tor or Oblivious HTTP.',
+				'contact the external provider using traffic anonymizing techniques, such as Tor or Oblivious HTTP.',
 		}
 	}
 
@@ -56,18 +56,18 @@ function getOffchainProviderInfo(
 		return {
 			rating: Rating.PARTIAL,
 			offchainInfo:
-				'It relies on an offchain third-party provider to do so. This offchain provider trick the wallet into sending funds to a different address than intended.',
+				'It relies on an offchain external provider to do so. This offchain provider trick the wallet into sending funds to a different address than intended.',
 			walletShould:
-				'ensure the response from the third-party provider is correct using onchain data verified by a light client.',
+				'ensure the response from the external provider is correct using onchain data verified by a light client.',
 		}
 	}
 
 	return {
 		rating: Rating.PARTIAL,
 		offchainInfo:
-			'It relies on an offchain third-party provider to do so. This offchain provider may trick the wallet into sending funds to a different address than intended, and may learn your IP address.',
+			'It relies on an offchain external provider to do so. This offchain provider may trick the wallet into sending funds to a different address than intended, and may learn your IP address.',
 		walletShould:
-			'contact the third-party provider using traffic anonymizing techniques (such as Tor or Oblivious HTTP), and ensure the response from the third-party provider is correct using onchain data verified by a light client.',
+			'contact the external provider using traffic anonymizing techniques (such as Tor or Oblivious HTTP), and ensure the response from the external provider is correct using onchain data verified by a light client.',
 	}
 }
 
@@ -271,8 +271,8 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 		* Be done using onchain data and reusing the wallet's common chain
 		  interaction client, inheriting its verifiability (via light client)
 		  and privacy properties.
-		* **OR** be done using an offchain third-party provider in such a way that
-		  the address returned by the third-party provider is verifiable, and
+		* **OR** be done using an offchain external provider in such a way that
+		  the address returned by the external provider is verifiable, and
 		  without revealing the user's IP address to the provider.
 			This ensures that:
 			- The wallet cannot be tricked into sending funds to an attacker
@@ -357,7 +357,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 			),
 			exampleRating(
 				mdSentence(
-					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses using an offchain third-party provider, without verifying the address.`,
+					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses using an offchain external provider, without verifying the address.`,
 				),
 				evaluateAddressResolution(
 					{
@@ -381,7 +381,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 			),
 			exampleRating(
 				mdSentence(
-					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses using an offchain third-party provider which may learn the user's IP address.`,
+					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses using an offchain external provider which may learn the user's IP address.`,
 				),
 				evaluateAddressResolution(
 					{

--- a/src/schema/attributes/privacy/address-correlation.ts
+++ b/src/schema/attributes/privacy/address-correlation.ts
@@ -218,11 +218,11 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 	`),
 	methodology: markdown(`
 		In order to qualify for a perfect rating on wallet address privacy, a
-		wallet must not, *by default*, allow any third-party to link your wallet
-		address to any personal information.
+		wallet must not, *by default*, allow any external entity to link your
+		wallet address to any personal information.
 
 		As Walletbeat only considers the wallet's *default* behavior, wallets may
-		still choose to offer features that allow third-parties to link wallet
+		still choose to offer features that allow external providers to link wallet
 		addresses with personal information, so long as this is done with explicit
 		user opt-in.
 
@@ -243,8 +243,8 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 			exampleRating(
 				paragraph(`
 					The wallet requires user information (other than IP address and
-					pseudonyms) by default, and uploads this data to a third-party
-					or records it onchain in a publicly-viewable manner.
+					pseudonyms) by default, and uploads this data to an external
+					provider or records it onchain in a publicly-viewable manner.
 				`),
 				Rating.FAIL,
 			),
@@ -252,10 +252,10 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 		partial: [
 			exampleRating(
 				paragraph(`
-					The wallet allows a third party to learn the relationship between a
-					user's wallet address and their IP address by default. This is treated
-					as a partial rating because users may mitigate against this by forcing
-					wallet requests to be proxied on their own.
+					The wallet allows an external provider to learn the relationship
+					between a user's wallet address and their IP address by default.
+					This is treated as a partial rating because users may mitigate
+					against this by forcing wallet requests to be proxied on their own.
 				`),
 				(value: AddressCorrelationValue) =>
 					value.rating === Rating.PARTIAL && value.worstLeak?.info === PersonalInfo.IP_ADDRESS,
@@ -263,9 +263,10 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 			exampleRating(
 				paragraph(`
 					The wallet requires the user to identify themselves via a pseudonym
-					which is sent to a third-party or recorded onchain. This is treated as
-					a partial rating because users may choose an arbitrary pseudonym for
-					each of their wallet address to mitigate this privacy issue.
+					which is sent to an external provider or recorded onchain. This is
+					treated as a partial rating because users may choose an arbitrary
+					pseudonym for each of their wallet address to mitigate this privacy
+					issue.
 				`),
 				(value: AddressCorrelationValue) =>
 					value.rating === Rating.PARTIAL && value.worstLeak?.info === PersonalInfo.PSEUDONYM,
@@ -283,7 +284,7 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 			exampleRating(
 				paragraph(`
 					The wallet relies exclusively on a user's self-hosted node,
-					involving no third parties.
+					involving no external providers.
 				`),
 				exampleRatingUnimplemented,
 			),
@@ -328,7 +329,7 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 		return {
 			value: uncorrelated,
 			details: paragraph(
-				'{{WALLET_NAME}} does not allow any third-party to link your wallet address to any personal information.',
+				'{{WALLET_NAME}} does not allow any external provider to link your wallet address to any personal information.',
 			),
 			references: allRefs,
 		}

--- a/src/schema/attributes/privacy/multi-address-correlation.ts
+++ b/src/schema/attributes/privacy/multi-address-correlation.ts
@@ -75,7 +75,7 @@ function bulkRequests(references: ReferenceArray): Evaluation<MultiAddressCorrel
 		value: {
 			id: 'bulkRequests',
 			rating: Rating.FAIL,
-			displayName: 'Multiple addresses are correlatable by a third party',
+			displayName: 'Multiple addresses are correlatable by an external provider',
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} makes bulk requests containing multiple addresses to the same endpoint, which allows it to correlate your addresses.',
 			),
@@ -85,7 +85,7 @@ function bulkRequests(references: ReferenceArray): Evaluation<MultiAddressCorrel
 			'When configured with multiple addresses, {{WALLET_NAME}} makes requests that contain multiple addresses simultaneously.',
 		),
 		impact: paragraph(
-			'Using multiple addresses in {{WALLET_NAME}} will allow them to be correlated by a third-party. You should avoid configuring multiple addresses with {{WALLET_NAME}}.',
+			'Using multiple addresses in {{WALLET_NAME}} will allow them to be correlated by an external provider. You should avoid configuring multiple addresses with {{WALLET_NAME}}.',
 		),
 		howToImprove: paragraph(
 			'{{WALLET_NAME}} should first ensure that it never makes requests containing multiple addresses simultaneously. Next, it should ensure that these requests are staggered and are proxied through different proxies and RPC endpoints to prevent correlation. This can be done through the use of privacy solutions such as Oblivious HTTP, Tor, and others.',
@@ -101,7 +101,7 @@ function correlatableRequests(
 		value: {
 			id: 'correlatableRequests',
 			rating: Rating.FAIL,
-			displayName: 'Multiple addresses are correlatable by a third party',
+			displayName: 'Multiple addresses are correlatable by an external provider',
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} makes requests about multiple addresses simultaneously to the same endpoint, which allows it to correlate your addresses.',
 			),
@@ -111,7 +111,7 @@ function correlatableRequests(
 			'When configured with multiple addresses, {{WALLET_NAME}} makes separate requests for each wallet address, but these requests are sent simultaneously and without proxying. This allows the RPC endpoint to correlate your addresses.',
 		),
 		impact: paragraph(
-			'Using multiple addresses in {{WALLET_NAME}} will allow them to be correlated by a third-party. You should avoid configuring multiple addresses with {{WALLET_NAME}}.',
+			'Using multiple addresses in {{WALLET_NAME}} will allow them to be correlated by an external provider. You should avoid configuring multiple addresses with {{WALLET_NAME}}.',
 		),
 		howToImprove: paragraph(
 			'{{WALLET_NAME}} should ensure that its requests are staggered and are proxied through different proxies and RPC endpoints to prevent correlation. This can be done through the use of privacy solutions such as Oblivious HTTP, Tor, and others.',
@@ -269,10 +269,10 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 		fact private. It is therefore important to use a wallet that does not reveal that fact.
 	`),
 	methodology: markdown(`
-		Wallets are assessed based on whether a third-party can learn that
+		Wallets are assessed based on whether an external provider can learn that
 		two or more of the user's wallet addresses belong to the same user.
 
-		A third-party may learn of this correlation either through:
+		An external provider may learn of this correlation either through:
 
 		- The wallet software explicitly sending this data (e.g. through
 		  analytics)
@@ -354,7 +354,7 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 			),
 			exampleRating(
 				paragraph(
-					"The wallet runs by default with a user's own self-hosted node, preventing any third-party from learning about any of the user's wallet addresses.",
+					"The wallet runs by default with a user's own self-hosted node, preventing any external provider from learning about any of the user's wallet addresses.",
 				),
 				exampleRatingUnimplemented,
 			),

--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -94,9 +94,9 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
 		It refers to the ability for participants to verify that the chain data
 		is valid when they interact with it.
 
-		Without such verification, users rely on trusted third-parties to tell
+		Without such verification, users rely on trusted external providers to tell
 		them what the state of the blockchain is, similar to the web2 trust model.
-		This allows such third-parties to trick wallet users into signing
+		This allows such external providers to trick wallet users into signing
 		transactions that do not end up having the user's intended effect.
 
 		To avoid this, Ethereum was designed to be verifiable on commodity
@@ -125,7 +125,7 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
 		),
 		fail: exampleRating(
 			paragraph(
-				'The wallet does not verify the integrity of the Ethereum L1 chain, relying on the honesty of third-party RPC providers instead.',
+				'The wallet does not verify the integrity of the Ethereum L1 chain, relying on the honesty of external RPC providers instead.',
 			),
 			noChainVerification(null).value,
 		),

--- a/src/schema/attributes/security/hardware-wallet-support.ts
+++ b/src/schema/attributes/security/hardware-wallet-support.ts
@@ -118,7 +118,8 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 		A wallet receives a passing rating if it supports 3 out of 4 major hardware
 		wallet brands with direct connections (USB, WebUSB, WebHID, Bluetooth, or QR):
 		Ledger, Trezor, Keystone, and GridPlus. Hardware wallets accessible only through 
-		WalletConnect are not counted as they require relying on another third party.
+		WalletConnect are not counted as they require relying on WalletConnect as
+		an external dependency.
 
 		A wallet receives a partial rating if it supports at least one hardware wallet
 		brand with direct connection but doesn't support 3 out of 4 major brands mentioned above.

--- a/src/schema/attributes/security/keys-handling.ts
+++ b/src/schema/attributes/security/keys-handling.ts
@@ -60,7 +60,7 @@ export const keysHandling: Attribute<KeysHandlingValue> = {
 	methodology: markdown(`
 		Evaluated based on:
 		- **Master Secret Generation:** Use of interoperable, well-documented standards for seed generation.
-		- **Key Secrecy:** Resistance against key extraction or recovery by the provider or third parties. Ensuring keys are not transmitted insecurely.
+		- **Key Secrecy:** Resistance against key extraction or recovery by the external providers. Ensuring keys are not transmitted insecurely.
 		- **Proprietary Mechanisms:** Security implications of any non-standard key handling or backup procedures.
 		- **Physical Attack Resistance:** Protection against passive (side-channel analysis) and active (glitching) physical attacks.
 	`),

--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -242,7 +242,7 @@ function evaluateScamAlerts(
 				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
-					No application should ever send your browsing history to a third-party, and neither should {{WALLET_NAME}}.
+					No application should ever send your browsing history to an external service, and neither should {{WALLET_NAME}}.
 
 					Scam URL detection can be implemented in a privacy-preserving manner using a local database or downloading a list of known-bad domains with the [same domain name hash prefix](https://security.googleblog.com/2022/08/how-hash-based-safe-browsing-works-in.html).
 				`),
@@ -270,7 +270,7 @@ function evaluateScamAlerts(
 				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
-					No application should ever send your browsing history to a third-party, and neither should {{WALLET_NAME}}.
+					No application should ever send your browsing history to an external service, and neither should {{WALLET_NAME}}.
 
 					Scam URL detection can be implemented in a privacy-preserving manner using a local database or downloading a list of known-bad domains with the [same domain name hash prefix](https://security.googleblog.com/2022/08/how-hash-based-safe-browsing-works-in.html).
 				`),
@@ -338,15 +338,15 @@ function evaluateScamAlerts(
 				${[
 					!needsImprovement(sendTransactionWarning) &&
 						`
-						* Sending a transaction should not allow a third-party to learn a link between any of the sender's IP or Ethereum address and the recipient's address.
+						* Sending a transaction should not allow an external service to learn a link between any of the sender's IP or Ethereum address and the recipient's address.
 					`,
 					!needsImprovement(contractTransactionWarning) &&
 						`
-						* Checking arbitrary transactions for potential scams should not allow a third-party to link your IP or Ethereum address to the contract you are about to interact with or your upcoming transaction.
+						* Checking arbitrary transactions for potential scams should not allow an external service to link your IP or Ethereum address to the contract you are about to interact with or your upcoming transaction.
 					`,
 					!needsImprovement(scamUrlWarning) &&
 						`
-						* Checking arbitrary transactions for potential scams should not allow a third-party to link your browsing history with your IP or Ethereum address.
+						* Checking arbitrary transactions for potential scams should not allow an external service to link your browsing history with your IP or Ethereum address.
 					`,
 				]
 					.filter(Boolean)
@@ -414,8 +414,9 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 		in a privacy-preserving manner. Specifically:
 
 		* When sending funds, does the lookup for past interactions with that
-			address unconditionally reveal the sender and recipient addresses to a
-			third-party other than the wallet's default RPC provider for this chain?
+			address unconditionally reveal the sender and recipient addresses to an
+			external provider other than the wallet's default RPC provider for this
+			chain?
 
 			* Wallets can implement this feature in a privacy-preserving manner by
 				maintaining a local set of known addresses.
@@ -457,7 +458,7 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 			),
 			exampleRating(
 				sentence(
-					'The wallet leaks visited URLs to a third-party as part of its malicious app warning feature.',
+					'The wallet leaks visited URLs to an external service as part of its malicious app warning feature.',
 				),
 				evaluateScamAlerts(WalletProfile.GENERIC, {
 					contractTransactionWarning: notSupported,

--- a/src/schema/attributes/security/security-audits.ts
+++ b/src/schema/attributes/security/security-audits.ts
@@ -188,7 +188,7 @@ export const securityAudits: Attribute<SecurityAuditsValue> = {
 		],
 		fail: [
 			exampleRating(
-				paragraph('The wallet was never audited by a third-party security auditor.'),
+				paragraph('The wallet was never audited by an independent security auditor.'),
 				noAudits().value,
 			),
 			exampleRating(

--- a/src/schema/attributes/security/user-safety.ts
+++ b/src/schema/attributes/security/user-safety.ts
@@ -111,13 +111,13 @@ export const userSafety: Attribute<UserSafetyValue> = {
 
 		- **Risk analysis support:** Is the HWW displaying a risk evaluation / threat warning to the user when signing transactions or messages? Describe how the evaluation works.
 
-		- **Risk analysis without phoning home possible:** Is it possible to run the risk analysis process without contacting the HWW manufacturer? Describe which third parties are involved and if the full TX/message data could be recovered by a party.
+		- **Risk analysis without phoning home possible:** Is it possible to run the risk analysis process without contacting the HWW manufacturer? Describe which external services are involved and if the full TX/message data could be recovered by any party.
 
 		- **Fully local risk analysis possible:** Is it possible to run the risk analysis evaluation locally? Describe the components provided by the HWW provider and the setup.
 
 		- **TX simulation support:** Is the HWW displaying high level simulation results (balance difference…) to the user when signing transactions or messages? Describe how the evaluation works.
 
-		- **TX simulation without phoning home possible:** Is it possible to run the simulation process without contacting the HWW manufacturer? Describe which third parties are involved and if the full TX/message data could be recovered by a party.
+		- **TX simulation without phoning home possible:** Is it possible to run the simulation process without contacting the HWW manufacturer? Describe which external services are involved and if the full TX/message data could be recovered by any party.
 
 		- **Fully local TX simulation possible:** Is it possible to run the simulation locally? Describe the components provided by the HWW provider and the setup.
 

--- a/src/schema/attributes/self-sovereignty/account-portability.ts
+++ b/src/schema/attributes/self-sovereignty/account-portability.ts
@@ -138,10 +138,10 @@ function evaluateMpc(
 				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. By default, the user does not custody enough shares of this private key in order to control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet.',
 			),
 			impact: paragraph(
-				'Users of {{WALLET_NAME}} do not have unilateral control over their account, and need to rely on a third-party to authorize transactions or transfer assets out of the account.',
+				'Users of {{WALLET_NAME}} do not have unilateral control over their account, and need to rely on an external provider to authorize transactions or transfer assets out of the account.',
 			),
 			howToImprove: mdParagraph(
-				'{{WALLET_NAME}} should provide a way for users to obtain enough key shares in self-custody such that users no longer *need* to rely on third parties for transactions.',
+				'{{WALLET_NAME}} should provide a way for users to obtain enough key shares in self-custody such that users no longer *need* to rely on an external provider for transactions.',
 			),
 			references,
 		}
@@ -149,24 +149,24 @@ function evaluateMpc(
 
 	if (
 		mpc.tokenTransferTransactionGeneration ===
-		TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API
+		TransactionGenerationCapability.RELYING_ON_EXTERNAL_API
 	) {
 		return {
 			value: {
 				id: 'mpc_cannot_transfer',
 				rating: Rating.FAIL,
 				icon: '\u{1faa4}', // Mouse trap
-				displayName: 'Cannot withdraw assets without third party',
+				displayName: 'Cannot withdraw assets without external provider',
 				shortExplanation: sentence(
-					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on a third party.',
+					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on an external party.',
 				),
 				__brand: brand,
 			},
 			details: paragraph(
-				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully own the account, but generating an asset withdrawal transaction nonetheless requires interaction with a third-party.',
+				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully own the account, but generating an asset withdrawal transaction nonetheless requires interaction with an external service.',
 			),
 			impact: paragraph(
-				'While users of {{WALLET_NAME}} have unilateral control over their account, the reliance on a third-party to generate valid transactions means that transactions can be censored by that third-party and effectively freeze the account in place.',
+				'While users of {{WALLET_NAME}} have unilateral control over their account, the reliance on an external provider to generate valid transactions means that transactions can be censored by that provider and effectively freeze the account in place.',
 			),
 			howToImprove: paragraph(
 				'{{WALLET_NAME}} should release an open-source standalone application that allows users to sign transactions using their self-custodial key shares.',
@@ -213,7 +213,7 @@ function evaluateMpc(
 			__brand: brand,
 		},
 		details: paragraph(
-			'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully control the account, and can generate transactions without relying on a third-party.',
+			'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully control the account, and can generate transactions without relying on an external provider.',
 		),
 		references,
 	}
@@ -254,16 +254,16 @@ function evaluateMultifactor(
 	if (multifactor.controllingSharesInSelfCustodyByDefault === 'NO') {
 		if (
 			multifactor.keyRotationTransactionGeneration ===
-			TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API
+			TransactionGenerationCapability.RELYING_ON_EXTERNAL_API
 		) {
 			return {
 				value: {
-					id: `${multifactorType}_no_control_by_default_and_cannot_change_without_third_party`,
+					id: `${multifactorType}_no_control_by_default_and_cannot_change_without_external_provider`,
 					rating: Rating.FAIL,
 					icon: '\u{1faa4}', // Mouse trap
 					displayName: 'Not self-custodial by default',
 					shortExplanation: sentence(
-						'{{WALLET_NAME}} is not self-custodial by default, and changing this requires cooperation from a third-party.',
+						'{{WALLET_NAME}} is not self-custodial by default, and changing this requires cooperation from an external provider.',
 					),
 					__brand: brand,
 				},
@@ -271,7 +271,7 @@ function evaluateMultifactor(
 					{{WALLET_NAME}} is an ${eipMarkdownLink(eip)} (Smart Contract) wallet. By default, the user does not have the ability to unilaterally control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet.
 
 
-					The user *may* update the smart contract control logic such that the account becomes effectively self-custodied. However, this process requires the cooperation of a third-party and is therefore at risk that the third-party prevents this switch from taking place.
+					The user *may* update the smart contract control logic such that the account becomes effectively self-custodied. However, this process requires the cooperation of an external provider and is therefore at risk that the provider prevents this switch from taking place.
 				`),
 				howToImprove: mdParagraph(
 					"{{WALLET_NAME}} should either change the smart contract's default control configuration such that the account is self-custodied by the user from the start, or should release an open-source standalone application that allows users to switch their account to be effectively self-custodied.",
@@ -311,27 +311,27 @@ function evaluateMultifactor(
 
 	if (
 		multifactor.tokenTransferTransactionGeneration ===
-		TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API
+		TransactionGenerationCapability.RELYING_ON_EXTERNAL_API
 	) {
 		return {
 			value: {
-				id: `${multifactorType}_cannot_transfer_without_third_party`,
+				id: `${multifactorType}_cannot_transfer_without_external_provider`,
 				rating: Rating.FAIL,
 				icon: '\u{1faa4}', // Mouse trap
-				displayName: 'Cannot withdraw assets without third party',
+				displayName: 'Cannot withdraw assets without external provider',
 				shortExplanation: sentence(
-					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on a third party.',
+					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on an external provider.',
 				),
 				__brand: brand,
 			},
 			details: mdParagraph(
-				'Users of {{WALLET_NAME}} cannot generate asset transfer transactions without relying on a third-party.',
+				'Users of {{WALLET_NAME}} cannot generate asset transfer transactions without relying on an external provider.',
 			),
 			impact: paragraph(
-				'The reliance on a third-party to generate valid transactions means that transactions can be censored by that third-party, opening up the risk that the third-party effectively freezes the account in place.',
+				'The reliance on an external provider to generate valid transactions means that transactions can be censored by that provider, opening up the risk that the provider effectively freezes the account in place.',
 			),
 			howToImprove: paragraph(
-				'{{WALLET_NAME}} should open-source sufficient wallet components such that users can sign and broadcast arbitrary transactions without relying on any third party.',
+				'{{WALLET_NAME}} should open-source sufficient wallet components such that users can sign and broadcast arbitrary transactions without relying on an external provider.',
 			),
 			references,
 		}
@@ -359,7 +359,7 @@ function evaluateMultifactor(
 				'The reliance on a proprietary application to generate valid transactions means that the application may opaquely decide to reject the generation of certain transactions, opening up the risk that the account is effectively frozen in place.',
 			),
 			howToImprove: paragraph(
-				'{{WALLET_NAME}} should open-source sufficient wallet components such that users can sign and broadcast arbitrary transactions without relying on any third party.',
+				'{{WALLET_NAME}} should open-source sufficient wallet components such that users can sign and broadcast arbitrary transactions without external or proprietary dependencies.',
 			),
 			references,
 		}
@@ -399,7 +399,7 @@ function evaluateMultifactor(
 			__brand: brand,
 		},
 		details: mdParagraph(
-			`{{WALLET_NAME}} is an ${eipMarkdownLink(erc4337)} (Smart Contract) wallet. By default, the user holds sufficient authority to generate and broadcast arbitrary transactions and can do so without relying on a third-party, including transactions which update the smart contract's control logic over the account (e.g. for key rotation).`,
+			`{{WALLET_NAME}} is an ${eipMarkdownLink(erc4337)} (Smart Contract) wallet. By default, the user holds sufficient authority to generate and broadcast arbitrary transactions and can do so without relying on an external provider, including transactions which update the smart contract's control logic over the account (e.g. for key rotation).`,
 		),
 		references,
 	}
@@ -476,10 +476,11 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 			shares of the underlying key to have full control over the wallet in
 			a self-custodial manner. Additionally, there must be a way for the user
 			to generate a transaction (Walletbeat uses a token transfer out of the
-			wallet as the litmus transaction for this) without reliance on a
-			third-party API or proprietary application. The combination of these
+			wallet as the litmus transaction for this) without reliance on an
+			external API or proprietary application. The combination of these
 			factors ensures that the wallet remains self-custodial and that the
-			account cannot be frozen in-place due to an uncooperative third party.
+			account cannot be frozen in-place due to an uncooperative external
+			provider.
 		* ${eipMarkdownLink(erc4337)} (smart contract wallets) are rated based on
 			the level of control the user has over their account according to the
 			smart contract's control logic that the wallet uses. The user must be
@@ -489,15 +490,15 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 
 			* Whether the user has the ability to change the cryptographic keys
 				used to control the account in general, in a manner that does not
-				involve relying on a third party or proprietary software.
+				involve relying on an external provider or proprietary software.
 			* Whether the smart contract wallet's default configuration starts
 				out with the user having self-custody of their account, for example
 				by having a majority of the key shares in self-custody in a multisig
 				wallet.
 			* Whether the generation of a token transfer transaction requires
-				relying on a third-party or proprietary software, even if the user
-				has self-custody of all requisite cryptographic keys to sign such a
-				transaction.
+				relying on an external provider or proprietary software, even if the
+				user has self-custody of all requisite cryptographic keys to sign
+				such a transaction.
 
 		* ${eipMarkdownLink(eip7702)} are not yet rated on account portability and
 			will show up as "Unrated".
@@ -541,7 +542,7 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 						controllingSharesInSelfCustodyByDefault: 'NO',
 						initialKeyGeneration: 'ON_USER_DEVICE',
 						tokenTransferTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 					},
 					[],
 				).value,
@@ -551,14 +552,14 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 					The wallet is an MPC wallet. By default, the user is in self-custody
 					of sufficient key shares to unilaterally control the account.
 					However, the user cannot generate a token transfer transaction
-					without relying on a third party API.
+					without relying on an external provider.
 				`),
 				evaluateMpc(
 					{
 						controllingSharesInSelfCustodyByDefault: 'YES',
 						initialKeyGeneration: 'ON_USER_DEVICE',
 						tokenTransferTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 					},
 					[],
 				).value,
@@ -575,7 +576,7 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 						controllingSharesInSelfCustodyByDefault: 'YES',
 						keyRotationTransactionGeneration: TransactionGenerationCapability.IMPOSSIBLE,
 						tokenTransferTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 					},
 					'erc4337',
 					[],
@@ -585,16 +586,16 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 				mdParagraph(`
 					The wallet is an ${eipMarkdownLink(erc4337)} (smart contract) wallet.
 					The user does not have full self-custodial control by default, and
-					needs to rely on a third-party API or proprietary software to change
+					needs to rely on an external provider or proprietary software to change
 					this.
 				`),
 				evaluateMultifactor(
 					{
 						controllingSharesInSelfCustodyByDefault: 'NO',
 						keyRotationTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 						tokenTransferTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 					},
 					'erc4337',
 					[],
@@ -604,16 +605,16 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 				mdParagraph(`
 					The wallet is an ${eipMarkdownLink(erc4337)} (smart contract) wallet.
 					The user has self-custodial control by default, but still needs to
-					rely on a third-party API or proprietary software to generate a
+					rely on an external provider or proprietary software to generate a
 					valid token transfer transaction.
 				`),
 				evaluateMultifactor(
 					{
 						controllingSharesInSelfCustodyByDefault: 'YES',
 						keyRotationTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 						tokenTransferTransactionGeneration:
-							TransactionGenerationCapability.RELYING_ON_THIRD_PARTY_API,
+							TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
 					},
 					'erc4337',
 					[],
@@ -702,7 +703,7 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 					The wallet is an MPC wallet where the user is in self-custody of
 					sufficient key shares to unilaterally control the account.
 					The user can generate a token transfer transaction using standalone
-					open-source software which does not rely on any third party API.
+					open-source software which does not rely on any external provider.
 				`),
 				evaluateMpc(
 					{
@@ -719,7 +720,7 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 					The wallet is an ${eipMarkdownLink(erc4337)} (smart contract) wallet,
 					with the user having full self-custodial control by default.
 					The user can create token transfer transactions using solely
-					open-source software without relying on a third-party API.
+					open-source software without relying on an external provider.
 				`),
 				evaluateMultifactor(
 					{

--- a/src/schema/attributes/self-sovereignty/interoperability.ts
+++ b/src/schema/attributes/self-sovereignty/interoperability.ts
@@ -15,13 +15,13 @@ import { exempt, pickWorstRating, unrated } from '../common'
 const brand = 'attributes.interoperability'
 
 export type InteroperabilityValue = Value & {
-	thirdPartyCompatibility: InteroperabilityType
+	interoperability: InteroperabilityType
 	noSupplierLinkage: InteroperabilityType
 	__brand: 'attributes.interoperability'
 }
 
 function evaluateInteroperability(features: InteroperabilitySupport): Rating {
-	const ratings = [features.thirdPartyCompatibility, features.noSupplierLinkage]
+	const ratings = [features.interoperability, features.noSupplierLinkage]
 	const passCount = ratings.filter(r => r === InteroperabilityType.PASS).length
 
 	if (passCount === 2) {
@@ -47,13 +47,13 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 		),
 	},
 	question: sentence(
-		'Does {{WALLET_NAME}} work well with third-party wallets and avoid supplier linkage?',
+		'Does {{WALLET_NAME}} work well with independent wallets and avoid supplier linkage?',
 	),
 	why: markdown(
-		'Interoperability ensures the wallet can be used with independent third-party wallets and does not leak identifying metadata to the supplier.',
+		'Interoperability ensures the wallet can be used with independent wallets and does not leak identifying metadata to the supplier.',
 	),
 	methodology: markdown(
-		'Evaluated based on third-party wallet compatibility and supplier independence.',
+		'Evaluated based on independent wallet compatibility and supplier independence.',
 	),
 	ratingScale: {
 		display: 'pass-fail',
@@ -82,7 +82,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 	evaluate: (features: ResolvedFeatures): Evaluation<InteroperabilityValue> => {
 		if (features.type !== WalletType.HARDWARE) {
 			return exempt(interoperability, sentence('Only rated for hardware wallets'), brand, {
-				thirdPartyCompatibility: InteroperabilityType.FAIL,
+				interoperability: InteroperabilityType.FAIL,
 				noSupplierLinkage: InteroperabilityType.FAIL,
 			})
 		}
@@ -91,7 +91,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 
 		if (interoperabilityFeature === null) {
 			return unrated(interoperability, brand, {
-				thirdPartyCompatibility: InteroperabilityType.FAIL,
+				interoperability: InteroperabilityType.FAIL,
 				noSupplierLinkage: InteroperabilityType.FAIL,
 			})
 		}

--- a/src/schema/attributes/self-sovereignty/self-hosted-node.ts
+++ b/src/schema/attributes/self-sovereignty/self-hosted-node.ts
@@ -46,12 +46,12 @@ function supportsSelfHostedNodeAfterRequests(
 			rating: Rating.PARTIAL,
 			displayName: 'Partially supports self-hosted nodes',
 			shortExplanation: sentence(
-				'{{WALLET_NAME}} contacts a third-party RPC endpoint before letting you configure a self-hosted node.',
+				'{{WALLET_NAME}} contacts an external RPC endpoint before letting you configure a self-hosted node.',
 			),
 			__brand: brand,
 		},
 		details: paragraph(
-			'{{WALLET_NAME}} lets you use a self-hosted Ethereum node, but you cannot configure this before a sensitive request is already made to a third-party RPC provider.',
+			'{{WALLET_NAME}} lets you use a self-hosted Ethereum node, but you cannot configure this before a sensitive request is already made to an external RPC provider.',
 		),
 		howToImprove: paragraph(
 			'{{WALLET_NAME}} should modify the wallet creation flow to allow the user to configure the RPC endpoint for L1 before making any requests, or should avoid making any such requests until the user can access the RPC endpoint configuration options.',
@@ -119,25 +119,25 @@ export const selfHostedNode: Attribute<SelfHostedNodeValue> = {
 
 		* **Privacy**: Because the wallet can work directly on your own hardware
 			with no outside dependencies, the wallet can query chain data without
-			revealing private details (wallet address, IP address, etc.) to a
-			third-party RPC provider.
-		* **Integrity**: Relying on a third-party RPC provider means that this
+			revealing private details (wallet address, IP address, etc.) to an
+			external RPC provider.
+		* **Integrity**: Relying on an external RPC provider means that this
 			provider may return incorrect data about the state of the chain,
 			tricking you into signing a transaction that ends up having a different
 			effect than intended. Your own L1 node will verify the integrity of the
 			chain, so such attacks cannot occur when using a self-hosted node.
 		* **Censorship resistance**: Because an L1 node may broadcast transactions
 			into a shared mempool directly to other nodes in the network, your
-			transactions are not censorable by a third-party RPC provider that would
+			transactions are not censorable by an external RPC provider that would
 			otherwise act as an intermediary.
 		* **No downtime**: Because the L1 node is running on your own hardware,
 			you are not at risk of losing funds or opportunities due to downtime
-			from a third-party RPC provider.
+			from an external RPC provider.
 	`),
 	methodology: markdown(`
 		Wallets are rated based on whether they allow the user to configure the
 		RPC endpoint used for Ethereum mainnet, and whether such configuration is
-		possible before any request is made to a third-party RPC endpoint by
+		possible before any request is made to an external RPC provider by
 		default.
 	`),
 	ratingScale: {
@@ -156,14 +156,14 @@ export const selfHostedNode: Attribute<SelfHostedNodeValue> = {
 			),
 			exampleRating(
 				paragraph(
-					'The wallet lets you configure the RPC endpoint used for Ethereum mainnet, but makes requests to a third-party RPC provider before the user has a chance to modify this RPC endpoint configuration.',
+					'The wallet lets you configure the RPC endpoint used for Ethereum mainnet, but makes requests to an external RPC provider before the user has a chance to modify this RPC endpoint configuration.',
 				),
 				supportsSelfHostedNodeAfterRequests([]).value,
 			),
 		],
 		fail: exampleRating(
 			paragraph(
-				'The wallet uses a third-party Ethereum node provider and does not let you change this setting.',
+				'The wallet uses an external Ethereum node provider and does not let you change this setting.',
 			),
 			noSelfHostedNode([]).value,
 		),

--- a/src/schema/attributes/self-sovereignty/transaction-inclusion.ts
+++ b/src/schema/attributes/self-sovereignty/transaction-inclusion.ts
@@ -177,7 +177,7 @@ export const transactionInclusion: Attribute<TransactionInclusionValue> = {
 			take it into account.
 		* Since L2 force-withdrawal transactions require an L1 transaction, the
 			wallet must also be able to get this transaction included without
-			relying on a third-party to broadcast this transaction for block
+			relying on an external service to broadcast this transaction for block
 			inclusion. Therefore, the wallet must also support either participating
 			in Ethereum's L1 gossip network, or (for environments that do not
 			support this such as browser extension wallets) support broadcasting
@@ -222,7 +222,7 @@ export const transactionInclusion: Attribute<TransactionInclusionValue> = {
 		partial: [
 			exampleRating(
 				paragraph(
-					'The wallet supports force-withdrawal transactions on L2s, but requires the use of a third-party RPC provider to submit the L1 transaction that it would take to initiate this force-withdrawal transaction.',
+					'The wallet supports force-withdrawal transactions on L2s, but requires the use of an external RPC provider to submit the L1 transaction that it would take to initiate this force-withdrawal transaction.',
 				),
 				transactionSubmissionEvaluation({
 					supportsL1Broadcast: 'NO',

--- a/src/schema/attributes/transparency/reputation.ts
+++ b/src/schema/attributes/transparency/reputation.ts
@@ -60,7 +60,7 @@ export const reputation: Attribute<ReputationValue> = {
 	methodology: markdown(
 		`Evaluated based on an aggregate of factors:
 
-- **Product Originality:** Degree of original design versus reliance on third-party components.
+- **Product Originality:** Degree of original design versus reliance on not-in-house components.
 
 - **Availability & Support:** History of product availability, risk of discontinuation, and perceived ability to honor warranty/support.
 

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -45,8 +45,8 @@ const allAccountTypes: NonEmptyArray<AccountType> = [
 
 /** The ability (or lack thereof) to generate a transaction of a specific type. */
 export enum TransactionGenerationCapability {
-	/** The process to generate such a transaction relies on a third-party API. */
-	RELYING_ON_THIRD_PARTY_API = 'RELYING_ON_THIRD_PARTY_API',
+	/** The process to generate such a transaction relies on an external API. */
+	RELYING_ON_EXTERNAL_API = 'RELYING_ON_EXTERNAL_API',
 
 	/** The process to generate such a transaction requires the use of a standalone proprietary application. */
 	USING_PROPRIETARY_STANDALONE_APP = 'USING_PROPRIETARY_STANDALONE_APP',
@@ -169,7 +169,7 @@ interface AccountTypeMultifactor {
 	/**
 	 * Is it possible to create and broadcast an Ethereum transaction that
 	 * withdraws any type of asset from the account to transfer it out to
-	 * another address, without the help of a third-party?
+	 * another address, without the help of an external provider?
 	 *
 	 * This implies that the code to create such a transaction already exists
 	 * and does not rely on any network request to a proprietary API or service.
@@ -183,7 +183,10 @@ interface AccountTypeMultifactor {
  */
 export type AccountTypeMpc = AccountTypeMultifactor & {
 	/** How is the underlying key generation performed before shares are distributed? */
-	initialKeyGeneration: 'ON_USER_DEVICE' | 'BY_THIRD_PARTY_IN_TEE' | 'BY_THIRD_PARTY_IN_THE_CLEAR'
+	initialKeyGeneration:
+		| 'ON_USER_DEVICE'
+		| 'BY_EXTERNAL_PROVIDER_IN_SECURE_ENCLAVE'
+		| 'BY_EXTERNAL_PROVIDER_IN_THE_CLEAR'
 }
 
 /**
@@ -194,7 +197,7 @@ export type AccountTypeMutableMultifactor = AccountTypeMultifactor & {
 	/**
 	 * Is it possible to create and broadcast an Ethereum transaction that
 	 * rotates one of the factors used to control the account without relying
-	 * on a third-party?
+	 * on an external service?
 	 *
 	 * This implies that the code to create such a transaction is open-source
 	 * and does not rely on any network request to a proprietary API or service.

--- a/src/schema/features/privacy/address-resolution.ts
+++ b/src/schema/features/privacy/address-resolution.ts
@@ -29,19 +29,19 @@ export type AddressResolutionData =
 	  }
 	| {
 			/**
-			 * The wallet uses a third-party offchain provider to look up the necessary
+			 * The wallet uses an external offchain provider to look up the necessary
 			 * data.
 			 */
 			medium: 'OFFCHAIN'
 
 			/**
-			 * Whether the third-party onchain provider's data is verified,
+			 * Whether the external offchain provider's data is verified,
 			 * for example through a light client.
 			 */
 			offchainDataVerifiability: 'VERIFIABLE' | 'NOT_VERIFIABLE'
 
 			/**
-			 * Whether the wallet directly connects to the third-party offchain
+			 * Whether the wallet directly connects to the external offchain
 			 * provider (thereby revealing information about who is doing the
 			 * lookup), or using anonymizing proxies to do so.
 			 */

--- a/src/schema/features/privacy/data-collection.ts
+++ b/src/schema/features/privacy/data-collection.ts
@@ -36,7 +36,7 @@ export enum CollectionPolicy {
 	 * In order to qualify for this level, it must be possible for the
 	 * user to access this setting and turn off the collection *before*
 	 * the first time it happens. For example, a wallet that refreshes
-	 * crypto prices by default (using a third-party service) and does so
+	 * crypto prices by default (using an external service) and does so
 	 * before ever giving the user a chance to access the wallet settings
 	 * to turn off this feature does not qualify for this level.
 	 */
@@ -92,7 +92,7 @@ export enum MultiAddressPolicy {
  * once, or multiple requests (one per address).
  * Wallets typically need data about multiple addresses at once in the context
  * of refreshing balances, or handling a set of stealth addresses. In either
- * case, there is a risk of allowing third-parties to correlate these
+ * case, there is a risk of allowing external services to correlate these
  * addresses together if the requests are not done carefully.
  *
  * If sending multiple requests, the wallet has additional control over how to

--- a/src/schema/features/privacy/transaction-privacy.ts
+++ b/src/schema/features/privacy/transaction-privacy.ts
@@ -102,14 +102,14 @@ export interface StealthAddressSupport {
 		  }
 		| {
 				/**
-				 * Resolution is done exclusively with a specific third-party provider.
+				 * Resolution is done exclusively with a specific external provider.
 				 */
-				type: 'THIRD_PARTY_RESOLVER'
+				type: 'EXTERNAL_RESOLVER'
 
-				/** The third party that does the resolution. */
-				thirdParty: Entity
+				/** The external resolver that does the resolution. */
+				externalResolver: Entity
 
-				/** What does this third party learn? */
+				/** What does this external resolver learn? */
 				learns: {
 					senderIpAddress: boolean
 					senderMetaAddress: boolean
@@ -142,12 +142,12 @@ export interface StealthAddressSupport {
 				>
 		  }
 		| {
-				type: 'THIRD_PARTY_SERVICE'
+				type: 'EXTERNAL_SERVICE'
 
-				/** The third party that does the balance lookup. */
-				thirdParty: Entity
+				/** The external service that does the balance lookup. */
+				externalService: Entity
 
-				/** What does this third party learn? */
+				/** What does this external service learn? */
 				learns: {
 					/** The user's stealth meta-address. */
 					userMetaAddress: boolean
@@ -169,11 +169,11 @@ export interface StealthAddressSupport {
 				type: 'DEFAULT_CHAIN_PROVIDER'
 		  }
 		| {
-				/** A third-party service provides private key data to the wallet. */
-				type: 'THIRD_PARTY_SERVICE'
+				/** An external service provides private key data to the wallet. */
+				type: 'EXTERNAL_SERVICE'
 
-				/** The third party that provides this. */
-				thirdParty: Entity
+				/** The external service that provides this. */
+				externalService: Entity
 		  }
 		| {
 				/** Private key derivation is done locally. */

--- a/src/schema/features/self-sovereignty/interoperability.ts
+++ b/src/schema/features/self-sovereignty/interoperability.ts
@@ -10,7 +10,7 @@ export interface InteroperabilitySupport {
 	type: InteroperabilityType
 	url?: string
 	details?: string
-	thirdPartyCompatibility: InteroperabilityType
+	interoperability: InteroperabilityType
 	noSupplierLinkage: InteroperabilityType
 }
 

--- a/src/ui/molecules/attributes/security/ScamAlertDetails.tsx
+++ b/src/ui/molecules/attributes/security/ScamAlertDetails.tsx
@@ -123,7 +123,7 @@ export function ScamAlertDetails({ wallet, value }: ScamAlertDetailsProps): Reac
 													? "the recipient's Ethereum address"
 													: null,
 											])}{' '}
-											to a third party which can correlate them.
+											to an external service which can correlate them.
 										</Typography>
 									)}
 									{toFullyQualified(value.scamAlerts.sendTransactionWarning.ref).length > 0 && (
@@ -179,7 +179,7 @@ export function ScamAlertDetails({ wallet, value }: ScamAlertDetailsProps): Reac
 													? 'the contract address'
 													: null,
 											])}{' '}
-											to a third party which can correlate them ahead of the transaction being
+											to an external service which can correlate them ahead of the transaction being
 											submitted.
 										</Typography>
 									)}
@@ -208,8 +208,8 @@ export function ScamAlertDetails({ wallet, value }: ScamAlertDetailsProps): Reac
 										{!value.scamUrlWarning.privacyPreserving && (
 											<>
 												{' '}
-												However, in doing so, it leaks {commaListFormat(scamUrlLeaks)} to a third
-												party{scamUrlLeaks.length > 1 && ' which can correlate them'}.
+												However, in doing so, it leaks {commaListFormat(scamUrlLeaks)} to an
+												external service{scamUrlLeaks.length > 1 && ' which can correlate them'}.
 											</>
 										)}
 									</Typography>

--- a/tests/banned-expressions.test.ts
+++ b/tests/banned-expressions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { commonExclusions, getCodebaseIndex, type IndexedFile } from './utils/codebase'
+
+interface BannedExpression {
+	name: string
+	regexp: RegExp
+	explanation: string
+}
+
+const bannedExpressions: BannedExpression[] = [
+	{
+		name: 'third party',
+		regexp: /\bthird([-_ ]|\s*)?part(y|ies)\b/i,
+		explanation:
+			'To distinguish between "third-party" as in "other than the wallet developer" and "non-local", use another term. Consider using "external" or "external provider" when talking about a network-level "third party", or "independent" when talking about a party different from the wallet developer.',
+	},
+]
+
+interface FileBannedExpressionNames {
+	matchedExprs: Set<string>
+}
+
+async function codebaseBannedExpressionIndex(): Promise<Map<string, Set<string>>> {
+	const bannedMap = new Map<string, Set<string>>()
+
+	await getCodebaseIndex({
+		indexFn: (_, fileContents: string): FileBannedExpressionNames => {
+			const matched = new Set<string>()
+
+			for (const bannedExpr of bannedExpressions) {
+				if (bannedExpr.regexp.test(fileContents)) {
+					matched.add(bannedExpr.name)
+				}
+			}
+
+			return { matchedExprs: matched }
+		},
+		aggregateFn: (fileMatch: IndexedFile<FileBannedExpressionNames>) => {
+			for (const bannedExprName of fileMatch.matchedExprs.keys()) {
+				let fileSet = bannedMap.get(bannedExprName)
+
+				if (fileSet === undefined) {
+					fileSet = new Set<string>()
+					bannedMap.set(bannedExprName, fileSet)
+				}
+
+				fileSet.add(fileMatch.filePath)
+			}
+		},
+		ignore: commonExclusions.concat([
+			// Exclude test files.
+			/\.test.ts$/i,
+
+			// Exclude governance documents (meeting transcripts etc).
+			/^governance\//i,
+		]),
+	})
+
+	return bannedMap
+}
+
+describe('banned expressions', async () => {
+	const index = await codebaseBannedExpressionIndex()
+
+	for (const banned of bannedExpressions) {
+		it(`does not contain the expression: "${banned.name}"`, () => {
+			const fileMatches = index.get(banned.name)
+
+			expect(fileMatches).toSatisfy(
+				val => val === undefined,
+				`Expression "${banned.name}" found in files:\n${
+					fileMatches === undefined
+						? ''
+						: Array.from(fileMatches.keys())
+								.map(path => `- ${path}`)
+								.join('\n')
+				}\n${banned.explanation}`,
+			)
+		})
+	}
+})


### PR DESCRIPTION
Replaced with "external provider" when talking about network-level third-party, or "independent" when talking about "different from the wallet developer".

The intent of this change is to disambiguate what some Walletbeat attributes look for. For example, "third party data collection" refers to all data sent by the wallet over the network, not just to services that aren't run by the wallet developer. In other words, the wallet developer's own data collection is included. By contrast, "third party security auditor" refers to security auditors with no ties or conflict of interest with the wallet developer; the wallet developer is not included

Also add test that verifies this expression does not creep back into the codebase.