### PR TITLE
Add external link to EIP-7702 delegation checker

### DIFF
--- a/src/ui/organisms/Eip7702Adoption.tsx
+++ b/src/ui/organisms/Eip7702Adoption.tsx
@@ -58,6 +58,16 @@ export function Eip7702Adoption(): React.JSX.Element {
 									fontSize: '0.9rem',
 								}}
 							/>
+							{' '}and{' '}
+							<ExternalLink
+								url='https://eip7702.app'
+								defaultLabel="Curvegrid's EIP-7702 delegation checker"
+								style={{
+									fontWeight: 500,
+									color: 'var(--text-primary)',
+									fontSize: '0.9rem',
+								}}
+							/>
 							!
 						</p>
 					</div>


### PR DESCRIPTION
Add a link to our EIP-7702 delegation checker to the EIP-7702 adoption page.

It's dependency free and live at [eip7702.app](https://eip7702.app/). The source code can be inspected there, it's just straightforward HTML/JS/CSS.

We've also opened an associated issue with MetaMask and added a note to an existing Rabby issue, for EIP-7702 revocation support:
- https://github.com/MetaMask/metamask-extension/issues/35520
- https://github.com/RabbyHub/Rabby/issues/3102#issuecomment-3290072789

Real world use examples:
- https://x.com/JeffInTokyo/status/1967259513519796358
- https://x.com/0xRiim/status/1967313378956784060