### PR TITLE
Update Safe data

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
 	"language": "en",
 	"words": [
 		"Aave",
+		"Ackee",
 		"Ambire",
 		"anonymizing",
 		"apikey",
@@ -201,6 +202,7 @@
 		"roadmaps",
 		"rollup",
 		"rollups",
+		"RPGF",
 		"safewallet",
 		"sandboxed",
 		"Satoshi",
@@ -218,6 +220,7 @@
 		"texlive",
 		"tmpl",
 		"toccolor",
+		"tokenomics",
 		"Tomasz",
 		"torrc",
 		"torsocks",

--- a/data/entities/ackee.ts
+++ b/data/entities/ackee.ts
@@ -1,0 +1,30 @@
+import type { CorporateEntity, SecurityAuditor } from '@/schema/entity'
+
+export const ackee: CorporateEntity & SecurityAuditor = {
+	id: 'ackee',
+	name: 'Ackee',
+	legalName: { name: 'Ackee Blockchain a.s.', soundsDifferent: false },
+	type: {
+		chainDataProvider: false,
+		corporate: true,
+		dataBroker: false,
+		exchange: false,
+		offchainDataProvider: false,
+		securityAuditor: true,
+		transactionBroadcastProvider: false,
+		walletDeveloper: false,
+	},
+	crunchbase: 'https://www.crunchbase.com/organization/ackee-blockchain',
+	farcaster: 'https://farcaster.xyz/ackee',
+	icon: {
+		extension: 'png',
+		height: 200,
+		width: 200,
+	},
+	jurisdiction: 'Prague, Czech Republic',
+	linkedin: 'https://linkedin.com/company/ackee-blockchain',
+	privacyPolicy: 'https://ackee.xyz/privacy-policy',
+	repoUrl: 'https://github.com/Ackee-Blockchain',
+	twitter: 'https://x.com/ackee_xyz',
+	url: 'https://ackee.xyz/',
+}

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -182,6 +182,7 @@ export const ambire: SoftwareWallet = {
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/coinbase.ts
+++ b/data/software-wallets/coinbase.ts
@@ -67,6 +67,7 @@ export const coinbase: SoftwareWallet = {
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -73,6 +73,7 @@ export const daimo: SoftwareWallet = {
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/elytro.ts
+++ b/data/software-wallets/elytro.ts
@@ -41,6 +41,7 @@ export const elytro: SoftwareWallet = {
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/family.ts
+++ b/data/software-wallets/family.ts
@@ -37,6 +37,7 @@ export const family: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -44,6 +44,7 @@ export const frame: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/gem.ts
+++ b/data/software-wallets/gem.ts
@@ -43,6 +43,7 @@ export const gemwallet: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -60,6 +60,7 @@ export const metamask: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -54,6 +54,7 @@ export const nufi: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -45,6 +45,7 @@ export const phantom: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -1,6 +1,6 @@
 import { nconsigny } from '@/data/contributors/nconsigny'
 import { polymutex } from '@/data/contributors/polymutex'
-import { AccountType } from '@/schema/features/account-support'
+import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import { ExposedAccountsBehavior } from '@/schema/features/privacy/app-isolation'
 import {
 	CollectionPolicy,
@@ -44,7 +44,6 @@ import { cure53 } from '../entities/cure53'
 import { deBank } from '../entities/debank'
 import { leastAuthority } from '../entities/least-authority'
 import { slowMist } from '../entities/slowmist'
-import { TransactionGenerationCapability } from '@/schema/features/account-support'
 
 export const rabby: SoftwareWallet = {
 	metadata: {
@@ -82,19 +81,21 @@ export const rabby: SoftwareWallet = {
 				canDeployNew: false,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				defaultConfig: {
+					modules: [],
 					owners: 1,
 					threshold: 1,
-					modules: [],
 				},
-				keyRotationTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				supportsKeyRotationWithoutModules: true,
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {
-					minOwners: 1,
 					maxOwners: 10,
-					supportsAnyThreshold: true,
+					minOwners: 1,
 					moduleSupport: 'partial',
+					supportsAnyThreshold: true,
 				},
-				tokenTransferTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
+				supportsKeyRotationWithoutModules: true,
+				tokenTransferTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 		},
 		addressResolution: {

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -44,6 +44,7 @@ import { cure53 } from '../entities/cure53'
 import { deBank } from '../entities/debank'
 import { leastAuthority } from '../entities/least-authority'
 import { slowMist } from '../entities/slowmist'
+import { TransactionGenerationCapability } from '@/schema/features/account-support'
 
 export const rabby: SoftwareWallet = {
 	metadata: {
@@ -77,6 +78,24 @@ export const rabby: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: supported({
+				canDeployNew: false,
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				defaultConfig: {
+					owners: 1,
+					threshold: 1,
+					modules: [],
+				},
+				keyRotationTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
+				supportsKeyRotationWithoutModules: true,
+				supportedConfigs: {
+					minOwners: 1,
+					maxOwners: 10,
+					supportsAnyThreshold: true,
+					moduleSupport: 'partial',
+				},
+				tokenTransferTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
+			}),
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -44,6 +44,7 @@ export const rainbow: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -1,6 +1,6 @@
 import { nconsigny } from '@/data/contributors/nconsigny'
-import { certora } from '@/data/entities/certora'
 import { ackee } from '@/data/entities/ackee'
+import { certora } from '@/data/entities/certora'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
 import { WalletProfile } from '@/schema/features/profile'
@@ -10,11 +10,14 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
-import { TransactionSubmissionL2Type, TransactionSubmissionL2Support } from '@/schema/features/self-sovereignty/transaction-submission'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
-import { License } from '@/schema/features/transparency/license' // assuming path
-import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display' // for level
+import {
+	TransactionSubmissionL2Support,
+	TransactionSubmissionL2Type,
+} from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
+import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display' // for level
+import { License } from '@/schema/features/transparency/license' // assuming path
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -56,19 +59,21 @@ export const safe: SoftwareWallet = {
 				canDeployNew: true,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				defaultConfig: {
+					modules: [],
 					owners: 1,
 					threshold: 1,
-					modules: [],
 				},
-				keyRotationTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				supportsKeyRotationWithoutModules: true,
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {
-					minOwners: 1,
 					maxOwners: 'unlimited',
-					supportsAnyThreshold: true,
+					minOwners: 1,
 					moduleSupport: 'full',
+					supportsAnyThreshold: true,
 				},
-				tokenTransferTransactionGeneration: TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
+				supportsKeyRotationWithoutModules: true,
+				tokenTransferTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 		},
 		addressResolution: {
@@ -96,11 +101,11 @@ export const safe: SoftwareWallet = {
 				ref: null,
 			},
 			walletCall: supported({
+				atomicMultiTransactions: featureSupported,
 				ref: {
 					explanation: 'Safe supports EIP-5792 for transaction batching.',
-					url: 'https://github.com/safe-global/safe-modules/tree/main/modules/batching',
+					url: 'https://github.com/safe-global/safe-wallet-monorepo/blob/f918ceb9b561dd3a27af96903071cd56c1fb5ddd/apps/web/src/services/safe-wallet-provider/index.ts#L184',
 				},
-				atomicMultiTransactions: featureSupported,
 			}),
 		},
 		license: {
@@ -116,19 +121,23 @@ export const safe: SoftwareWallet = {
 		monetization: {
 			ref: [
 				{
-					explanation: 'SafeDAO has received ecosystem grants; example Optimism grant proposal in the Optimism governance forum.',
+					explanation:
+						'SafeDAO has received ecosystem grants; example Optimism grant proposal in the Optimism governance forum.',
 					url: 'https://gov.optimism.io/t/draft-gf-phase-1-proposal-old-template-safe/3400',
 				},
 				{
-					explanation: 'Safe community updates covering grants and RPGF-related support across ecosystems.',
+					explanation:
+						'Safe community updates covering grants and RPGF-related support across ecosystems.',
 					url: 'https://forum.safe.global/t/safedao-community-updates/4213',
 				},
 				{
-					explanation: 'Community‑Aligned Fees: revenue (e.g., Native Swaps) pledged to SafeDAO; fee approach is explained publicly.',
+					explanation:
+						'Community‑Aligned Fees: revenue (e.g., Native Swaps) pledged to SafeDAO; fee approach is explained publicly.',
 					url: 'https://safefoundation.org/blog/safedao-community-aligned-fees-introduction',
 				},
 				{
-					explanation: 'SAFE tokenomics and governance scope; currently primarily used for SafeDAO treasury resource allocation (e.g., grants).',
+					explanation:
+						'SAFE tokenomics and governance scope; currently primarily used for SafeDAO treasury resource allocation (e.g., grants).',
 					url: 'https://safefoundation.org/blog/safe-tokenomics',
 				},
 			],
@@ -242,29 +251,38 @@ export const safe: SoftwareWallet = {
 			transactionSubmission: {
 				l1: {
 					selfBroadcastViaDirectGossip: notSupported,
-					selfBroadcastViaSelfHostedNode: featureSupported
+					selfBroadcastViaSelfHostedNode: featureSupported,
 				},
 				l2: {
-					[TransactionSubmissionL2Type.arbitrum]: TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
-					[TransactionSubmissionL2Type.opStack]: TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					[TransactionSubmissionL2Type.arbitrum]:
+						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					[TransactionSubmissionL2Type.opStack]:
+						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 				},
 			},
 		},
 		transparency: {
 			operationFees: {
-				ethL1Transfer: supported({
-					byDefault: FeeDisplayLevel.COMPREHENSIVE,
+				builtInErc20Swap: supported({
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,
 				}),
 				erc20L1Transfer: supported({
-					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,
 				}),
-				builtInErc20Swap: null,
-				uniswapUSDCToEtherSwap: null,
-				// add other required fields as null or with values
+				ethL1Transfer: supported({
+					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+					byDefault: FeeDisplayLevel.COMPREHENSIVE,
+					fullySponsored: false,
+				}),
+				uniswapUSDCToEtherSwap: supported({
+					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+					byDefault: FeeDisplayLevel.COMPREHENSIVE,
+					fullySponsored: false,
+				}),
 			},
 		},
 	},

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -42,6 +42,7 @@ export const zerion: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: notSupported,
+			safe: notSupported,
 		},
 		addressResolution: {
 			chainSpecificAddressing: {

--- a/src/schema/attributes/ecosystem/account-abstraction.ts
+++ b/src/schema/attributes/ecosystem/account-abstraction.ts
@@ -14,6 +14,7 @@ import {
 	type AccountTypeEoa,
 	type AccountTypeMpc,
 	type AccountTypeMutableMultifactor,
+	type AccountTypeSafe,
 	isAccountTypeSupported,
 } from '@/schema/features/account-support'
 import { mergeRefs, type ReferenceArray, refs } from '@/schema/reference'
@@ -229,6 +230,7 @@ export const accountAbstraction: Attribute<AccountAbstractionValue> = {
 		const supported: Record<AccountType, boolean> = {
 			eoa: isAccountTypeSupported<AccountTypeEoa>(features.accountSupport.eoa),
 			mpc: isAccountTypeSupported<AccountTypeMpc>(features.accountSupport.mpc),
+			safe: isAccountTypeSupported<AccountTypeSafe>(features.accountSupport.safe),
 			rawErc4337: isAccountTypeSupported<AccountTypeMutableMultifactor>(
 				features.accountSupport.rawErc4337,
 			),

--- a/src/schema/attributes/ecosystem/transaction-batching.ts
+++ b/src/schema/attributes/ecosystem/transaction-batching.ts
@@ -195,6 +195,7 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 					{
 						eoa: notSupported,
 						mpc: notSupported,
+						safe: notSupported,
 						eip7702: notSupported,
 						rawErc4337: notSupported,
 						defaultAccountType: AccountType.eoa,
@@ -210,6 +211,7 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 					{
 						eoa: notSupported,
 						mpc: notSupported,
+						safe: notSupported,
 						eip7702: supported({
 							contract: 'UNKNOWN',
 						}),
@@ -228,6 +230,7 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 				{
 					eoa: notSupported,
 					mpc: notSupported,
+					safe: notSupported,
 					eip7702: supported({
 						contract: 'UNKNOWN',
 					}),
@@ -247,6 +250,7 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 				{
 					eoa: notSupported,
 					mpc: notSupported,
+					safe: notSupported,
 					eip7702: supported({
 						contract: 'UNKNOWN',
 					}),

--- a/src/schema/attributes/self-sovereignty/account-portability.ts
+++ b/src/schema/attributes/self-sovereignty/account-portability.ts
@@ -414,7 +414,6 @@ function evaluateSafe(
 	safe: AccountTypeSafe,
 	references: ReferenceArray,
 ): Evaluation<AccountPortabilityValue> {
-	// Similar to multifactor, but for Safe
 	if (safe.keyRotationTransactionGeneration === TransactionGenerationCapability.IMPOSSIBLE) {
 		return {
 			value: {
@@ -440,8 +439,6 @@ function evaluateSafe(
 		}
 	}
 
-	// Add other conditions similar to multifactor
-	// For simplicity, assume pass if supports key rotation without external provider
 	return {
 		value: {
 			id: 'safe_ok',
@@ -846,7 +843,9 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 
 		if (isSupported<AccountTypeSafe>(features.accountSupport.safe)) {
 			const evaluation = evaluateSafe(features.accountSupport.safe, allRefs)
+
 			evaluations.push(evaluation)
+
 			if (features.accountSupport.defaultAccountType === AccountType.safe) {
 				defaultEvaluation = evaluation
 			}

--- a/src/schema/attributes/self-sovereignty/account-portability.ts
+++ b/src/schema/attributes/self-sovereignty/account-portability.ts
@@ -16,6 +16,7 @@ import {
 	type AccountTypeEoa,
 	type AccountTypeMpc,
 	type AccountTypeMutableMultifactor,
+	type AccountTypeSafe, // add this
 	TransactionGenerationCapability,
 } from '@/schema/features/account-support'
 import { isSupported } from '@/schema/features/support'
@@ -409,6 +410,55 @@ function evaluateMultifactor(
 	}
 }
 
+function evaluateSafe(
+	safe: AccountTypeSafe,
+	references: ReferenceArray,
+): Evaluation<AccountPortabilityValue> {
+	// Similar to multifactor, but for Safe
+	if (safe.keyRotationTransactionGeneration === TransactionGenerationCapability.IMPOSSIBLE) {
+		return {
+			value: {
+				id: 'safe_cannot_rotate_authority',
+				rating: Rating.FAIL,
+				icon: '\u{1faa4}', // Mouse trap
+				displayName: 'Not a self-custodial wallet',
+				shortExplanation: sentence(
+					'{{WALLET_NAME}} is not self-custodial, and cannot be converted to become self-custodial.',
+				),
+				__brand: brand,
+			},
+			details: mdParagraph(
+				'{{WALLET_NAME}} is a Safe multisig wallet. The account control logic cannot be updated to put the user fully in control of the account.',
+			),
+			impact: paragraph(
+				'{{WALLET_NAME}} is not a self-custodial wallet and users cannot update it into one. Users of {{WALLET_NAME}} are therefore not in control of their account.',
+			),
+			howToImprove: paragraph(
+				'{{WALLET_NAME}} should update the control logic to allow users to take full control of the account.',
+			),
+			references,
+		}
+	}
+
+	// Add other conditions similar to multifactor
+	// For simplicity, assume pass if supports key rotation without external provider
+	return {
+		value: {
+			id: 'safe_ok',
+			rating: Rating.PASS,
+			displayName: 'Self-custodial Safe wallet',
+			shortExplanation: sentence(
+				'{{WALLET_NAME}} is self-custodial and puts the user in control of their Safe wallet without lock-in.',
+			),
+			__brand: brand,
+		},
+		details: mdParagraph(
+			'{{WALLET_NAME}} is a Safe multisig wallet. By default, the user holds sufficient authority to generate and broadcast arbitrary transactions and can do so without relying on an external provider, including transactions which update the control logic (e.g., for owner changes).',
+		),
+		references,
+	}
+}
+
 function evaluateEip7702(
 	accountSupport: AccountSupport,
 	references: ReferenceArray,
@@ -790,6 +840,14 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 			evaluations.push(evaluation)
 
 			if (features.accountSupport.defaultAccountType === AccountType.eip7702) {
+				defaultEvaluation = evaluation
+			}
+		}
+
+		if (isSupported<AccountTypeSafe>(features.accountSupport.safe)) {
+			const evaluation = evaluateSafe(features.accountSupport.safe, allRefs)
+			evaluations.push(evaluation)
+			if (features.accountSupport.defaultAccountType === AccountType.safe) {
 				defaultEvaluation = evaluation
 			}
 		}

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -226,30 +226,30 @@ export type AccountType7702 = SmartAccountType
 /** Support information for Safe multisig accounts. */
 export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
 	/** Can the wallet deploy new Safe contracts? */
-	canDeployNew: boolean;
+	canDeployNew: boolean
 
 	/** Default configuration when creating a new Safe. */
 	defaultConfig: {
 		/** Number of owners by default. */
-		owners: number;
+		owners: number
 		/** Signature threshold by default. */
-		threshold: number;
+		threshold: number
 		/** Enabled modules by default. */
-		modules: string[]; // or more specific type if needed
-	};
+		modules: string[] // or more specific type if needed
+	}
 
 	/** Does the wallet support key rotation without additional modules? */
-	supportsKeyRotationWithoutModules: boolean;
+	supportsKeyRotationWithoutModules: boolean
 
 	/** Supported configurations for existing Safes. */
 	supportedConfigs: {
 		/** Minimum number of owners supported. */
-		minOwners: number;
+		minOwners: number
 		/** Maximum number of owners supported (or 'unlimited'). */
-		maxOwners: number | 'unlimited';
+		maxOwners: number | 'unlimited'
 		/** Whether any threshold is supported. */
-		supportsAnyThreshold: boolean;
+		supportsAnyThreshold: boolean
 		/** Level of module support. */
-		moduleSupport: 'none' | 'partial' | 'full';
-	};
+		moduleSupport: 'none' | 'partial' | 'full'
+	}
 }

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -34,6 +34,8 @@ export enum AccountType {
 	 * smart contract code.
 	 */
 	rawErc4337 = 'rawErc4337',
+	/** Safe multisig smart contract account. */
+	safe = 'safe',
 }
 
 const allAccountTypes: NonEmptyArray<AccountType> = [
@@ -41,6 +43,7 @@ const allAccountTypes: NonEmptyArray<AccountType> = [
 	AccountType.mpc,
 	AccountType.rawErc4337,
 	AccountType.eip7702,
+	AccountType.safe,
 ]
 
 /** The ability (or lack thereof) to generate a transaction of a specific type. */
@@ -87,6 +90,8 @@ export type AccountSupport = Exclude<
 		 * address matches the contract code).
 		 */
 		rawErc4337: AccountTypeSupport<AccountType4337>
+		/** Support for Safe multisig accounts. */
+		safe: AccountTypeSupport<AccountTypeSafe>
 	},
 	// At least one account type must be supported.
 	Record<AccountType, NotSupported>
@@ -217,3 +222,34 @@ export type AccountType4337 = AccountTypeMutableMultifactor & SmartAccountType
  * Support information for EIP-7702 accounts.
  */
 export type AccountType7702 = SmartAccountType
+
+/** Support information for Safe multisig accounts. */
+export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
+	/** Can the wallet deploy new Safe contracts? */
+	canDeployNew: boolean;
+
+	/** Default configuration when creating a new Safe. */
+	defaultConfig: {
+		/** Number of owners by default. */
+		owners: number;
+		/** Signature threshold by default. */
+		threshold: number;
+		/** Enabled modules by default. */
+		modules: string[]; // or more specific type if needed
+	};
+
+	/** Does the wallet support key rotation without additional modules? */
+	supportsKeyRotationWithoutModules: boolean;
+
+	/** Supported configurations for existing Safes. */
+	supportedConfigs: {
+		/** Minimum number of owners supported. */
+		minOwners: number;
+		/** Maximum number of owners supported (or 'unlimited'). */
+		maxOwners: number | 'unlimited';
+		/** Whether any threshold is supported. */
+		supportsAnyThreshold: boolean;
+		/** Level of module support. */
+		moduleSupport: 'none' | 'partial' | 'full';
+	};
+}


### PR DESCRIPTION
Add Ackee corporate entity definition and update software wallets with 'safe' support attribute

- Introduced a new corporate entity for Ackee with relevant details.
- Added 'safe' support attribute to multiple software wallets including Ambire, Coinbase, Daimo, Elytros, Family, Frame, Gem, Metamask, Nufi, Phantom, Rainbow, and Zerion.
- Enhanced account portability evaluation to include Safe multisig accounts.
- Updated account support schema to recognize Safe as a new account type.