### PR TITLE
Minor stylistic fixes on and fixed URL on "About" page

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,21 +1,25 @@
-import ForumIcon from '@mui/icons-material/Forum'
-import HelpCenterIcon from '@mui/icons-material/HelpCenter'
-import HomeIcon from '@mui/icons-material/Home'
-import { LuBadgeCheck, LuBuilding2, LuGithub } from 'react-icons/lu'
+import {
+	LuBadgeCheck,
+	LuBadgeHelp,
+	LuBuilding2,
+	LuGithub,
+	LuHouse,
+	LuMessageCircleHeart,
+} from 'react-icons/lu'
 
 import { betaSiteRoot, repositoryUrl, socialChannel } from '@/constants'
 import type { NavigationLinkItem } from '@/ui/organisms/Navigation'
 
 export const navigationHome: NavigationLinkItem = {
 	id: 'wallet-table',
-	icon: <HomeIcon />,
+	icon: <LuHouse />,
 	title: 'Walletbeat',
 	href: `${betaSiteRoot}/#`,
 }
 
 export const navigationFaq: NavigationLinkItem = {
 	id: 'faq',
-	icon: <HelpCenterIcon />,
+	icon: <LuBadgeHelp />,
 	title: 'FAQ',
 	href: `${betaSiteRoot}/faq`,
 }
@@ -43,7 +47,7 @@ export const navigationRepository: NavigationLinkItem = {
 
 export const navigationFarcasterChannel: NavigationLinkItem = {
 	id: 'farcaster-channel',
-	icon: <ForumIcon />,
+	icon: <LuMessageCircleHeart />,
 	title: 'Discuss on Farcaster',
 	href: socialChannel,
 }

--- a/src/global.css
+++ b/src/global.css
@@ -46,7 +46,7 @@
 		--rating-neutral: #bdc3c7; /* Gray */
 
 		/* Link colors for light mode */
-		--link-color: #105C7E; /* Dark blue for good contrast on light background */
+		--link-color: #105c7e; /* Dark blue for good contrast on light background */
 	}
 }
 
@@ -89,7 +89,7 @@ html.dark {
 	--rating-neutral: #bdc3c7; /* Gray */
 
 	/* Link colors for dark mode */
-	--link-color: #CDEAF7; /* Light blue for good contrast on dark background */
+	--link-color: #cdeaf7; /* Light blue for good contrast on dark background */
 }
 
 html,

--- a/src/global.css
+++ b/src/global.css
@@ -44,6 +44,9 @@
 		--rating-partial: #f1c40f; /* Yellow */
 		--rating-fail: #e74c3c; /* Red */
 		--rating-neutral: #bdc3c7; /* Gray */
+
+		/* Link colors for light mode */
+		--link-color: #105C7E; /* Dark blue for good contrast on light background */
 	}
 }
 
@@ -84,6 +87,9 @@ html.dark {
 	--rating-partial: #f1c40f; /* Yellow */
 	--rating-fail: #e74c3c; /* Red */
 	--rating-neutral: #bdc3c7; /* Gray */
+
+	/* Link colors for dark mode */
+	--link-color: #CDEAF7; /* Light blue for good contrast on dark background */
 }
 
 html,

--- a/src/pages/about/_AboutPage.tsx
+++ b/src/pages/about/_AboutPage.tsx
@@ -11,7 +11,7 @@ import {
 	navigationHome,
 	navigationRepository,
 } from '@/components/navigation'
-import { betaSiteRoot, repositoryUrl } from '@/constants'
+import { betaSiteRoot, repositoryUrl, socialChannel } from '@/constants'
 import { NavigationPageLayout } from '@/layouts/NavigationPageLayout'
 import type { Url } from '@/schema/url'
 import { ExternalLink } from '@/ui/atoms/ExternalLink'
@@ -98,8 +98,8 @@ function AboutContents(): React.JSX.Element {
 					open-source project
 				</IconLink>{' '}
 				licensed under the Free and Open-Source MIT license. Discussions are held on the{' '}
-				<IconLink IconComponent={ForumIcon} href={repositoryUrl} target='_blank'>
-					public /walletbeat Farcaster channel
+				<IconLink IconComponent={ForumIcon} href={socialChannel} target='_blank'>
+					Walletbeat Farcaster channel
 				</IconLink>
 				.
 			</Typography>

--- a/src/ui/atoms/ExternalLink.tsx
+++ b/src/ui/atoms/ExternalLink.tsx
@@ -1,6 +1,5 @@
 import { Link, type TypographyOwnProps } from '@mui/material'
 import type React from 'react'
-import { useState } from 'react'
 import { LuExternalLink } from 'react-icons/lu'
 
 import { labeledUrl, type Url } from '@/schema/url'
@@ -21,7 +20,6 @@ export function ExternalLink({
 	children?: React.ReactNode
 }): React.JSX.Element {
 	const labeled = labeledUrl(url, defaultLabel)
-	const [hovered, setHovered] = useState(false)
 
 	return (
 		<span className='inline-block'>
@@ -34,19 +32,10 @@ export function ExternalLink({
 					...style,
 				}}
 				className='flex flex-row gap-2 items-baseline'
-				onMouseEnter={() => {
-					setHovered(true)
-				}}
-				onMouseLeave={() => {
-					setHovered(false)
-				}}
 			>
- 			<span
- 				className='inline-block'
- 				style={{ textDecoration: 'underline' }}
- 			>
- 				{children ?? labeled.label}
- 			</span>{' '}
+				<span className='inline-block' style={{ textDecoration: 'underline' }}>
+					{children ?? labeled.label}
+				</span>{' '}
 				<LuExternalLink />
 			</Link>
 		</span>

--- a/src/ui/atoms/ExternalLink.tsx
+++ b/src/ui/atoms/ExternalLink.tsx
@@ -8,7 +8,7 @@ import { labeledUrl, type Url } from '@/schema/url'
 export function ExternalLink({
 	url,
 	defaultLabel = undefined,
-	color = 'primary.main',
+	color = undefined,
 	style = undefined,
 	rel = 'noopener noreferrer nofollow',
 	children = undefined,
@@ -30,6 +30,7 @@ export function ExternalLink({
 				target='_blank'
 				rel={rel}
 				style={{
+					color: color ?? 'var(--link-color)',
 					...style,
 				}}
 				className='flex flex-row gap-2 items-baseline'
@@ -39,16 +40,13 @@ export function ExternalLink({
 				onMouseLeave={() => {
 					setHovered(false)
 				}}
-				sx={{
-					color,
-				}}
 			>
-				<span
-					className='inline-block'
-					style={{ textDecoration: hovered ? 'underline' : 'inherit' }}
-				>
-					{children ?? labeled.label}
-				</span>{' '}
+ 			<span
+ 				className='inline-block'
+ 				style={{ textDecoration: 'underline' }}
+ 			>
+ 				{children ?? labeled.label}
+ 			</span>{' '}
 				<LuExternalLink />
 			</Link>
 		</span>

--- a/src/ui/atoms/IconLink.tsx
+++ b/src/ui/atoms/IconLink.tsx
@@ -25,8 +25,8 @@ export function IconLink({
 	// Convert gap to Tailwind spacing class
 	const gapClass = gap === '0.25rem' ? 'gap-1' : 'gap-2'
 
-	// Default color to text-primary
-	const colorClass = color ?? 'text-primary'
+	// Default color to link-color CSS variable
+	const linkColor = color ?? 'var(--link-color)'
 
 	return (
 		<span className='inline-block'>
@@ -34,12 +34,14 @@ export function IconLink({
 				href={href}
 				target={target}
 				rel={rel}
-				style={style}
-				className={cx(
-					'inline-flex flex-row items-baseline no-underline hover:underline',
-					gapClass,
-					colorClass,
-				)}
+				style={{
+					color: linkColor,
+					...style,
+				}}
+ 			className={cx(
+ 				'inline-flex flex-row items-baseline underline',
+ 				gapClass,
+ 			)}
 			>
 				<IconComponent className='inline-block' fontSize='inherit' />
 				<span className='inline-block'>{children}</span>

--- a/src/ui/atoms/IconLink.tsx
+++ b/src/ui/atoms/IconLink.tsx
@@ -38,10 +38,7 @@ export function IconLink({
 					color: linkColor,
 					...style,
 				}}
- 			className={cx(
- 				'inline-flex flex-row items-baseline underline',
- 				gapClass,
- 			)}
+				className={cx('inline-flex flex-row items-baseline underline', gapClass)}
 			>
 				<IconComponent className='inline-block' fontSize='inherit' />
 				<span className='inline-block'>{children}</span>


### PR DESCRIPTION
- Fixed Farcaster URL that was pointing to GH
- Added underline to all links to be consistent
- Fixed light theme external link underline (was not visible)
- Changed navigation icons. All icons from "react-icons/lu" so they have the same size