### PR TITLE
Disallow cspell ignore comments.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -190,6 +190,7 @@
 		"replaceability",
 		"reviewable",
 		"riscv",
+		"rman",
 		"roadmap",
 		"roadmaps",
 		"rollup",

--- a/data/contributors/0xh3rman.ts
+++ b/data/contributors/0xh3rman.ts
@@ -3,7 +3,6 @@ import type { Contributor } from '@/schema/wallet'
 import { gemEntity } from '../entities/gem'
 
 export const h3rman: Contributor = {
-	// cspell:disable-next-line
 	name: '0xh3rman',
 	affiliation: [
 		{
@@ -12,6 +11,5 @@ export const h3rman: Contributor = {
 			role: 'EMPLOYEE',
 		},
 	],
-	// cspell:disable-next-line
 	url: 'https://github.com/0xh3rman',
 }

--- a/data/software-wallets/gem.ts
+++ b/data/software-wallets/gem.ts
@@ -1,4 +1,3 @@
-// cspell:disable-next-line
 import { h3rman } from '@/data/contributors/0xh3rman'
 import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'


### PR DESCRIPTION
cSpell config is shared with Harper.js so such comments are mostly ineffective.