### PR TITLE
Make `ref`s explicit, add `Nullable` feature fields.

### DIFF
--- a/data/embedded-wallets/unrated.tmpl.ts
+++ b/data/embedded-wallets/unrated.tmpl.ts
@@ -1,5 +1,6 @@
 import { exampleContributor } from '@/data/contributors/example'
 import { WalletProfile } from '@/schema/features/profile'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { EmbeddedWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -24,7 +25,7 @@ export const unratedEmbeddedTemplate: EmbeddedWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,

--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -17,6 +17,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -47,16 +48,16 @@ export const bitboxWallet: HardwareWallet = {
 	features: {
 		accountSupport: null,
 		license: {
-			license: License.APACHE_2_0,
 			ref: [
 				{
 					explanation: 'BitBox02 firmware is fully open source and verified by WalletScrutiny',
 					url: 'https://github.com/BitBoxSwiss/bitbox02-firmware',
 				},
 			],
+			license: License.APACHE_2_0,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -76,6 +77,13 @@ export const bitboxWallet: HardwareWallet = {
 				[UserFlow.UNCLASSIFIED]: {
 					collected: [
 						{
+							ref: [
+								{
+									explanation:
+										'BitBoxApp sends IP address for update checks and uses BitBox backend servers for Bitcoin address lookups',
+									url: 'https://bitbox.swiss/policies/privacy-policy/',
+								},
+							],
 							byEntity: bitbox,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.BY_DEFAULT,
@@ -84,15 +92,15 @@ export const bitboxWallet: HardwareWallet = {
 								endpoint: RegularEndpoint,
 							},
 							purposes: [DataCollectionPurpose.ANALYTICS],
+						},
+						{
 							ref: [
 								{
 									explanation:
-										'BitBoxApp sends IP address for update checks and uses BitBox backend servers for Bitcoin address lookups',
+										'BitBoxApp uses Etherscan to query Ethereum and ERC20 token account information',
 									url: 'https://bitbox.swiss/policies/privacy-policy/',
 								},
 							],
-						},
-						{
 							byEntity: etherscan,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.BY_DEFAULT,
@@ -103,13 +111,6 @@ export const bitboxWallet: HardwareWallet = {
 							purposes: [
 								DataCollectionPurpose.CHAIN_DATA_LOOKUP,
 								DataCollectionPurpose.ASSET_METADATA,
-							],
-							ref: [
-								{
-									explanation:
-										'BitBoxApp uses Etherscan to query Ethereum and ERC20 token account information',
-									url: 'https://bitbox.swiss/policies/privacy-policy/',
-								},
 							],
 						},
 					],
@@ -135,13 +136,13 @@ export const bitboxWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.DISCLOSURE_ONLY,
-				details:
-					'BitBox maintains a comprehensive bug bounty program with a Hall of Thanks, clear disclosure process, and PGP-encrypted communication.',
 				ref: [
 					{
 						url: 'https://bitbox.swiss/bug-bounty-program/',
 					},
 				],
+				details:
+					'BitBox maintains a comprehensive bug bounty program with a Hall of Thanks, clear disclosure process, and PGP-encrypted communication.',
 				upgradePathAvailable: true,
 				url: 'https://bitbox.swiss/bug-bounty-program/',
 			},
@@ -153,6 +154,12 @@ export const bitboxWallet: HardwareWallet = {
 				silentUpdateProtection: FirmwareType.PASS,
 			},
 			hardwareWalletAppSigning: {
+				ref: [
+					{
+						explanation: 'Independent video demonstration of BitBox02 signing capabilities',
+						url: 'https://youtu.be/-m1jcBFS0dc?t=300',
+					},
+				],
 				messageSigning: {
 					calldataDecoding: noCalldataDecoding,
 					details:
@@ -163,12 +170,6 @@ export const bitboxWallet: HardwareWallet = {
 						[DataExtraction.QRCODE]: false,
 					},
 				},
-				ref: [
-					{
-						explanation: 'Independent video demonstration of BitBox02 signing capabilities',
-						url: 'https://youtu.be/-m1jcBFS0dc?t=300',
-					},
-				],
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: {

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -8,6 +8,7 @@ import {
 	noDataExtraction,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -38,16 +39,16 @@ export const cypherockWallet: HardwareWallet = {
 	features: {
 		accountSupport: null,
 		license: {
-			license: License.MIT_WITH_CLAUSE,
 			ref: [
 				{
 					explanation: 'Cypherock is open-source and reproducible',
 					url: 'https://github.com/Cypherock/x1_wallet_firmware/blob/main/LICENSE.md',
 				},
 			],
+			license: License.MIT_WITH_CLAUSE,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -72,8 +73,6 @@ export const cypherockWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.BASIC,
-				details:
-					'Cypherock provides legal protection for security researchers and discretionary rewards for valid security issues affecting X1 Wallet and X1 Card.',
 				ref: [
 					{
 						explanation:
@@ -81,6 +80,8 @@ export const cypherockWallet: HardwareWallet = {
 						url: 'https://cypherock.com/bug-bounty',
 					},
 				],
+				details:
+					'Cypherock provides legal protection for security researchers and discretionary rewards for valid security issues affecting X1 Wallet and X1 Card.',
 				upgradePathAvailable: true,
 				url: 'https://cypherock.com/bug-bounty',
 			},
@@ -92,16 +93,6 @@ export const cypherockWallet: HardwareWallet = {
 				silentUpdateProtection: FirmwareType.PASS,
 			},
 			hardwareWalletAppSigning: {
-				messageSigning: {
-					calldataDecoding: noCalldataDecoding,
-					details:
-						'Shows EIP-712 signature data only in the companion application, not on the hardware wallet itself.',
-					messageExtraction: {
-						[DataExtraction.EYES]: true,
-						[DataExtraction.HASHES]: false,
-						[DataExtraction.QRCODE]: false,
-					},
-				},
 				ref: [
 					{
 						explanation: "Independent video demonstration of Cypherock's signing implementation.",
@@ -113,6 +104,16 @@ export const cypherockWallet: HardwareWallet = {
 						url: 'https://youtube.com/shorts/YG6lzwTUojE',
 					},
 				],
+				messageSigning: {
+					calldataDecoding: noCalldataDecoding,
+					details:
+						'Shows EIP-712 signature data only in the companion application, not on the hardware wallet itself.',
+					messageExtraction: {
+						[DataExtraction.EYES]: true,
+						[DataExtraction.HASHES]: false,
+						[DataExtraction.QRCODE]: false,
+					},
+				},
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: noDataExtraction,

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -1,6 +1,7 @@
 import { nconsigny } from '@/data/contributors/nconsigny'
 import { HardwareWalletManufactureType, WalletProfile } from '@/schema/features/profile'
 import { BugBountyProgramType } from '@/schema/features/security/bug-bounty-program'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -33,7 +34,7 @@ export const fireflyWallet: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -58,20 +59,20 @@ export const fireflyWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.NONE,
+				ref: refTodo,
 				details: 'No formal bug bounty program has been established for the Firefly DIY wallet.',
-				ref: undefined,
 				upgradePathAvailable: false,
 				url: '',
 			},
 			firmware: null,
 			hardwareWalletAppSigning: {
+				ref: refTodo,
 				messageSigning: {
 					calldataDecoding: null,
 					details:
 						'Firefly currently does not provide message signing support as it is still in development.',
 					messageExtraction: null,
 				},
-				ref: null,
 				transactionSigning: {
 					calldataDecoding: null,
 					calldataExtraction: null,

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -6,6 +6,7 @@ import {
 	DataExtraction,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -38,7 +39,7 @@ export const gridplusWallet: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -63,8 +64,6 @@ export const gridplusWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'GridPlus pledges not to initiate legal action for security research conducted pursuant to all Bug Bounty Program policies, including good faith, accidental violations',
 				ref: [
 					{
 						explanation:
@@ -72,11 +71,25 @@ export const gridplusWallet: HardwareWallet = {
 						url: 'https://docs.gridplus.io/resources/bug-bounty-and-responsible-disclosure-policy',
 					},
 				],
+				details:
+					'GridPlus pledges not to initiate legal action for security research conducted pursuant to all Bug Bounty Program policies, including good faith, accidental violations',
 				upgradePathAvailable: true,
 				url: 'https://docs.gridplus.io/resources/bug-bounty-and-responsible-disclosure-policy',
 			},
 			firmware: null,
 			hardwareWalletAppSigning: {
+				ref: [
+					{
+						explanation:
+							"Independent video demonstration of GridPlus's clear signing implementation on Safe.",
+						url: 'https://youtu.be/9YmPWxAvKYY?t=2079',
+					},
+					{
+						explanation:
+							"Independent video demonstration of GridPlus's transaction implementation on Safe.",
+						url: 'https://youtube.com/shorts/_s5PjZhgBig',
+					},
+				],
 				messageSigning: {
 					calldataDecoding: {
 						[CalldataDecoding.ETH_USDC_TRANSFER]: true,
@@ -93,18 +106,6 @@ export const gridplusWallet: HardwareWallet = {
 						[DataExtraction.QRCODE]: false,
 					},
 				},
-				ref: [
-					{
-						explanation:
-							"Independent video demonstration of GridPlus's clear signing implementation on Safe.",
-						url: 'https://youtu.be/9YmPWxAvKYY?t=2079',
-					},
-					{
-						explanation:
-							"Independent video demonstration of GridPlus's transaction implementation on Safe.",
-						url: 'https://youtube.com/shorts/_s5PjZhgBig',
-					},
-				],
 				transactionSigning: {
 					calldataDecoding: {
 						[CalldataDecoding.ETH_USDC_TRANSFER]: true,

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -7,6 +7,7 @@ import {
 	DataExtraction,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -39,7 +40,7 @@ export const keystoneWallet: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -64,8 +65,6 @@ export const keystoneWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'The Keystone Bug Bounty Program is designed to encourage security research in Keystone hardware and software to award them for their invaluable contribution to the security of all Keystone users.',
 				ref: [
 					{
 						explanation:
@@ -73,6 +72,8 @@ export const keystoneWallet: HardwareWallet = {
 						url: 'https://keyst.one/bug-bounty-program',
 					},
 				],
+				details:
+					'The Keystone Bug Bounty Program is designed to encourage security research in Keystone hardware and software to award them for their invaluable contribution to the security of all Keystone users.',
 				upgradePathAvailable: false,
 				url: 'https://keyst.one/bug-bounty-program',
 			},
@@ -84,6 +85,18 @@ export const keystoneWallet: HardwareWallet = {
 				silentUpdateProtection: FirmwareType.PASS,
 			},
 			hardwareWalletAppSigning: {
+				ref: [
+					{
+						explanation:
+							"Independent video demonstration of Keystone's signing implementation on a Safe.",
+						url: 'https://youtu.be/9YmPWxAvKYY?t=759',
+					},
+					{
+						explanation:
+							"Independent video demonstration of Keystone's transaction implementation on a Safe.",
+						url: 'https://youtube.com/shorts/Ly9lo4g5NpA',
+					},
+				],
 				messageSigning: {
 					calldataDecoding: {
 						[CalldataDecoding.ETH_USDC_TRANSFER]: true,
@@ -100,18 +113,6 @@ export const keystoneWallet: HardwareWallet = {
 						[DataExtraction.QRCODE]: true,
 					},
 				},
-				ref: [
-					{
-						explanation:
-							"Independent video demonstration of Keystone's signing implementation on a Safe.",
-						url: 'https://youtu.be/9YmPWxAvKYY?t=759',
-					},
-					{
-						explanation:
-							"Independent video demonstration of Keystone's transaction implementation on a Safe.",
-						url: 'https://youtube.com/shorts/Ly9lo4g5NpA',
-					},
-				],
 				transactionSigning: {
 					calldataDecoding: {
 						[CalldataDecoding.ETH_USDC_TRANSFER]: true,

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -7,6 +7,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -63,7 +64,7 @@ export const ledgerWallet: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -88,8 +89,6 @@ export const ledgerWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'Ledger offers a comprehensive bug bounty program through their Donjon security team. The program offers competitive rewards based on the severity of findings and has a clear disclosure process.',
 				ref: [
 					{
 						explanation:
@@ -97,11 +96,20 @@ export const ledgerWallet: HardwareWallet = {
 						url: 'https://donjon.ledger.com/bounty/',
 					},
 				],
+				details:
+					'Ledger offers a comprehensive bug bounty program through their Donjon security team. The program offers competitive rewards based on the severity of findings and has a clear disclosure process.',
 				upgradePathAvailable: true,
 				url: 'https://donjon.ledger.com/bounty/',
 			},
 			firmware: null,
 			hardwareWalletAppSigning: {
+				ref: [
+					{
+						explanation:
+							"Independent video demonstration of Ledger's signing implementation on a Safe.",
+						url: 'https://youtu.be/9YmPWxAvKYY?t=1722',
+					},
+				],
 				messageSigning: {
 					calldataDecoding: noCalldataDecoding,
 					details:
@@ -112,13 +120,6 @@ export const ledgerWallet: HardwareWallet = {
 						[DataExtraction.QRCODE]: false,
 					},
 				},
-				ref: [
-					{
-						explanation:
-							"Independent video demonstration of Ledger's signing implementation on a Safe.",
-						url: 'https://youtu.be/9YmPWxAvKYY?t=1722',
-					},
-				],
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: {
@@ -136,8 +137,8 @@ export const ledgerWallet: HardwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			supplyChainDIY: null,

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -6,6 +6,7 @@ import {
 	noDataExtraction,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -36,16 +37,16 @@ export const ngrave: HardwareWallet = {
 	features: {
 		accountSupport: null,
 		license: {
-			license: License.PROPRIETARY,
 			ref: [
 				{
 					explanation: 'NGRAVE is not open source',
 					url: 'https://youtu.be/-m1jcBFS0dc?t=701',
 				},
 			],
+			license: License.PROPRIETARY,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -71,6 +72,12 @@ export const ngrave: HardwareWallet = {
 			bugBountyProgram: null,
 			firmware: null,
 			hardwareWalletAppSigning: {
+				ref: [
+					{
+						explanation: 'Independent video demonstration of NGRAVE Zero signing issues',
+						url: 'https://youtu.be/-m1jcBFS0dc?t=701',
+					},
+				],
 				messageSigning: {
 					calldataDecoding: noCalldataDecoding,
 					details:
@@ -81,12 +88,6 @@ export const ngrave: HardwareWallet = {
 						[DataExtraction.QRCODE]: false,
 					},
 				},
-				ref: [
-					{
-						explanation: 'Independent video demonstration of NGRAVE Zero signing issues',
-						url: 'https://youtu.be/-m1jcBFS0dc?t=701',
-					},
-				],
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: noDataExtraction,

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -8,6 +8,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -38,16 +39,16 @@ export const onekeyWallet: HardwareWallet = {
 	features: {
 		accountSupport: null,
 		license: {
-			license: License.GPL_3_0,
 			ref: [
 				{
 					explanation: 'OneKey has mixed licensing (GPLv3/LGPLv3/MIT)',
 					url: 'https://walletscrutiny.com/hardware/onekey.pro/',
 				},
 			],
+			license: License.GPL_3_0,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -72,8 +73,6 @@ export const onekeyWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'OneKey offers a comprehensive bug bounty program covering app monorepo, firmware, hardware SDK, and websites. Rewards range from $100-$10,000 USDC based on severity, with higher rewards for firmware vulnerabilities.',
 				ref: [
 					{
 						explanation:
@@ -81,6 +80,8 @@ export const onekeyWallet: HardwareWallet = {
 						url: 'https://bugrap.io/bounties/OneKey',
 					},
 				],
+				details:
+					'OneKey offers a comprehensive bug bounty program covering app monorepo, firmware, hardware SDK, and websites. Rewards range from $100-$10,000 USDC based on severity, with higher rewards for firmware vulnerabilities.',
 				upgradePathAvailable: false,
 				url: 'https://bugrap.io/bounties/OneKey',
 			},
@@ -92,16 +93,6 @@ export const onekeyWallet: HardwareWallet = {
 				silentUpdateProtection: null,
 			},
 			hardwareWalletAppSigning: {
-				messageSigning: {
-					calldataDecoding: noCalldataDecoding,
-					details:
-						'OneKey Pro shows EIP-712 domain types and message data but does not display domain hash or message hash for easier verification.',
-					messageExtraction: {
-						[DataExtraction.EYES]: true,
-						[DataExtraction.HASHES]: false,
-						[DataExtraction.QRCODE]: false,
-					},
-				},
 				ref: [
 					{
 						explanation:
@@ -113,6 +104,16 @@ export const onekeyWallet: HardwareWallet = {
 						url: 'https://youtube.com/shorts/J_XG7cNOVhM',
 					},
 				],
+				messageSigning: {
+					calldataDecoding: noCalldataDecoding,
+					details:
+						'OneKey Pro shows EIP-712 domain types and message data but does not display domain hash or message hash for easier verification.',
+					messageExtraction: {
+						[DataExtraction.EYES]: true,
+						[DataExtraction.HASHES]: false,
+						[DataExtraction.QRCODE]: false,
+					},
+				},
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: {

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -7,6 +7,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -57,7 +58,7 @@ export const trezorWallet: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -82,8 +83,6 @@ export const trezorWallet: HardwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'At SatoshiLabs and Trezor, the safety of our products and services is a top priority. If you have identified a security vulnerability, we would greatly appreciate your assistance in disclosing it to us in a responsible manner.',
 				ref: [
 					{
 						explanation:
@@ -91,21 +90,13 @@ export const trezorWallet: HardwareWallet = {
 						url: 'https://trezor.io/support/a/how-to-report-a-security-issue',
 					},
 				],
+				details:
+					'At SatoshiLabs and Trezor, the safety of our products and services is a top priority. If you have identified a security vulnerability, we would greatly appreciate your assistance in disclosing it to us in a responsible manner.',
 				upgradePathAvailable: true,
 				url: 'https://trezor.io/support/a/how-to-report-a-security-issue',
 			},
 			firmware: null,
 			hardwareWalletAppSigning: {
-				messageSigning: {
-					calldataDecoding: noCalldataDecoding,
-					details:
-						'Trezor provides basic message signing details when using hardware wallets, but some complex interactions may be difficult to verify off device.',
-					messageExtraction: {
-						[DataExtraction.EYES]: true,
-						[DataExtraction.HASHES]: false,
-						[DataExtraction.QRCODE]: false,
-					},
-				},
 				ref: [
 					{
 						explanation:
@@ -117,6 +108,16 @@ export const trezorWallet: HardwareWallet = {
 						url: 'https://youtube.com/shorts/4LayLrSuHNg',
 					},
 				],
+				messageSigning: {
+					calldataDecoding: noCalldataDecoding,
+					details:
+						'Trezor provides basic message signing details when using hardware wallets, but some complex interactions may be difficult to verify off device.',
+					messageExtraction: {
+						[DataExtraction.EYES]: true,
+						[DataExtraction.HASHES]: false,
+						[DataExtraction.QRCODE]: false,
+					},
+				},
 				transactionSigning: {
 					calldataDecoding: noCalldataDecoding,
 					calldataExtraction: {
@@ -138,8 +139,8 @@ export const trezorWallet: HardwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			supplyChainDIY: null,

--- a/data/hardware-wallets/unrated.tmpl.ts
+++ b/data/hardware-wallets/unrated.tmpl.ts
@@ -1,5 +1,6 @@
 import { exampleContributor } from '@/data/contributors/example'
 import { WalletProfile } from '@/schema/features/profile'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -24,7 +25,7 @@ export const unratedHardwareTemplate: HardwareWallet = {
 		accountSupport: null,
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -20,13 +20,14 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import type { SecurityAudit } from '@/schema/features/security/security-audits'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import { TransactionSubmissionL2Support } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
-import type { References } from '@/schema/reference'
+import { type References, refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -44,6 +45,7 @@ import { ambireDelegatorContract } from '../wallet-contracts/ambire-delegator'
 
 const v2Audits: SecurityAudit[] = [
 	{
+		ref: 'https://github.com/AmbireTech/ambire-common/blob/v2/audits/Pashov-Ambire-third-security-review.md',
 		auditDate: '2024-01-26',
 		auditor: pashov,
 		codeSnapshot: {
@@ -51,11 +53,11 @@ const v2Audits: SecurityAudit[] = [
 				'https://github.com/AmbireTech/ambire-common/tree/da3ba641a004d1f0143a20ddde48049b619431ad',
 			date: '2023-11-08',
 		},
-		ref: 'https://github.com/AmbireTech/ambire-common/blob/v2/audits/Pashov-Ambire-third-security-review.md',
 		unpatchedFlaws: 'ALL_FIXED',
 		variantsScope: { [Variant.BROWSER]: true },
 	},
 	{
+		ref: 'https://github.com/AmbireTech/ambire-common/blob/v2/audits/Ambire-EIP-7702-Update-Hunter-Security-Audit-Report-0.1.pdf',
 		auditDate: '2025-02-20',
 		auditor: hunterSecurity,
 		codeSnapshot: {
@@ -63,7 +65,6 @@ const v2Audits: SecurityAudit[] = [
 				'https://github.com/AmbireTech/ambire-common/commit/de88e26041db8777468f384e56d5ad0cb96e29a5',
 			date: '2025-02-17',
 		},
-		ref: 'https://github.com/AmbireTech/ambire-common/blob/v2/audits/Ambire-EIP-7702-Update-Hunter-Security-Audit-Report-0.1.pdf',
 		unpatchedFlaws: 'NONE_FOUND',
 		variantsScope: { [Variant.BROWSER]: true },
 	},
@@ -152,14 +153,15 @@ export const ambire: SoftwareWallet = {
 		accountSupport: {
 			defaultAccountType: AccountType.eip7702,
 			eip7702: supported({
-				contract: ambireDelegatorContract,
 				ref: {
 					explanation:
 						'Ambire is AA wallet by default. With the introduction of EIP-7702 it allows you to use your existing EOA just like you would use any smart account wallet!',
 					url: 'https://blog.ambire.com/eip-7702-wallet',
 				},
+				contract: ambireDelegatorContract,
 			}),
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				canExportSeedPhrase: true,
 				keyDerivation: {
@@ -171,20 +173,21 @@ export const ambire: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: supported({
-				contract: ambireAccountContract,
-				controllingSharesInSelfCustodyByDefault: 'YES',
-				keyRotationTransactionGeneration:
-					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				ref: {
 					explanation: 'Ambire supports ERC-4337 smart contract wallets',
 					url: 'https://github.com/AmbireTech/ambire-common/blob/v2/contracts/AmbireAccount.sol',
 				},
+				contract: ambireAccountContract,
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: notSupported,
 				erc7831: notSupported,
@@ -198,47 +201,44 @@ export const ambire: SoftwareWallet = {
 			bridging: {
 				/** Does the wallet have a built-in bridging feature? */
 				builtInBridging: supported({
-					feesLargerThan1bps: comprehensiveFeesShownByDefault,
 					ref: {
 						explanation: 'All fees are displayed when agreeing to the bridge',
 						url: 'https://www.ambire.com/',
 					},
+					feesLargerThan1bps: comprehensiveFeesShownByDefault,
 					risksExplained: 'NOT_IN_UI',
 				}),
 				suggestedBridging: notSupported,
 			},
 			crossChainBalances: {
-				ether: supported({
-					crossChainSumView: notSupported,
-					perChainBalanceViewAcrossMultipleChains: featureSupported,
-					ref: {
-						explanation: 'Ambire supports filtering by token name.',
-						label: 'Implementation of token filtering by name',
-						url: 'https://github.com/AmbireTech/extension/blob/main/src/common/modules/dashboard/components/Tokens/Tokens.tsx#L89-L106',
-					},
-				}),
-				globalAccountValue: featureSupported,
-				perChainAccountValue: featureSupported,
 				ref: {
 					explanation:
 						'Ambire supports filtering by token name and chain, as well as displaying the total balance from the resulting tokens',
 					label: 'Implementation of token filtering by name',
 					url: 'https://github.com/AmbireTech/extension/blob/main/src/common/modules/dashboard/components/Tokens/Tokens.tsx#L89-L106',
 				},
-				usdc: supported({
+				ether: supported({
+					ref: {
+						explanation: 'Ambire supports filtering by token name.',
+						label: 'Implementation of token filtering by name',
+						url: 'https://github.com/AmbireTech/extension/blob/main/src/common/modules/dashboard/components/Tokens/Tokens.tsx#L89-L106',
+					},
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: featureSupported,
+				}),
+				globalAccountValue: featureSupported,
+				perChainAccountValue: featureSupported,
+				usdc: supported({
 					ref: {
 						explanation: 'Ambire supports filtering by token name.',
 						url: 'https://www.ambire.com/',
 					},
+					crossChainSumView: notSupported,
+					perChainBalanceViewAcrossMultipleChains: featureSupported,
 				}),
 			},
 		},
 		chainConfigurability: {
-			customChains: true,
-			l1RpcEndpoint: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
-			otherRpcEndpoints: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			ref: {
 				explanation: "Ambire executes generic RPC requests to get user's balance and ENS.",
 				label: 'List of RPCs Ambire uses for default chains',
@@ -248,6 +248,9 @@ export const ambire: SoftwareWallet = {
 					'https://github.com/AmbireTech/ambire-common/blob/v2/src/libs/portfolio/getOnchainBalances.ts',
 				],
 			},
+			customChains: true,
+			l1RpcEndpoint: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+			otherRpcEndpoints: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 		},
 		ecosystem: {
 			delegation: {
@@ -265,25 +268,24 @@ export const ambire: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
-				'1193': featureSupported,
-				'2700': featureSupported,
-				'6963': featureSupported,
 				ref: {
 					url: 'https://github.com/AmbireTech/extension/blob/v2/src/web/extension-services/background/background.ts',
 				},
+				'1193': featureSupported,
+				'2700': featureSupported,
+				'6963': featureSupported,
 			},
 			walletCall: supported({
-				atomicMultiTransactions: supported({
-					ref: 'https://github.com/AmbireTech/ambire-common/blob/eba5dda7bccbd1c404f293d75c4ea74d939c8d01/src/libs/account/EOA7702.ts#L181-L183',
-				}),
+				ref: 'https://github.com/AmbireTech/ambire-common/blob/eba5dda7bccbd1c404f293d75c4ea74d939c8d01/src/libs/account/EOA7702.ts#L181-L183',
+				atomicMultiTransactions: featureSupported,
 			}),
 		},
 		license: {
-			license: License.GPL_3_0,
 			ref: 'https://github.com/AmbireTech/extension/blob/main/LICENSE',
+			license: License.GPL_3_0,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: false,
@@ -304,6 +306,7 @@ export const ambire: SoftwareWallet = {
 					createInAppConnectionFlow: notSupported,
 					erc7846WalletConnect: notSupported,
 					ethAccounts: supported({
+						ref: refTodo,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
 					useAppSpecificLastConnectedAddresses: notSupported,
@@ -315,13 +318,13 @@ export const ambire: SoftwareWallet = {
 				[UserFlow.NATIVE_SWAP]: {
 					collected: [
 						{
+							ref: dataLeakReferences.lifi,
 							byEntity: lifi,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
 								endpoint: RegularEndpoint,
 							},
 							purposes: [DataCollectionPurpose.ASSET_METADATA],
-							ref: dataLeakReferences.lifi,
 						},
 					],
 				},
@@ -338,6 +341,7 @@ export const ambire: SoftwareWallet = {
 				[UserFlow.TRANSACTION]: {
 					collected: [
 						{
+							ref: dataLeakReferences.ambire,
 							byEntity: ambireEntity,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -352,9 +356,9 @@ export const ambire: SoftwareWallet = {
 								DataCollectionPurpose.CHAIN_DATA_LOOKUP,
 								DataCollectionPurpose.TRANSACTION_BROADCAST,
 							],
-							ref: dataLeakReferences.ambire,
 						},
 						{
+							ref: dataLeakReferences.pimlico,
 							byEntity: pimlico,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -366,9 +370,9 @@ export const ambire: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
-							ref: dataLeakReferences.pimlico,
 						},
 						{
+							ref: dataLeakReferences.biconomy,
 							byEntity: biconomy,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -380,13 +384,13 @@ export const ambire: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
-							ref: dataLeakReferences.biconomy,
 						},
 					],
 				},
 				[UserFlow.UNCLASSIFIED]: {
 					collected: [
 						{
+							ref: dataLeakReferences.github,
 							byEntity: github,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -396,7 +400,6 @@ export const ambire: SoftwareWallet = {
 								DataCollectionPurpose.UPDATE_CHECKING,
 								DataCollectionPurpose.STATIC_ASSETS,
 							],
-							ref: dataLeakReferences.github,
 						},
 					],
 				},
@@ -413,6 +416,7 @@ export const ambire: SoftwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
+				ref: refTodo,
 
 				details: `Rewards are distributed according to the impact of the vulnerability based on the Immunefi Vulnerability Severity Classification System V2.2. This is a simplified 5-level scale, with separate scales for websites/apps and smart contracts/blockchains, encompassing everything from consequence of exploitation to privilege required to likelihood of a successful exploit.
 
@@ -449,16 +453,13 @@ Payouts are handled by the Ambire team directly and are denominated in USD. Howe
 				ethereumL1: notSupported,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: v2Audits,
 			scamAlerts: {
 				contractTransactionWarning: notSupported,
-				scamUrlWarning: supported({
-					leaksIp: false,
-					leaksUserAddress: false,
-					leaksVisitedUrl: 'NO',
+				scamUrlWarning: supported<ScamUrlWarning>({
 					ref: {
 						explanation:
 							"Every 6 hours, Ambire downloads a list of publicly available known scam URLs from an external API. Then, it checks if the website you're connecting to is on that list. If it is, a warning is displayed.",
@@ -470,6 +471,9 @@ Payouts are handled by the Ambire team directly and are denominated in USD. Howe
 							},
 						],
 					},
+					leaksIp: false,
+					leaksUserAddress: false,
+					leaksVisitedUrl: 'NO',
 				}),
 				sendTransactionWarning: notSupported,
 			},
@@ -477,10 +481,12 @@ Payouts are handled by the Ambire team directly and are denominated in USD. Howe
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: featureSupported,
 				},
 				l2: {
+					ref: refTodo,
 					arbitrum: TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 					opStack: TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 				},

--- a/data/software-wallets/coinbase.ts
+++ b/data/software-wallets/coinbase.ts
@@ -12,6 +12,7 @@ import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-v
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -39,13 +40,14 @@ export const coinbase: SoftwareWallet = {
 		accountSupport: {
 			defaultAccountType: AccountType.eip7702,
 			eip7702: supported({
-				contract: 'UNKNOWN',
 				ref: {
 					explanation: 'Coinbase Wallet announced support for EIP-7702.',
 					url: 'https://www.coinbase.com/blog/coinbase-wallet-introduces-support-for-eip-7702',
 				},
+				contract: 'UNKNOWN',
 			}),
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				canExportSeedPhrase: true,
 				keyDerivation: {
@@ -57,25 +59,25 @@ export const coinbase: SoftwareWallet = {
 			}),
 			mpc: notSupported,
 			rawErc4337: supported({
-				contract: 'UNKNOWN',
-				controllingSharesInSelfCustodyByDefault: 'YES',
-				keyRotationTransactionGeneration: TransactionGenerationCapability.IMPOSSIBLE,
 				ref: {
 					explanation: 'Coinbase Wallet supports ERC-4337 via its smart wallet implementation.',
 					url: 'https://github.com/coinbase/smart-wallet',
 				},
+				contract: 'UNKNOWN',
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration: TransactionGenerationCapability.IMPOSSIBLE,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -84,15 +86,14 @@ export const coinbase: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: {
-			license: License.BSD_3_CLAUSE,
 			ref: {
 				explanation: 'Coinbase Wallet uses the BSD-3-Clause license for its source code',
 				urls: [
@@ -102,9 +103,10 @@ export const coinbase: SoftwareWallet = {
 					},
 				],
 			},
+			license: License.BSD_3_CLAUSE,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -134,7 +136,7 @@ export const coinbase: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.webUSB],
@@ -145,40 +147,40 @@ export const coinbase: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
-				library: PasskeyVerificationLibrary.WEB_AUTHN_SOL,
-				libraryUrl:
-					'https://github.com/base/webauthn-sol/tree/619f20ab0f074fef41066ee4ab24849a913263b2',
 				ref: {
 					explanation: 'Coinbase uses the webauthn-sol library for passkey verification.',
 					url: 'https://github.com/base/webauthn-sol/tree/619f20ab0f074fef41066ee4ab24849a913263b2',
 				},
+				library: PasskeyVerificationLibrary.WEB_AUTHN_SOL,
+				libraryUrl:
+					'https://github.com/base/webauthn-sol/tree/619f20ab0f074fef41066ee4ab24849a913263b2',
 			},
 			publicSecurityAudits: [
 				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-April-2024.pdf',
 					auditDate: '2024-04-01',
 					auditor: cantina,
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-April-2024.pdf',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Code4rena-March-2024.md',
 					auditDate: '2024-03-01',
 					auditor: code4rena,
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Code4rena-March-2024.md',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Certora-February-2024.pdf',
 					auditDate: '2024-02-01',
 					auditor: certora,
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Certora-February-2024.pdf',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-December-2023.pdf',
 					auditDate: '2023-12-01',
 					auditor: cantina,
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-December-2023.pdf',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
@@ -188,12 +190,14 @@ export const coinbase: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -2,6 +2,7 @@ import { nconsigny } from '@/data/contributors/nconsigny'
 import { polymutex } from '@/data/contributors/polymutex'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
+import { appConnectionNotSupported } from '@/schema/features/privacy/app-isolation'
 import {
 	CollectionPolicy,
 	DataCollectionPurpose,
@@ -22,6 +23,7 @@ import {
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -61,28 +63,21 @@ export const daimo: SoftwareWallet = {
 			eoa: notSupported,
 			mpc: notSupported,
 			rawErc4337: supported({
-				contract: 'UNKNOWN',
-				controllingSharesInSelfCustodyByDefault: 'YES',
-				keyRotationTransactionGeneration:
-					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				ref: {
 					explanation:
 						'Key rotation changes are supported in the UI and result in onchain transactions with a well-known structure',
 					url: 'https://github.com/daimo-eth/daimo/blob/master/apps/daimo-mobile/src/view/screen/keyRotation/AddKeySlotButton.tsx',
 				},
+				contract: 'UNKNOWN',
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: notSupported,
 		},
 		addressResolution: {
-			chainSpecificAddressing: {
-				erc7828: notSupported,
-				erc7831: notSupported,
-			},
-			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
-				medium: 'CHAIN_CLIENT',
-			}),
 			ref: [
 				{
 					explanation:
@@ -90,10 +85,18 @@ export const daimo: SoftwareWallet = {
 					url: 'https://github.com/daimo-eth/daimo/blob/a960ddbbc0cb486f21b8460d22cebefc6376aac9/packages/daimo-api/src/network/viemClient.ts#L128',
 				},
 			],
+			chainSpecificAddressing: {
+				erc7828: notSupported,
+				erc7831: notSupported,
+			},
+			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
+				medium: 'CHAIN_CLIENT',
+			}),
 		},
 		chainAbstraction: {
 			bridging: {
 				builtInBridging: supported({
+					ref: refTodo,
 					feesLargerThan1bps: {
 						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 						byDefault: FeeDisplayLevel.COMPREHENSIVE,
@@ -104,6 +107,7 @@ export const daimo: SoftwareWallet = {
 				suggestedBridging: notSupported,
 			},
 			crossChainBalances: {
+				ref: refTodo,
 				ether: {
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: notSupported,
@@ -117,6 +121,7 @@ export const daimo: SoftwareWallet = {
 			},
 		},
 		chainConfigurability: {
+			ref: refTodo,
 			customChains: false,
 			l1RpcEndpoint: RpcEndpointConfiguration.NEVER_USED,
 			otherRpcEndpoints: RpcEndpointConfiguration.NO,
@@ -129,13 +134,13 @@ export const daimo: SoftwareWallet = {
 			walletCall: notSupported,
 		},
 		license: {
-			license: License.GPL_3_0,
 			ref: [
 				{
 					explanation: 'Daimo is licensed under the GPL-3.0 license.',
 					url: 'https://github.com/daimo-eth/daimo/blob/master/LICENSE',
 				},
 			],
+			license: License.GPL_3_0,
 		},
 		monetization: {
 			ref: [
@@ -168,7 +173,7 @@ export const daimo: SoftwareWallet = {
 		},
 		multiAddress: featureSupported,
 		privacy: {
-			appIsolation: 'APP_CONNECTION_NOT_SUPPORTED',
+			appIsolation: appConnectionNotSupported,
 			dataCollection: {
 				[UserFlow.APP_CONNECTION]: 'FLOW_NOT_SUPPORTED',
 				[UserFlow.NATIVE_SWAP]: 'FLOW_NOT_SUPPORTED',
@@ -178,6 +183,13 @@ export const daimo: SoftwareWallet = {
 				[UserFlow.ONBOARDING]: {
 					collected: [
 						{
+							ref: [
+								{
+									explanation:
+										"Users may deposit from Binance Pay, after which Binance will learn the user's wallet address.",
+									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/binanceClient.ts#L132',
+								},
+							],
 							byEntity: binance,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.OPT_IN,
@@ -189,15 +201,15 @@ export const daimo: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.EXTERNAL_ACCOUNT_LINKING],
+						},
+						{
 							ref: [
 								{
 									explanation:
-										"Users may deposit from Binance Pay, after which Binance will learn the user's wallet address.",
-									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/binanceClient.ts#L132',
+										'Users may opt to link their Farcaster profile to their Daimo profile.',
+									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx#L141-L148',
 								},
 							],
-						},
-						{
 							byEntity: daimoInc,
 							dataCollection: {
 								endpoint: RegularEndpoint,
@@ -206,6 +218,8 @@ export const daimo: SoftwareWallet = {
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.OPT_IN,
 							},
 							purposes: [DataCollectionPurpose.EXTERNAL_ACCOUNT_LINKING],
+						},
+						{
 							ref: [
 								{
 									explanation:
@@ -213,8 +227,6 @@ export const daimo: SoftwareWallet = {
 									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx#L141-L148',
 								},
 							],
-						},
-						{
 							byEntity: merkleManufactory,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.OPT_IN,
@@ -223,28 +235,28 @@ export const daimo: SoftwareWallet = {
 								endpoint: RegularEndpoint,
 							},
 							purposes: [DataCollectionPurpose.EXTERNAL_ACCOUNT_LINKING],
-							ref: [
-								{
-									explanation:
-										'Users may opt to link their Farcaster profile to their Daimo profile.',
-									url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/apps/daimo-mobile/src/view/sheet/FarcasterBottomSheet.tsx#L141-L148',
-								},
-							],
 						},
 					],
 					publishedOnchain: {
 						[PersonalInfo.PSEUDONYM]: CollectionPolicy.ALWAYS,
-						purposes: [DataCollectionPurpose.ACCOUNT_SIGNUP],
 						ref: {
 							explanation:
 								"Creating a Daimo wallet creates a transaction publicly registering your name and address in Daimo's nameRegistry contract on Ethereum.",
 							url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/contract/nameRegistry.ts#L183-L197',
 						},
+						purposes: [DataCollectionPurpose.ACCOUNT_SIGNUP],
 					},
 				},
 				[UserFlow.TRANSACTION]: {
 					collected: [
 						{
+							ref: {
+								explanation:
+									'Sending bundled transactions uses the Pimlico API via api.pimlico.io as Paymaster.',
+								url: [
+									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/bundlerClient.ts#L131-L133',
+								],
+							},
 							byEntity: pimlico,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -256,19 +268,17 @@ export const daimo: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.TRANSACTION_BROADCAST],
-							ref: {
-								explanation:
-									'Sending bundled transactions uses the Pimlico API via api.pimlico.io as Paymaster.',
-								url: [
-									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/bundlerClient.ts#L131-L133',
-								],
-							},
 						},
 					],
 				},
 				[UserFlow.UNCLASSIFIED]: {
 					collected: [
 						{
+							ref: {
+								explanation:
+									'Wallet operations are routed through Daimo.com servers without proxying.',
+								url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/viemClient.ts#L35-L50',
+							},
 							byEntity: daimoInc,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -284,13 +294,15 @@ export const daimo: SoftwareWallet = {
 								DataCollectionPurpose.CHAIN_DATA_LOOKUP,
 								DataCollectionPurpose.ACCOUNT_SIGNUP,
 							],
-							ref: {
-								explanation:
-									'Wallet operations are routed through Daimo.com servers without proxying.',
-								url: 'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/network/viemClient.ts#L35-L50',
-							},
 						},
 						{
+							ref: {
+								explanation:
+									'Daimo records telemetry events to Honeycomb. This data includes your Daimo username. Since this username is also linked to your wallet address onchain, Honeycomb can associate the username they receive with your wallet address.',
+								url: [
+									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/server/telemetry.ts#L101-L111',
+								],
+							},
 							byEntity: honeycomb,
 							dataCollection: {
 								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -302,21 +314,8 @@ export const daimo: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.ANALYTICS],
-							ref: {
-								explanation:
-									'Daimo records telemetry events to Honeycomb. This data includes your Daimo username. Since this username is also linked to your wallet address onchain, Honeycomb can associate the username they receive with your wallet address.',
-								url: [
-									'https://github.com/daimo-eth/daimo/blob/e1ddce7c37959d5cec92b05608ce62f93f3316b7/packages/daimo-api/src/server/telemetry.ts#L101-L111',
-								],
-							},
 						},
 						{
-							byEntity: openExchangeRates,
-							dataCollection: {
-								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
-								endpoint: RegularEndpoint,
-							},
-							purposes: [DataCollectionPurpose.ASSET_METADATA],
 							ref: [
 								{
 									explanation:
@@ -327,6 +326,12 @@ export const daimo: SoftwareWallet = {
 									],
 								},
 							],
+							byEntity: openExchangeRates,
+							dataCollection: {
+								[PersonalInfo.IP_ADDRESS]: CollectionPolicy.ALWAYS,
+								endpoint: RegularEndpoint,
+							},
+							purposes: [DataCollectionPurpose.ASSET_METADATA],
 						},
 					],
 				},
@@ -343,17 +348,13 @@ export const daimo: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {},
 			},
 			lightClient: {
 				ethereumL1: notSupported,
 			},
 			passkeyVerification: {
-				details:
-					'Daimo uses a verifier based on FreshCryptoLib for passkey verification in their P256Verifier contract.',
-				library: PasskeyVerificationLibrary.DAIMO_P256_VERIFIER,
-				libraryUrl: 'https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol',
 				ref: [
 					{
 						explanation:
@@ -361,16 +362,20 @@ export const daimo: SoftwareWallet = {
 						url: 'https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol',
 					},
 				],
+				details:
+					'Daimo uses a verifier based on FreshCryptoLib for passkey verification in their P256Verifier contract.',
+				library: PasskeyVerificationLibrary.DAIMO_P256_VERIFIER,
+				libraryUrl: 'https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol',
 			},
 			publicSecurityAudits: [
 				{
+					ref: 'https://github.com/daimo-eth/daimo/blob/master/audits/2023-10-veridise-daimo.pdf',
 					auditDate: '2023-10-06',
 					auditor: veridise,
 					codeSnapshot: {
 						commit: 'f0dc56d68852c1488461e88a506ff7b0f027f245',
 						date: '2023-09-12',
 					},
-					ref: 'https://github.com/daimo-eth/daimo/blob/master/audits/2023-10-veridise-daimo.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: { [Variant.MOBILE]: true },
 				},
@@ -379,10 +384,6 @@ export const daimo: SoftwareWallet = {
 				contractTransactionWarning: notSupported,
 				scamUrlWarning: notSupported,
 				sendTransactionWarning: supported({
-					leaksRecipient: false,
-					leaksUserAddress: false,
-					leaksUserIp: false,
-					newRecipientWarning: true,
 					ref: [
 						{
 							explanation:
@@ -390,6 +391,10 @@ export const daimo: SoftwareWallet = {
 							url: 'https://github.com/daimo-eth/daimo/blob/a960ddbbc0cb486f21b8460d22cebefc6376aac9/apps/daimo-mobile/src/view/screen/send/SendTransferScreen.tsx#L234-L238',
 						},
 					],
+					leaksRecipient: false,
+					leaksUserAddress: false,
+					leaksUserIp: false,
+					newRecipientWarning: true,
 					userWhitelist: false,
 				}),
 			},
@@ -397,6 +402,7 @@ export const daimo: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: notSupported,
 				},
@@ -405,6 +411,7 @@ export const daimo: SoftwareWallet = {
 						TransactionSubmissionL2Support.NOT_SUPPORTED_BY_WALLET_BY_DEFAULT,
 					[TransactionSubmissionL2Type.opStack]:
 						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/elytro.ts
+++ b/data/software-wallets/elytro.ts
@@ -5,6 +5,7 @@ import { WalletProfile } from '@/schema/features/profile'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -30,26 +31,26 @@ export const elytro: SoftwareWallet = {
 			eoa: notSupported,
 			mpc: notSupported,
 			rawErc4337: supported({
-				contract: 'UNKNOWN',
-				controllingSharesInSelfCustodyByDefault: 'YES',
-				keyRotationTransactionGeneration:
-					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				ref: {
 					explanation: 'Elytro supports ERC-4337 smart contract wallets',
 					url: 'https://github.com/Elytro-eth/soul-wallet-contract',
 				},
+				contract: 'UNKNOWN',
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -58,16 +59,16 @@ export const elytro: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -97,17 +98,13 @@ export const elytro: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: undefined,
+				ref: refTodo,
 				wallets: {},
 			},
 			lightClient: {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
-				details: 'Elytro uses FreshCryptoLib for passkey verification in their WebAuthn library.',
-				library: PasskeyVerificationLibrary.OPEN_ZEPPELIN_P256_VERIFIER,
-				libraryUrl:
-					'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/P256.sol',
 				ref: [
 					{
 						explanation:
@@ -115,6 +112,10 @@ export const elytro: SoftwareWallet = {
 						url: 'https://github.com/Elytro-eth/Elytro-wallet-contract/blob/develop/contracts/libraries/WebAuthn.sol',
 					},
 				],
+				details: 'Elytro uses FreshCryptoLib for passkey verification in their WebAuthn library.',
+				library: PasskeyVerificationLibrary.OPEN_ZEPPELIN_P256_VERIFIER,
+				libraryUrl:
+					'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/P256.sol',
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -122,10 +123,12 @@ export const elytro: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
 				},

--- a/data/software-wallets/family.ts
+++ b/data/software-wallets/family.ts
@@ -5,6 +5,7 @@ import { WalletProfile } from '@/schema/features/profile'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -27,6 +28,7 @@ export const family: SoftwareWallet = {
 			eip7702: notSupported,
 			// BIP support is not verified
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -40,12 +42,12 @@ export const family: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -54,16 +56,16 @@ export const family: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -93,15 +95,15 @@ export const family: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {},
 			},
 			lightClient: {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -109,10 +111,12 @@ export const family: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
 				},

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -13,6 +13,7 @@ import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-v
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -34,6 +35,7 @@ export const frame: SoftwareWallet = {
 			defaultAccountType: AccountType.eoa,
 			eip7702: notSupported,
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -47,18 +49,15 @@ export const frame: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: {
-			customChains: true,
-			l1RpcEndpoint: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
-			otherRpcEndpoints: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			ref: [
 				{
 					explanation: 'Frame allows connecting to your own Ethereum node',
@@ -70,22 +69,25 @@ export const frame: SoftwareWallet = {
 					],
 				},
 			],
+			customChains: true,
+			l1RpcEndpoint: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+			otherRpcEndpoints: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 		},
 		ecosystem: {
 			delegation: null,
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -115,7 +117,7 @@ export const frame: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.webUSB],
@@ -138,8 +140,8 @@ export const frame: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -147,12 +149,14 @@ export const frame: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/gem.ts
+++ b/data/software-wallets/gem.ts
@@ -8,6 +8,7 @@ import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -33,6 +34,7 @@ export const gemwallet: SoftwareWallet = {
 			defaultAccountType: AccountType.eoa,
 			eip7702: notSupported,
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -46,13 +48,6 @@ export const gemwallet: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
-			chainSpecificAddressing: {
-				erc7828: notSupported,
-				erc7831: notSupported,
-			},
-			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
-				medium: 'CHAIN_CLIENT',
-			}),
 			ref: [
 				{
 					explanation:
@@ -60,6 +55,13 @@ export const gemwallet: SoftwareWallet = {
 					url: 'https://gemwallet.com',
 				},
 			],
+			chainSpecificAddressing: {
+				erc7828: notSupported,
+				erc7831: notSupported,
+			},
+			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
+				medium: 'CHAIN_CLIENT',
+			}),
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -71,13 +73,13 @@ export const gemwallet: SoftwareWallet = {
 			walletCall: null,
 		},
 		license: {
-			license: License.GPL_3_0,
 			ref: [
 				{
 					explanation: 'Gem Wallet is licensed under the GPL-3.0 license.',
 					url: 'https://github.com/gemwalletcom/gem-ios/blob/main/LICENSE',
 				},
 			],
+			license: License.GPL_3_0,
 		},
 		monetization: {
 			ref: [
@@ -120,18 +122,12 @@ export const gemwallet: SoftwareWallet = {
 				ethereumL1: notSupported,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: {
 				contractTransactionWarning: supported({
-					contractRegistry: true,
-					leaksContractAddress: true,
-					leaksUserAddress: true,
-					leaksUserIp: true,
-					previousContractInteractionWarning: false,
-					recentContractWarning: false,
 					ref: [
 						{
 							explanation:
@@ -139,13 +135,15 @@ export const gemwallet: SoftwareWallet = {
 							url: 'https://gemwallet.com',
 						},
 					],
+					contractRegistry: true,
+					leaksContractAddress: true,
+					leaksUserAddress: true,
+					leaksUserIp: true,
+					previousContractInteractionWarning: false,
+					recentContractWarning: false,
 				}),
 				scamUrlWarning: notSupported,
 				sendTransactionWarning: supported({
-					leaksRecipient: false,
-					leaksUserAddress: false,
-					leaksUserIp: false,
-					newRecipientWarning: true,
 					ref: [
 						{
 							explanation:
@@ -153,6 +151,10 @@ export const gemwallet: SoftwareWallet = {
 							url: 'https://gemwallet.com',
 						},
 					],
+					leaksRecipient: false,
+					leaksUserAddress: false,
+					leaksUserIp: false,
+					newRecipientWarning: true,
 					userWhitelist: false,
 				}),
 			},
@@ -160,12 +162,14 @@ export const gemwallet: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/imtoken.ts
+++ b/data/software-wallets/imtoken.ts
@@ -18,6 +18,7 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { type ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import {
 	TransactionSubmissionL2Support,
@@ -26,6 +27,7 @@ import {
 import { notSupported, supported } from '@/schema/features/support'
 import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -52,6 +54,7 @@ export const imtoken: SoftwareWallet = {
 			defaultAccountType: AccountType.eoa,
 			eip7702: notSupported,
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -65,13 +68,6 @@ export const imtoken: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
-			chainSpecificAddressing: {
-				erc7828: notSupported,
-				erc7831: notSupported,
-			},
-			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
-				medium: 'CHAIN_CLIENT',
-			}),
 			ref: [
 				{
 					explanation:
@@ -79,15 +75,17 @@ export const imtoken: SoftwareWallet = {
 					url: 'https://support.token.im/hc/articles/360039928813',
 				},
 			],
+			chainSpecificAddressing: {
+				erc7828: notSupported,
+				erc7831: notSupported,
+			},
+			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
+				medium: 'CHAIN_CLIENT',
+			}),
 		},
 		chainAbstraction: {
 			bridging: {
 				builtInBridging: supported({
-					feesLargerThan1bps: {
-						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
-						byDefault: FeeDisplayLevel.COMPREHENSIVE,
-						fullySponsored: false,
-					},
 					ref: [
 						{
 							explanation:
@@ -95,11 +93,17 @@ export const imtoken: SoftwareWallet = {
 							url: 'https://support.token.im/hc/en-us/articles/4404355206553-How-to-use-cBridge-with-imToken',
 						},
 					],
+					feesLargerThan1bps: {
+						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+						byDefault: FeeDisplayLevel.COMPREHENSIVE,
+						fullySponsored: false,
+					},
 					risksExplained: 'NOT_IN_UI',
 				}),
 				suggestedBridging: notSupported,
 			},
 			crossChainBalances: {
+				ref: refTodo,
 				ether: {
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: notSupported,
@@ -113,9 +117,6 @@ export const imtoken: SoftwareWallet = {
 			},
 		},
 		chainConfigurability: {
-			customChains: true,
-			l1RpcEndpoint: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
-			otherRpcEndpoints: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 			ref: [
 				{
 					explanation:
@@ -123,6 +124,9 @@ export const imtoken: SoftwareWallet = {
 					url: 'https://support.token.im/hc/en-us/articles/900005324266-imToken-now-supports-custom-RPC-Experience-the-layer-2-ecosystem-today',
 				},
 			],
+			customChains: true,
+			l1RpcEndpoint: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+			otherRpcEndpoints: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 		},
 		ecosystem: {
 			delegation: null,
@@ -133,7 +137,6 @@ export const imtoken: SoftwareWallet = {
 		},
 		license: {
 			[Variant.MOBILE]: {
-				license: License.APACHE_2_0,
 				ref: [
 					{
 						explanation:
@@ -141,6 +144,7 @@ export const imtoken: SoftwareWallet = {
 						url: 'https://github.com/consenlabs/token-core-monorepo/blob/main/LICENSE',
 					},
 				],
+				license: License.APACHE_2_0,
 			},
 		},
 		monetization: {
@@ -185,6 +189,13 @@ export const imtoken: SoftwareWallet = {
 				[UserFlow.TRANSACTION]: {
 					collected: [
 						{
+							ref: [
+								{
+									explanation:
+										"imToken can associate your wallet address along with your mobile device's IP address, per its privacy policy. Each request only involves one active address.",
+									url: 'https://token.im/tos-en.html',
+								},
+							],
 							byEntity: imToken,
 							dataCollection: {
 								[WalletInfo.ACCOUNT_ADDRESS]: CollectionPolicy.ALWAYS,
@@ -194,13 +205,6 @@ export const imtoken: SoftwareWallet = {
 								},
 							},
 							purposes: [DataCollectionPurpose.CHAIN_DATA_LOOKUP],
-							ref: [
-								{
-									explanation:
-										"imToken can associate your wallet address along with your mobile device's IP address, per its privacy policy. Each request only involves one active address.",
-									url: 'https://token.im/tos-en.html',
-								},
-							],
 						},
 					],
 				},
@@ -224,8 +228,6 @@ export const imtoken: SoftwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
-				details:
-					'imToken operates a comprehensive bug bounty program through Bugrap platform, covering both the wallet and the website. The program has a wide scope, competitive rewards, and a responsive disclosure process.',
 				ref: [
 					{
 						explanation:
@@ -237,6 +239,8 @@ export const imtoken: SoftwareWallet = {
 						url: 'https://bugrap.io/bounties/imToken%20Website',
 					},
 				],
+				details:
+					'imToken operates a comprehensive bug bounty program through Bugrap platform, covering both the wallet and the website. The program has a wide scope, competitive rewards, and a responsive disclosure process.',
 				upgradePathAvailable: true,
 				url: 'https://bugrap.io/bounties/imToken%20Wallet',
 			},
@@ -264,14 +268,12 @@ export const imtoken: SoftwareWallet = {
 			},
 			passkeyVerification: {
 				[Variant.MOBILE]: {
+					ref: refNotNecessary,
 					library: PasskeyVerificationLibrary.NONE,
-					ref: null,
 				},
 			},
 			publicSecurityAudits: [
 				{
-					auditDate: '2018-05-07',
-					auditor: cure53,
 					ref: [
 						{
 							explanation:
@@ -279,18 +281,14 @@ export const imtoken: SoftwareWallet = {
 							url: 'https://cure53.de/pentest-report_imtoken.pdf',
 						},
 					],
+					auditDate: '2018-05-07',
+					auditor: cure53,
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 			],
 			scamAlerts: {
 				contractTransactionWarning: supported({
-					contractRegistry: true,
-					leaksContractAddress: true,
-					leaksUserAddress: true,
-					leaksUserIp: true,
-					previousContractInteractionWarning: true,
-					recentContractWarning: false,
 					ref: [
 						{
 							explanation:
@@ -298,11 +296,14 @@ export const imtoken: SoftwareWallet = {
 							url: 'https://support.token.im/hc/en-us/articles/21850966355737-Revamped-imToken-signature-for-safer-and-more-intuitive-transactions',
 						},
 					],
+					contractRegistry: true,
+					leaksContractAddress: true,
+					leaksUserAddress: true,
+					leaksUserIp: true,
+					previousContractInteractionWarning: true,
+					recentContractWarning: false,
 				}),
-				scamUrlWarning: supported({
-					leaksIp: false,
-					leaksUserAddress: false,
-					leaksVisitedUrl: 'NO',
+				scamUrlWarning: supported<ScamUrlWarning>({
 					ref: [
 						{
 							explanation:
@@ -310,6 +311,9 @@ export const imtoken: SoftwareWallet = {
 							url: 'https://support.token.im/hc/en-us/articles/21850966355737-Revamped-imToken-signature-for-safer-and-more-intuitive-transactions',
 						},
 					],
+					leaksIp: false,
+					leaksUserAddress: false,
+					leaksVisitedUrl: 'NO',
 				}),
 				sendTransactionWarning: notSupported,
 			},
@@ -317,10 +321,12 @@ export const imtoken: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]:
 						TransactionSubmissionL2Support.NOT_SUPPORTED_BY_WALLET_BY_DEFAULT,
 					[TransactionSubmissionL2Type.opStack]:

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -10,6 +10,7 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
@@ -18,6 +19,7 @@ import {
 	FeeDisplayLevel,
 } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { mdParagraph, paragraph } from '@/types/content'
@@ -47,9 +49,11 @@ export const metamask: SoftwareWallet = {
 		accountSupport: {
 			defaultAccountType: AccountType.eoa,
 			eip7702: supported({
+				ref: refTodo,
 				contract: metamask7702DelegatorContract,
 			}),
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -63,6 +67,12 @@ export const metamask: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: [
+				{
+					explanation: 'MetaMask supports ENS domain resolution.',
+					url: 'https://support.metamask.io/more-web3/learn/sending-or-receiving-a-transaction-with-ens/',
+				},
+			],
 			chainSpecificAddressing: {
 				erc7828: notSupported,
 				erc7831: notSupported,
@@ -70,31 +80,30 @@ export const metamask: SoftwareWallet = {
 			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
 				medium: 'CHAIN_CLIENT',
 			}),
-			ref: [
-				{
-					explanation: 'MetaMask supports ENS domain resolution.',
-					url: 'https://support.metamask.io/more-web3/learn/sending-or-receiving-a-transaction-with-ens/',
-				},
-			],
 		},
 		chainAbstraction: {
 			bridging: {
 				builtInBridging: supported({
-					feesLargerThan1bps: {
-						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
-						byDefault: FeeDisplayLevel.COMPREHENSIVE,
-						fullySponsored: false,
-					},
 					ref: {
 						explanation:
 							'MetaMask has a built-in bridge feature that allows users to bridge assets between chains.',
 						url: 'https://support.metamask.io/more-web3/learn/field-guide-to-bridges/',
+					},
+					feesLargerThan1bps: {
+						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
+						byDefault: FeeDisplayLevel.COMPREHENSIVE,
+						fullySponsored: false,
 					},
 					risksExplained: 'NOT_IN_UI',
 				}),
 				suggestedBridging: notSupported,
 			},
 			crossChainBalances: {
+				ref: {
+					explanation:
+						'MetaMask displays tokens across multiple networks in a single aggregated view with estimated portfolio value',
+					url: 'https://support.metamask.io/manage-crypto/tokens/how-to-view-your-token-balance-across-multiple-networks/',
+				},
 				ether: {
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: featureSupported,
@@ -102,11 +111,6 @@ export const metamask: SoftwareWallet = {
 				// MetaMask supports aggregated balance across popular networks, but custom networks are not included
 				globalAccountValue: featureSupported,
 				perChainAccountValue: featureSupported,
-				ref: {
-					explanation:
-						'MetaMask displays tokens across multiple networks in a single aggregated view with estimated portfolio value',
-					url: 'https://support.metamask.io/manage-crypto/tokens/how-to-view-your-token-balance-across-multiple-networks/',
-				},
 				usdc: {
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: featureSupported,
@@ -114,9 +118,6 @@ export const metamask: SoftwareWallet = {
 			},
 		},
 		chainConfigurability: {
-			customChains: true,
-			l1RpcEndpoint: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
-			otherRpcEndpoints: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 			ref: [
 				{
 					explanation:
@@ -124,15 +125,15 @@ export const metamask: SoftwareWallet = {
 					url: 'https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/',
 				},
 			],
+			customChains: true,
+			l1RpcEndpoint: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+			otherRpcEndpoints: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 		},
 		ecosystem: {
 			delegation: null,
 		},
 		integration: {
 			browser: {
-				'1193': featureSupported,
-				'2700': featureSupported,
-				'6963': featureSupported,
 				ref: [
 					{
 						explanation:
@@ -140,26 +141,30 @@ export const metamask: SoftwareWallet = {
 						url: 'https://support.metamask.io/hc/en-us/articles/360015489471',
 					},
 				],
+				'1193': featureSupported,
+				'2700': featureSupported,
+				'6963': featureSupported,
 			},
 			walletCall: supported({
+				ref: refTodo,
 				atomicMultiTransactions: featureSupported,
 			}),
 		},
 		license: {
 			[Variant.BROWSER]: {
-				license: License.PROPRIETARY_SOURCE_AVAILABLE,
 				ref: {
 					explanation:
 						'The MetaMask browser extension uses a proprietary source-available license.',
 					url: 'https://github.com/MetaMask/metamask-extension/blob/main/LICENSE',
 				},
+				license: License.PROPRIETARY_SOURCE_AVAILABLE,
 			},
 			[Variant.MOBILE]: {
-				license: License.PROPRIETARY_SOURCE_AVAILABLE,
 				ref: {
 					explanation: 'The MetaMask mobile app uses a proprietary source-available license.',
 					url: 'https://github.com/MetaMask/metamask-mobile/blob/main/LICENSE',
 				},
+				license: License.PROPRIETARY_SOURCE_AVAILABLE,
 			},
 		},
 		monetization: {
@@ -226,11 +231,13 @@ export const metamask: SoftwareWallet = {
 			},
 			passkeyVerification: {
 				[Variant.BROWSER]: {
+					ref: refTodo,
 					details:
 						'MetaMask browser extension does not currently implement passkey verification. Phase 2 seedless onboarding has passkey scheduled for extension.',
 					library: PasskeyVerificationLibrary.NONE,
 				},
 				[Variant.MOBILE]: {
+					ref: refTodo,
 					details:
 						'MetaMask mobile uses biometrics that leverage the hardware enclave similar to passkeys. Standard passkey verification is not yet implemented.',
 					library: PasskeyVerificationLibrary.NONE,
@@ -238,54 +245,48 @@ export const metamask: SoftwareWallet = {
 			},
 			publicSecurityAudits: [
 				{
+					ref: 'https://assets.ctfassets.net/clixtyxoaeas/21m4LE3WLYbgWjc33aDcp2/8252073e115688b1dc1500a9c2d33fe4/metamask-delegator-framework-audit-2024-10.pdf',
 					auditDate: '2024-10-25',
 					auditor: diligence,
 					codeSnapshot: {
 						date: '2024-10-25',
 					},
-					ref: 'https://assets.ctfassets.net/clixtyxoaeas/21m4LE3WLYbgWjc33aDcp2/8252073e115688b1dc1500a9c2d33fe4/metamask-delegator-framework-audit-2024-10.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://assets.ctfassets.net/clixtyxoaeas/4sNMB55kkGw6BtAiIn08mm/f1f4a78d3901dd03848d070e15a1ff12/pentest-report_metamask-signing-snap.pdf',
 					auditDate: '2024-10-25',
 					auditor: cure53,
 					codeSnapshot: {
 						date: '2024-03-25',
 					},
-					ref: 'https://assets.ctfassets.net/clixtyxoaeas/4sNMB55kkGw6BtAiIn08mm/f1f4a78d3901dd03848d070e15a1ff12/pentest-report_metamask-signing-snap.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-03-18-cyfrin-Metamask-DelegationFramework1-v2.0.pdf',
 					auditDate: '2025-03-18',
 					auditor: cyfrin,
 					codeSnapshot: {
 						date: '2025-02-07',
 					},
-					ref: 'https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-03-18-cyfrin-Metamask-DelegationFramework1-v2.0.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-04-01-cyfrin-Metamask-DelegationFramework2-v2.0.pdf',
 					auditDate: '2025-04-01',
 					auditor: cyfrin,
 					codeSnapshot: {
 						date: '2025-04-01',
 					},
-					ref: 'https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-04-01-cyfrin-Metamask-DelegationFramework2-v2.0.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 			],
 			scamAlerts: {
 				contractTransactionWarning: supported({
-					contractRegistry: true,
-					leaksContractAddress: true,
-					leaksUserAddress: true,
-					leaksUserIp: true,
-					previousContractInteractionWarning: true,
-					recentContractWarning: true,
 					ref: [
 						{
 							explanation:
@@ -293,11 +294,14 @@ export const metamask: SoftwareWallet = {
 							url: 'https://metamask.io/news/latest/metamask-security-alerts-by-blockaid-the-new-normal-for-a-safer-transaction/',
 						},
 					],
+					contractRegistry: true,
+					leaksContractAddress: true,
+					leaksUserAddress: true,
+					leaksUserIp: true,
+					previousContractInteractionWarning: true,
+					recentContractWarning: true,
 				}),
-				scamUrlWarning: supported({
-					leaksIp: false,
-					leaksUserAddress: false,
-					leaksVisitedUrl: 'NO',
+				scamUrlWarning: supported<ScamUrlWarning>({
 					ref: [
 						{
 							explanation:
@@ -310,12 +314,11 @@ export const metamask: SoftwareWallet = {
 							url: 'https://github.com/MetaMask/eth-phishing-detect',
 						},
 					],
+					leaksIp: false,
+					leaksUserAddress: false,
+					leaksVisitedUrl: 'NO',
 				}),
 				sendTransactionWarning: supported({
-					leaksRecipient: true,
-					leaksUserAddress: true,
-					leaksUserIp: true,
-					newRecipientWarning: true,
 					ref: [
 						{
 							explanation:
@@ -323,6 +326,10 @@ export const metamask: SoftwareWallet = {
 							url: 'https://support.metamask.io/configure/privacy/how-to-adjust-metamask-privacy-settings/',
 						},
 					],
+					leaksRecipient: true,
+					leaksUserAddress: true,
+					leaksUserIp: true,
+					newRecipientWarning: true,
 					userWhitelist: true,
 				}),
 			},
@@ -330,12 +337,14 @@ export const metamask: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: notSupported,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/mtpelerin.ts
+++ b/data/software-wallets/mtpelerin.ts
@@ -6,6 +6,7 @@ import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-v
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported } from '@/schema/features/support'
 import { License } from '@/schema/features/transparency/license'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -44,12 +45,12 @@ export const mtpelerin: SoftwareWallet = {
 		},*/
 		accountSupport: null,
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -58,14 +59,15 @@ export const mtpelerin: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: {
+			ref: refTodo,
 			license: License.PROPRIETARY,
 		},
 		monetization: {
@@ -99,20 +101,21 @@ export const mtpelerin: SoftwareWallet = {
 		security: {
 			bugBountyProgram: {
 				type: BugBountyProgramType.COMPREHENSIVE,
+				ref: refTodo,
 				details: 'The wallet implements a comprehensive bug bounty program through Immunefi.',
 				upgradePathAvailable: true,
 				url: 'https://immunefi.com/bug-bounty/mtpelerin/',
 			},
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {},
 			},
 			lightClient: {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -120,12 +123,14 @@ export const mtpelerin: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -11,6 +11,7 @@ import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/cha
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { License } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -35,15 +36,16 @@ export const nufi: SoftwareWallet = {
 		accountSupport: {
 			defaultAccountType: AccountType.eoa,
 			eip7702: supported({
-				contract: metamask7702DelegatorContract,
 				ref: {
 					explanation:
 						'The NuFi FAQ mentions the use the MetaMask DeleGator contract as smart account implementation.',
 					label: 'NuFi support site',
 					url: 'https://support.nu.fi/support/solutions/articles/80001178239',
 				},
+				contract: metamask7702DelegatorContract,
 			}),
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: false,
 				keyDerivation: {
 					type: 'BIP32',
@@ -57,6 +59,7 @@ export const nufi: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: notSupported,
 				erc7831: notSupported,
@@ -65,6 +68,7 @@ export const nufi: SoftwareWallet = {
 		},
 		chainAbstraction: null,
 		chainConfigurability: {
+			ref: refTodo,
 			customChains: true,
 			l1RpcEndpoint: RpcEndpointConfiguration.NO,
 			otherRpcEndpoints: RpcEndpointConfiguration.NO,
@@ -85,18 +89,22 @@ export const nufi: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': featureSupported,
 				'2700': featureSupported,
 				'6963': featureSupported,
 			},
 			walletCall: supported({
+				ref: refTodo,
 				atomicMultiTransactions: featureSupported,
 			}),
 		},
 		license: {
+			ref: refTodo,
 			license: License.PROPRIETARY,
 		},
 		monetization: {
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: false,
@@ -126,6 +134,7 @@ export const nufi: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
+				ref: refTodo,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.webUSB, HardwareWalletConnection.bluetooth],
@@ -157,10 +166,12 @@ export const nufi: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: notSupported,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
 				},

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -10,6 +10,7 @@ import {
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -35,6 +36,7 @@ export const phantom: SoftwareWallet = {
 			defaultAccountType: AccountType.eoa,
 			eip7702: notSupported,
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -48,12 +50,12 @@ export const phantom: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -62,16 +64,16 @@ export const phantom: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -101,7 +103,7 @@ export const phantom: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.webUSB],
@@ -112,8 +114,8 @@ export const phantom: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -121,10 +123,12 @@ export const phantom: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
 				},

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -19,6 +19,7 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { SecurityFlawSeverity } from '@/schema/features/security/security-audits'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import {
@@ -36,6 +37,7 @@ import {
 	FeeDisplayLevel,
 } from '@/schema/features/transparency/fee-display'
 import { License } from '@/schema/features/transparency/license'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -67,6 +69,7 @@ export const rabby: SoftwareWallet = {
 				ref: 'https://github.com/RabbyHub/Rabby/blob/fa9d0988e944f67e70da67d852cf3041d3b162da/src/background/controller/provider/controller.ts#L402-L407',
 			}),
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -78,6 +81,7 @@ export const rabby: SoftwareWallet = {
 			mpc: notSupported,
 			rawErc4337: notSupported,
 			safe: supported({
+				ref: refTodo,
 				canDeployNew: false,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				defaultConfig: {
@@ -99,11 +103,6 @@ export const rabby: SoftwareWallet = {
 			}),
 		},
 		addressResolution: {
-			chainSpecificAddressing: {
-				erc7828: notSupported,
-				erc7831: notSupported,
-			},
-			nonChainSpecificEnsResolution: notSupported,
 			ref: [
 				{
 					explanation:
@@ -111,10 +110,16 @@ export const rabby: SoftwareWallet = {
 					url: 'https://github.com/RabbyHub/Rabby/blob/5f2b84491b6af881ab4ef41f7627d5e068d10652/src/ui/views/ImportWatchAddress.tsx#L170',
 				},
 			],
+			chainSpecificAddressing: {
+				erc7828: notSupported,
+				erc7831: notSupported,
+			},
+			nonChainSpecificEnsResolution: notSupported,
 		},
 		chainAbstraction: {
 			bridging: {
 				builtInBridging: supported({
+					ref: refTodo,
 					feesLargerThan1bps: {
 						afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 						byDefault: FeeDisplayLevel.NONE,
@@ -125,6 +130,7 @@ export const rabby: SoftwareWallet = {
 				suggestedBridging: notSupported,
 			},
 			crossChainBalances: {
+				ref: refTodo,
 				ether: {
 					crossChainSumView: notSupported,
 					perChainBalanceViewAcrossMultipleChains: featureSupported,
@@ -138,6 +144,7 @@ export const rabby: SoftwareWallet = {
 			},
 		},
 		chainConfigurability: {
+			ref: refTodo,
 			customChains: true,
 			l1RpcEndpoint: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			otherRpcEndpoints: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
@@ -147,9 +154,6 @@ export const rabby: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
-				'1193': featureSupported,
-				'2700': featureSupported,
-				'6963': featureSupported,
 				ref: [
 					{
 						explanation:
@@ -157,19 +161,22 @@ export const rabby: SoftwareWallet = {
 						url: 'https://github.com/RabbyHub/Rabby/blob/develop/src/background/utils/buildinProvider.ts',
 					},
 				],
+				'1193': featureSupported,
+				'2700': featureSupported,
+				'6963': featureSupported,
 			},
 			walletCall: notSupportedWithRef({
 				ref: 'https://github.com/RabbyHub/Rabby/blob/fa9d0988e944f67e70da67d852cf3041d3b162da/src/background/controller/provider/controller.ts#L402-L407',
 			}),
 		},
 		license: {
-			license: License.MIT,
 			ref: [
 				{
 					explanation: 'Rabby is licensed under the MIT license.',
 					url: 'https://github.com/RabbyHub/Rabby/blob/develop/LICENSE',
 				},
 			],
+			license: License.MIT,
 		},
 		monetization: {
 			ref: [
@@ -207,6 +214,7 @@ export const rabby: SoftwareWallet = {
 					createInAppConnectionFlow: notSupported,
 					erc7846WalletConnect: notSupported,
 					ethAccounts: supported({
+						ref: refTodo,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
 					useAppSpecificLastConnectedAddresses: notSupported,
@@ -232,6 +240,14 @@ export const rabby: SoftwareWallet = {
 					[UserFlow.APP_CONNECTION]: {
 						collected: [
 							{
+								ref: [
+									{
+										explanation:
+											'Rabby checks whether the domain you are connecting your wallet to is on a scam list. It sends the domain along with Ethereum address in non-proxied HTTP requests for API methods `getOriginIsScam`, `getOriginPopularityLevel`, `getRecommendChains`, and others.',
+										label: 'Rabby API code on npmjs.com',
+										url: 'https://www.npmjs.com/package/@rabby-wallet/rabby-api?activeTab=code',
+									},
+								],
 								// The code refers to this by `api.rabby.io`, but Rabby is wholly owned by DeBank.
 								byEntity: deBank,
 								dataCollection: {
@@ -245,20 +261,27 @@ export const rabby: SoftwareWallet = {
 									},
 								},
 								purposes: [DataCollectionPurpose.SCAM_DETECTION],
-								ref: [
-									{
-										explanation:
-											'Rabby checks whether the domain you are connecting your wallet to is on a scam list. It sends the domain along with Ethereum address in non-proxied HTTP requests for API methods `getOriginIsScam`, `getOriginPopularityLevel`, `getRecommendChains`, and others.',
-										label: 'Rabby API code on npmjs.com',
-										url: 'https://www.npmjs.com/package/@rabby-wallet/rabby-api?activeTab=code',
-									},
-								],
 							},
 						],
 					},
 					[UserFlow.UNCLASSIFIED]: {
 						collected: [
 							{
+								ref: [
+									{
+										explanation: 'All wallet traffic goes through api.rabby.io without proxying.',
+										url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/constant/index.ts#L468',
+									},
+									{
+										explanation: 'Balance refresh requests are made about the active address only.',
+										url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/background/controller/wallet.ts#L1622',
+									},
+									{
+										explanation:
+											'Rabby uses self-hosted Matomo Analytics to track user actions within the wallet interface. While this tracking data does not contain wallet addresses, it goes to DeBank-owned servers much like Ethereum RPC requests do. This puts DeBank in a position to link user actions with wallet addresses through IP address correlation.',
+										url: 'https://github.com/search?q=repo%3ARabbyHub%2FRabby%20matomoRequestEvent&type=code',
+									},
+								],
 								// The code refers to this by `api.rabby.io`, but Rabby is wholly owned by DeBank.
 								byEntity: deBank,
 								dataCollection: {
@@ -279,21 +302,6 @@ export const rabby: SoftwareWallet = {
 									DataCollectionPurpose.SWAP_QUOTE,
 									DataCollectionPurpose.TRANSACTION_BROADCAST,
 									DataCollectionPurpose.TRANSACTION_SIMULATION,
-								],
-								ref: [
-									{
-										explanation: 'All wallet traffic goes through api.rabby.io without proxying.',
-										url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/constant/index.ts#L468',
-									},
-									{
-										explanation: 'Balance refresh requests are made about the active address only.',
-										url: 'https://github.com/RabbyHub/Rabby/blob/356ed60957d61d508a89d71c63a33b7474d6b311/src/background/controller/wallet.ts#L1622',
-									},
-									{
-										explanation:
-											'Rabby uses self-hosted Matomo Analytics to track user actions within the wallet interface. While this tracking data does not contain wallet addresses, it goes to DeBank-owned servers much like Ethereum RPC requests do. This puts DeBank in a position to link user actions with wallet addresses through IP address correlation.',
-										url: 'https://github.com/search?q=repo%3ARabbyHub%2FRabby%20matomoRequestEvent&type=code',
-									},
 								],
 							},
 						],
@@ -347,21 +355,22 @@ export const rabby: SoftwareWallet = {
 				ethereumL1: notSupported,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: [
 				{
+					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/Rabby%20chrome%20extension%20Penetration%20Testing%20Report.pdf',
 					auditDate: '2021-06-18',
 					auditor: slowMist,
 					codeSnapshot: {
 						date: '2021-06-23',
 					},
-					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/Rabby%20chrome%20extension%20Penetration%20Testing%20Report.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/SlowMist%20Audit%20Report%20-%20Rabby%20browser%20extension%20wallet-2022.03.18.pdf',
 					auditDate: '2022-03-18',
 					auditor: slowMist,
 					codeSnapshot: {
@@ -369,11 +378,11 @@ export const rabby: SoftwareWallet = {
 						date: '2022-01-26',
 						tag: 'v0.21.1',
 					},
-					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/SlowMist%20Audit%20Report%20-%20Rabby%20browser%20extension%20wallet-2022.03.18.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/SlowMist%20Audit%20Report%20-%20Rabby%20Wallet-2023.07.20.pdf',
 					auditDate: '2023-07-20',
 					auditor: slowMist,
 					codeSnapshot: {
@@ -381,11 +390,11 @@ export const rabby: SoftwareWallet = {
 						date: '2023-06-19',
 						tag: 'v0.91.0',
 					},
-					ref: 'https://github.com/RabbyHub/Rabby/blob/master/docs/SlowMist%20Audit%20Report%20-%20Rabby%20Wallet-2023.07.20.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/RabbyDesktop/blob/publish/prod/docs/SlowMist%20Audit%20Report%20-%20Rabby%20Wallet%20Desktop.pdf',
 					auditDate: '2023-09-26',
 					auditor: slowMist,
 					codeSnapshot: {
@@ -393,18 +402,17 @@ export const rabby: SoftwareWallet = {
 						date: '2023-09-01',
 						tag: 'v0.33.0-prod',
 					},
-					ref: 'https://github.com/RabbyHub/RabbyDesktop/blob/publish/prod/docs/SlowMist%20Audit%20Report%20-%20Rabby%20Wallet%20Desktop.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: { [Variant.DESKTOP]: true },
 				},
 				{
+					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/Least%20Authority%20-%20Debank%20Rabby%20Walle%20Audit%20Report.pdf',
 					auditDate: '2024-10-18',
 					auditor: leastAuthority,
 					codeSnapshot: {
 						commit: 'a8dea5d8c530cb1acf9104a7854089256c36d85a',
 						date: '2024-09-08',
 					},
-					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/Least%20Authority%20-%20Debank%20Rabby%20Walle%20Audit%20Report.pdf',
 					unpatchedFlaws: [
 						{
 							name: 'Issue B: Insecure Key Derivation Function',
@@ -425,13 +433,13 @@ export const rabby: SoftwareWallet = {
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/Cure53%20-%20Debank%20Rabby%20Wallet%20Audit%20Report.pdf',
 					auditDate: '2024-10-22',
 					auditor: cure53,
 					codeSnapshot: {
 						commit: 'a8dea5d8c530cb1acf9104a7854089256c36d85a',
 						date: '2024-09-08',
 					},
-					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/Cure53%20-%20Debank%20Rabby%20Wallet%20Audit%20Report.pdf',
 					unpatchedFlaws: [
 						{
 							name: 'RBY-01-001 WP1-WP2: Mnemonic recoverable via process dump',
@@ -462,47 +470,41 @@ export const rabby: SoftwareWallet = {
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/SlowMist%20Audit%20Report%20-%20Rabby%20mobile%20wallet%20iOS.pdf',
 					auditDate: '2024-10-23',
 					auditor: slowMist,
 					codeSnapshot: {
 						commit: 'a424dbe54bba464da7585769140f6b7136c9108b',
 						date: '2024-06-17',
 					},
-					ref: 'https://github.com/RabbyHub/rabby-mobile/blob/develop/docs/SlowMist%20Audit%20Report%20-%20Rabby%20mobile%20wallet%20iOS.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/Rabby/blob/develop/docs/Least%20Authority%20-%20DeBank%20Rabby%20Wallet%20Extension%20Final%20Audit%20Report-20241212.pdf',
 					auditDate: '2024-12-12',
 					auditor: leastAuthority,
 					codeSnapshot: {
 						commit: 'eb5da18727b38a3fd693af8b74f6f151f2fd361c',
 						date: '2024-10-14',
 					},
-					ref: 'https://github.com/RabbyHub/Rabby/blob/develop/docs/Least%20Authority%20-%20DeBank%20Rabby%20Wallet%20Extension%20Final%20Audit%20Report-20241212.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/RabbyHub/Rabby/blob/develop/docs/Rabby%20Browser%20Extension%20Wallet%20-%20SlowMist%20Audit%20Report-20241217.pdf',
 					auditDate: '2024-12-17',
 					auditor: slowMist,
 					codeSnapshot: {
 						commit: '4e900e5944a671e99a135eea417bdfdb93072d99',
 						date: '2024-11-28',
 					},
-					ref: 'https://github.com/RabbyHub/Rabby/blob/develop/docs/Rabby%20Browser%20Extension%20Wallet%20-%20SlowMist%20Audit%20Report-20241217.pdf',
 					unpatchedFlaws: 'ALL_FIXED',
 					variantsScope: 'ALL_VARIANTS',
 				},
 			],
 			scamAlerts: {
 				contractTransactionWarning: supported({
-					contractRegistry: true,
-					leaksContractAddress: true,
-					leaksUserAddress: true,
-					leaksUserIp: true,
-					previousContractInteractionWarning: false,
-					recentContractWarning: true,
 					ref: [
 						{
 							label: 'Rabby Security engine rule for contract recency',
@@ -519,11 +521,14 @@ export const rabby: SoftwareWallet = {
 							url: 'https://www.npmjs.com/package/@rabby-wallet/rabby-api?activeTab=code',
 						},
 					],
-				}),
-				scamUrlWarning: supported({
-					leaksIp: true,
+					contractRegistry: true,
+					leaksContractAddress: true,
 					leaksUserAddress: true,
-					leaksVisitedUrl: 'DOMAIN_ONLY',
+					leaksUserIp: true,
+					previousContractInteractionWarning: false,
+					recentContractWarning: true,
+				}),
+				scamUrlWarning: supported<ScamUrlWarning>({
 					ref: [
 						{
 							label: 'Rabby Security engine rule for scam URL flagging',
@@ -536,12 +541,11 @@ export const rabby: SoftwareWallet = {
 							url: 'https://www.npmjs.com/package/@rabby-wallet/rabby-api?activeTab=code',
 						},
 					],
+					leaksIp: true,
+					leaksUserAddress: true,
+					leaksVisitedUrl: 'DOMAIN_ONLY',
 				}),
 				sendTransactionWarning: supported({
-					leaksRecipient: false,
-					leaksUserAddress: false,
-					leaksUserIp: false,
-					newRecipientWarning: false,
 					ref: [
 						{
 							label: 'Rabby Security engine rule for sending to unknown addresses',
@@ -552,6 +556,10 @@ export const rabby: SoftwareWallet = {
 							url: 'https://github.com/RabbyHub/rabby-security-engine/blob/5f6acd1a90eb0230176fadc7d0ae373cf8c21a73/src/rules/send.ts#L113-L132',
 						},
 					],
+					leaksRecipient: false,
+					leaksUserAddress: false,
+					leaksUserIp: false,
+					newRecipientWarning: false,
 					userWhitelist: true,
 				}),
 			},
@@ -559,6 +567,7 @@ export const rabby: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: featureSupported,
 				},
@@ -567,22 +576,26 @@ export const rabby: SoftwareWallet = {
 						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 					[TransactionSubmissionL2Type.opStack]:
 						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					ref: refTodo,
 				},
 			},
 		},
 		transparency: {
 			operationFees: {
 				builtInErc20Swap: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.NONE,
 					fullySponsored: false,
 				}),
 				erc20L1Transfer: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.NONE,
 					fullySponsored: false,
 				}),
 				ethL1Transfer: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.NONE,
 					fullySponsored: false,

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -11,6 +11,7 @@ import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-v
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
 import { License } from '@/schema/features/transparency/license'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -34,6 +35,7 @@ export const rainbow: SoftwareWallet = {
 			defaultAccountType: AccountType.eoa,
 			eip7702: notSupported,
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -47,12 +49,12 @@ export const rainbow: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -61,15 +63,14 @@ export const rainbow: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: {
-			license: License.GPL_3_0,
 			ref: [
 				{
 					explanation: 'Rainbow uses the GPL-3.0 license for its source code',
@@ -77,9 +78,10 @@ export const rainbow: SoftwareWallet = {
 					url: 'https://github.com/rainbow-me/rainbow/blob/develop/LICENSE',
 				},
 			],
+			license: License.GPL_3_0,
 		},
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -109,7 +111,7 @@ export const rainbow: SoftwareWallet = {
 		security: {
 			bugBountyProgram: null,
 			hardwareWalletSupport: {
-				ref: null,
+				ref: refTodo,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.webUSB, HardwareWalletConnection.bluetooth],
@@ -123,8 +125,8 @@ export const rainbow: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -132,12 +134,14 @@ export const rainbow: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -10,6 +10,7 @@ import {
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { type ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import {
 	TransactionSubmissionL2Support,
@@ -18,6 +19,7 @@ import {
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display' // for level
 import { License } from '@/schema/features/transparency/license' // assuming path
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -44,18 +46,19 @@ export const safe: SoftwareWallet = {
 			eoa: notSupported,
 			mpc: notSupported,
 			rawErc4337: supported({
-				contract: 'UNKNOWN',
-				controllingSharesInSelfCustodyByDefault: 'YES',
-				keyRotationTransactionGeneration:
-					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				ref: {
 					explanation: 'Safe supports ERC-4337 via their 4337 module implementation',
 					url: 'https://github.com/safe-global/safe-modules/tree/master/4337',
 				},
+				contract: 'UNKNOWN',
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration:
+					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: supported({
+				ref: refNotNecessary, // It's Safe Wallet, duh.
 				canDeployNew: true,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				defaultConfig: {
@@ -77,15 +80,16 @@ export const safe: SoftwareWallet = {
 			}),
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: {
+			ref: refTodo,
 			customChains: false,
 			l1RpcEndpoint: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 			otherRpcEndpoints: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
@@ -95,21 +99,20 @@ export const safe: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: supported({
-				atomicMultiTransactions: featureSupported,
 				ref: {
 					explanation: 'Safe supports EIP-5792 for transaction batching.',
 					url: 'https://github.com/safe-global/safe-wallet-monorepo/blob/f918ceb9b561dd3a27af96903071cd56c1fb5ddd/apps/web/src/services/safe-wallet-provider/index.ts#L184',
 				},
+				atomicMultiTransactions: featureSupported,
 			}),
 		},
 		license: {
-			license: License.GPL_3_0,
 			ref: [
 				{
 					explanation: 'Safe uses the LGPL-3.0 license for its source code', // keep explanation but change enum if needed
@@ -117,6 +120,7 @@ export const safe: SoftwareWallet = {
 					url: 'https://github.com/safe-global/safe-wallet-monorepo',
 				},
 			],
+			license: License.GPL_3_0,
 		},
 		monetization: {
 			ref: [
@@ -194,10 +198,6 @@ export const safe: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
-				details: 'Safe uses FreshCryptoLib for passkey verification in their 4337 modules.',
-				library: PasskeyVerificationLibrary.FRESH_CRYPTO_LIB,
-				libraryUrl:
-					'https://github.com/safe-global/safe-modules/tree/main/modules/passkey/contracts/vendor/FCL',
 				ref: [
 					{
 						url: 'https://github.com/safe-global/safe-modules/tree/main/modules/passkey/contracts/vendor/FCL',
@@ -207,25 +207,30 @@ export const safe: SoftwareWallet = {
 						url: 'https://github.com/safe-global/safe-modules/blob/main/modules/passkey/contracts/verifiers/FCLP256Verifier.sol',
 					},
 				],
+				details: 'Safe uses FreshCryptoLib for passkey verification in their 4337 modules.',
+				library: PasskeyVerificationLibrary.FRESH_CRYPTO_LIB,
+				libraryUrl:
+					'https://github.com/safe-global/safe-modules/tree/main/modules/passkey/contracts/vendor/FCL',
 			},
 			publicSecurityAudits: [
 				{
+					ref: 'https://github.com/safe-global/safe-smart-account/blob/main/docs/Safe_Audit_Report_1_5_0_Certora.pdf',
 					auditDate: '2025-01-14',
 					auditor: certora,
-					ref: 'https://github.com/safe-global/safe-smart-account/blob/main/docs/Safe_Audit_Report_1_5_0_Certora.pdf',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
 				{
+					ref: 'https://github.com/safe-global/safe-smart-account/blob/main/docs/Safe_Audit_Report_1_5_0_Ackee.pdf',
 					auditDate: '2025-05-28',
 					auditor: ackee,
-					ref: 'https://github.com/safe-global/safe-smart-account/blob/main/docs/Safe_Audit_Report_1_5_0_Ackee.pdf',
 					unpatchedFlaws: 'NONE_FOUND',
 					variantsScope: 'ALL_VARIANTS',
 				},
 			],
 			scamAlerts: {
 				contractTransactionWarning: supported({
+					ref: refTodo,
 					contractRegistry: true, //blockaid
 					leaksContractAddress: true,
 					leaksUserAddress: true,
@@ -233,12 +238,14 @@ export const safe: SoftwareWallet = {
 					previousContractInteractionWarning: false,
 					recentContractWarning: true, //blockaid
 				}),
-				scamUrlWarning: supported({
+				scamUrlWarning: supported<ScamUrlWarning>({
+					ref: refTodo,
 					leaksIp: true,
 					leaksUserAddress: true,
 					leaksVisitedUrl: 'FULL_URL',
 				}),
 				sendTransactionWarning: supported({
+					ref: refTodo,
 					leaksRecipient: true,
 					leaksUserAddress: true,
 					leaksUserIp: true,
@@ -250,10 +257,12 @@ export const safe: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: notSupported,
 					selfBroadcastViaSelfHostedNode: featureSupported,
 				},
 				l2: {
+					ref: refTodo,
 					[TransactionSubmissionL2Type.arbitrum]:
 						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 					[TransactionSubmissionL2Type.opStack]:
@@ -264,21 +273,25 @@ export const safe: SoftwareWallet = {
 		transparency: {
 			operationFees: {
 				builtInErc20Swap: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,
 				}),
 				erc20L1Transfer: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,
 				}),
 				ethL1Transfer: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,
 				}),
 				uniswapUSDCToEtherSwap: supported({
+					ref: refTodo,
 					afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 					byDefault: FeeDisplayLevel.COMPREHENSIVE,
 					fullySponsored: false,

--- a/data/software-wallets/unrated.tmpl.ts
+++ b/data/software-wallets/unrated.tmpl.ts
@@ -1,6 +1,7 @@
 import { exampleContributor } from '@/data/contributors/example'
 import { WalletProfile } from '@/schema/features/profile'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -24,12 +25,12 @@ export const unratedTemplate: SoftwareWallet = {
 	features: {
 		accountSupport: null,
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -38,16 +39,16 @@ export const unratedTemplate: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -82,12 +83,14 @@ export const unratedTemplate: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -10,6 +10,7 @@ import {
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
+import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -32,6 +33,7 @@ export const zerion: SoftwareWallet = {
 			eip7702: notSupported,
 			// BIP support is not verified
 			eoa: supported({
+				ref: refTodo,
 				canExportPrivateKey: true,
 				keyDerivation: {
 					type: 'BIP32',
@@ -45,12 +47,12 @@ export const zerion: SoftwareWallet = {
 			safe: notSupported,
 		},
 		addressResolution: {
+			ref: refTodo,
 			chainSpecificAddressing: {
 				erc7828: null,
 				erc7831: null,
 			},
 			nonChainSpecificEnsResolution: null,
-			ref: null,
 		},
 		chainAbstraction: null,
 		chainConfigurability: null,
@@ -59,16 +61,16 @@ export const zerion: SoftwareWallet = {
 		},
 		integration: {
 			browser: {
+				ref: refTodo,
 				'1193': null,
 				'2700': null,
 				'6963': null,
-				ref: null,
 			},
 			walletCall: null,
 		},
 		license: null,
 		monetization: {
-			ref: null,
+			ref: refTodo,
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -124,8 +126,8 @@ export const zerion: SoftwareWallet = {
 				ethereumL1: null,
 			},
 			passkeyVerification: {
+				ref: refNotNecessary,
 				library: PasskeyVerificationLibrary.NONE,
-				ref: null,
 			},
 			publicSecurityAudits: null,
 			scamAlerts: null,
@@ -133,12 +135,14 @@ export const zerion: SoftwareWallet = {
 		selfSovereignty: {
 			transactionSubmission: {
 				l1: {
+					ref: refTodo,
 					selfBroadcastViaDirectGossip: null,
 					selfBroadcastViaSelfHostedNode: null,
 				},
 				l2: {
 					[TransactionSubmissionL2Type.arbitrum]: null,
 					[TransactionSubmissionL2Type.opStack]: null,
+					ref: refTodo,
 				},
 			},
 		},

--- a/data/wallet-contracts/ambire-account.ts
+++ b/data/wallet-contracts/ambire-account.ts
@@ -10,10 +10,10 @@ export const ambireAccountContract: SmartWalletContract = {
 		validateUserOp: featureSupported,
 	},
 	sourceCode: {
-		available: true,
 		ref: {
 			label: 'Ambire ERC-4337 smart contract',
 			url: 'https://github.com/AmbireTech/ambire-common/blob/v2/contracts/AmbireAccount.sol',
 		},
+		available: true,
 	},
 }

--- a/data/wallet-contracts/ambire-delegator.ts
+++ b/data/wallet-contracts/ambire-delegator.ts
@@ -10,10 +10,10 @@ export const ambireDelegatorContract: SmartWalletContract = {
 		validateUserOp: featureSupported,
 	},
 	sourceCode: {
-		available: true,
 		ref: {
 			label: 'Ambire EIP-7702 smart contract code',
 			url: 'https://github.com/AmbireTech/ambire-common/blob/v2/contracts/AmbireAccount7702.sol',
 		},
+		available: true,
 	},
 }

--- a/data/wallet-contracts/metamask-7702-delegator.ts
+++ b/data/wallet-contracts/metamask-7702-delegator.ts
@@ -1,5 +1,6 @@
 import type { SmartWalletContract } from '@/schema/contracts'
 import { featureSupported } from '@/schema/features/support'
+import { refTodo } from '@/schema/reference'
 
 export const metamask7702DelegatorContract: SmartWalletContract = {
 	name: 'MetaMask 7702 Delegator',
@@ -9,5 +10,8 @@ export const metamask7702DelegatorContract: SmartWalletContract = {
 		isValidSignature: featureSupported,
 		validateUserOp: featureSupported,
 	},
-	sourceCode: { available: true },
+	sourceCode: {
+		ref: refTodo,
+		available: true,
+	},
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ const firstOrderedKeys = [
 	'formalTitle',
 	'type',
 	'metadata',
+	'ref',
 ]
 
 export default [

--- a/src/schema/attributes/ecosystem/account-abstraction.ts
+++ b/src/schema/attributes/ecosystem/account-abstraction.ts
@@ -17,6 +17,7 @@ import {
 	type AccountTypeSafe,
 	isAccountTypeSupported,
 } from '@/schema/features/account-support'
+import { isSupported } from '@/schema/features/support'
 import { mergeRefs, type ReferenceArray, refs } from '@/schema/reference'
 import { markdown, mdParagraph, mdSentence, sentence } from '@/types/content'
 
@@ -237,10 +238,12 @@ export const accountAbstraction: Attribute<AccountAbstractionValue> = {
 			eip7702: isAccountTypeSupported<AccountType7702>(features.accountSupport.eip7702),
 		}
 		const allRefs = mergeRefs(
-			refs(features.accountSupport.eoa),
-			refs(features.accountSupport.mpc),
-			refs(features.accountSupport.rawErc4337),
-			refs(features.accountSupport.eip7702),
+			isSupported(features.accountSupport.eoa) ? refs(features.accountSupport.eoa) : [],
+			isSupported(features.accountSupport.mpc) ? refs(features.accountSupport.mpc) : [],
+			isSupported(features.accountSupport.rawErc4337)
+				? refs(features.accountSupport.rawErc4337)
+				: [],
+			isSupported(features.accountSupport.eip7702) ? refs(features.accountSupport.eip7702) : [],
 		)
 
 		if (supported.rawErc4337 && supported.eip7702) {

--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -328,7 +328,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 							support: 'NOT_SUPPORTED',
 						},
 					},
-					refs({}),
+					[],
 				),
 			),
 		],

--- a/src/schema/attributes/ecosystem/browser-integration.ts
+++ b/src/schema/attributes/ecosystem/browser-integration.ts
@@ -16,7 +16,7 @@ import {
 	notSupported,
 	type Support,
 } from '@/schema/features/support'
-import { popRefs, type WithRef } from '@/schema/reference'
+import { popRefs, refNotNecessary, type WithRef } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { commaListFormat } from '@/types/utils/text'
@@ -141,6 +141,7 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
 		pass: exampleRating(
 			sentence('The wallet implements all listed web browser integration standards.'),
 			browserIntegrationSupport({
+				ref: refNotNecessary,
 				'1193': featureSupported,
 				'2700': featureSupported,
 				'6963': featureSupported,
@@ -149,6 +150,7 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
 		partial: exampleRating(
 			sentence('The wallet implements some but not all listed web browser integration standards.'),
 			browserIntegrationSupport({
+				ref: refNotNecessary,
 				'1193': featureSupported,
 				'2700': featureSupported,
 				'6963': notSupported,
@@ -157,6 +159,7 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
 		fail: exampleRating(
 			sentence('The wallet implements none of the listed web browser integration standards.'),
 			browserIntegrationSupport({
+				ref: refNotNecessary,
 				'1193': notSupported,
 				'2700': notSupported,
 				'6963': notSupported,

--- a/src/schema/attributes/ecosystem/chain-abstraction.ts
+++ b/src/schema/attributes/ecosystem/chain-abstraction.ts
@@ -10,12 +10,18 @@ import type {
 	ChainAbstraction,
 	CrossChainBalanceDisplay,
 } from '@/schema/features/ecosystem/chain-abstraction'
-import { featureSupported, isSupported, notSupported, supported } from '@/schema/features/support'
+import {
+	featureSupported,
+	featureSupportedNoRef,
+	isSupported,
+	notSupported,
+	supported,
+} from '@/schema/features/support'
 import {
 	comprehensiveFeesShownByDefault,
 	FeeDisplayLevel,
 } from '@/schema/features/transparency/fee-display'
-import { mergeRefs, refs } from '@/schema/reference'
+import { mergeRefs, refNotNecessary, refs } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, sentence } from '@/types/content'
 
@@ -330,18 +336,20 @@ const fullySupportedCrossChainBalanceDisplay: CrossChainBalanceDisplay = {
 }
 
 const fullySupportedCrossChainBalances: ChainAbstraction['crossChainBalances'] = {
-	globalAccountValue: featureSupported,
-	perChainAccountValue: featureSupported,
+	globalAccountValue: featureSupportedNoRef,
+	perChainAccountValue: featureSupportedNoRef,
 	ether: fullySupportedCrossChainBalanceDisplay,
 	usdc: fullySupportedCrossChainBalanceDisplay,
+	ref: refNotNecessary,
 }
 
 const fullySupportedBridging: ChainAbstraction['bridging'] = {
 	builtInBridging: supported({
+		ref: refNotNecessary,
 		risksExplained: 'VISIBLE_BY_DEFAULT',
 		feesLargerThan1bps: comprehensiveFeesShownByDefault,
 	}),
-	suggestedBridging: featureSupported,
+	suggestedBridging: featureSupportedNoRef,
 }
 
 export const chainAbstraction: Attribute<ChainAbstractionValue> = {
@@ -405,6 +413,7 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
 				),
 				evaluateChainAbstraction({
 					crossChainBalances: {
+						ref: refNotNecessary,
 						globalAccountValue: notSupported,
 						perChainAccountValue: notSupported,
 						ether: {
@@ -437,6 +446,7 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
 				),
 				evaluateChainAbstraction({
 					crossChainBalances: {
+						ref: refNotNecessary,
 						globalAccountValue: featureSupported,
 						perChainAccountValue: featureSupported,
 						ether: {
@@ -459,6 +469,7 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
 					crossChainBalances: fullySupportedCrossChainBalances,
 					bridging: {
 						builtInBridging: supported({
+							ref: refNotNecessary,
 							feesLargerThan1bps: {
 								byDefault: FeeDisplayLevel.NONE,
 								afterSingleAction: FeeDisplayLevel.NONE,
@@ -478,6 +489,7 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
 					crossChainBalances: fullySupportedCrossChainBalances,
 					bridging: {
 						builtInBridging: supported({
+							ref: refNotNecessary,
 							feesLargerThan1bps: comprehensiveFeesShownByDefault,
 							risksExplained: 'HIDDEN_BY_DEFAULT',
 						}),

--- a/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
+++ b/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
@@ -17,7 +17,7 @@ import {
 	supportsHardwareWalletTypesMarkdown,
 } from '@/schema/features/security/hardware-wallet-support'
 import { isSupported, notSupported, supported } from '@/schema/features/support'
-import { popRefs } from '@/schema/reference'
+import { popRefs, refNotNecessary } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 import type { NonEmptyArray } from '@/types/utils/non-empty'
@@ -206,6 +206,7 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 				WalletConnect with an external application).
 			`),
 			comprehensiveHardwareWalletSupport({
+				ref: refNotNecessary,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.USB],
@@ -227,6 +228,7 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 					additional software in order to use.
 				`),
 				insufficientHardwareWalletManufacturerSupport({
+					ref: refNotNecessary,
 					wallets: {
 						[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 							connectionTypes: [HardwareWalletConnection.USB],
@@ -249,6 +251,7 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 					additional software in order to use.
 				`),
 				singleHardwareWalletManufacturerSupport({
+					ref: refNotNecessary,
 					wallets: {
 						[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 							connectionTypes: [HardwareWalletConnection.USB],
@@ -272,13 +275,13 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 					'This attribute is not applicable for {{WALLET_NAME}} as it is a hardware wallet itself.',
 				),
 				brand,
-				{ hardwareWalletSupport: { wallets: {} } },
+				{ hardwareWalletSupport: { ref: refNotNecessary, wallets: {} } },
 			)
 		}
 
 		if (features.security.hardwareWalletSupport === null) {
 			return unrated(hardwareWalletInteroperability, brand, {
-				hardwareWalletSupport: { wallets: {} },
+				hardwareWalletSupport: { ref: refNotNecessary, wallets: {} },
 			})
 		}
 
@@ -308,13 +311,15 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 						{ hardwareWalletSupport: features.security.hardwareWalletSupport },
 					)
 				case 1:
-					return singleHardwareWalletManufacturerSupport(withoutRefs)
+					return singleHardwareWalletManufacturerSupport(features.security.hardwareWalletSupport)
 				default:
 					if (majorManufacturerSupported < minMajorHardwareWalletManufacturers) {
-						return insufficientHardwareWalletManufacturerSupport(withoutRefs)
+						return insufficientHardwareWalletManufacturerSupport(
+							features.security.hardwareWalletSupport,
+						)
 					}
 
-					return comprehensiveHardwareWalletSupport(withoutRefs)
+					return comprehensiveHardwareWalletSupport(features.security.hardwareWalletSupport)
 			}
 		})()
 

--- a/src/schema/attributes/ecosystem/transaction-batching.ts
+++ b/src/schema/attributes/ecosystem/transaction-batching.ts
@@ -22,10 +22,11 @@ import {
 	featureSupported,
 	isSupported,
 	notSupported,
+	notSupportedWithRef,
 	type Support,
 	supported,
 } from '@/schema/features/support'
-import { mergeRefs, refs, type WithRef } from '@/schema/reference'
+import { mergeRefs, refNotNecessary, refs, type WithRef } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content'
 
@@ -39,7 +40,7 @@ export type TransactionBatchingValue = Value & {
 
 function evaluateTransactionBatching(
 	accountSupport: AccountSupport,
-	walletCall: WithRef<Support<WalletCallIntegration>>,
+	walletCall: Support<WithRef<WalletCallIntegration>>,
 ): Evaluation<TransactionBatchingValue> {
 	if (
 		!isSupported<AccountType7702>(accountSupport.eip7702) &&
@@ -66,11 +67,14 @@ function evaluateTransactionBatching(
 				{{WALLET_NAME}} should support smart accounts, such as
 				${eipMarkdownLink(eip7702)} accounts.
 			`),
-			references: mergeRefs(refs(accountSupport.eip7702), refs(accountSupport.rawErc4337)),
+			references: mergeRefs(
+				isSupported(accountSupport.eip7702) ? refs(accountSupport.eip7702) : [],
+				isSupported(accountSupport.rawErc4337) ? refs(accountSupport.rawErc4337) : [],
+			),
 		}
 	}
 
-	let references = mergeRefs(refs(walletCall))
+	let references = mergeRefs(isSupported(walletCall) ? refs(walletCall) : [])
 
 	if (!isSupported<WalletCallIntegration>(walletCall)) {
 		return {
@@ -95,7 +99,7 @@ function evaluateTransactionBatching(
 		}
 	}
 
-	references = mergeRefs(references, refs(walletCall.atomicMultiTransactions))
+	references = mergeRefs(references, refs(walletCall))
 
 	if (!isSupported<Support>(walletCall.atomicMultiTransactions)) {
 		return {
@@ -193,11 +197,20 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 				sentence('The wallet does not support any type of smart account.'),
 				evaluateTransactionBatching(
 					{
-						eoa: notSupported,
-						mpc: notSupported,
+						eoa: supported({
+							canExportPrivateKey: true,
+							keyDerivation: {
+								type: 'BIP32',
+								derivationPath: 'BIP44',
+								seedPhrase: 'BIP39',
+								canExportSeedPhrase: true,
+							},
+							ref: refNotNecessary,
+						}),
 						safe: notSupported,
-						eip7702: notSupported,
-						rawErc4337: notSupported,
+						mpc: notSupportedWithRef({ ref: refNotNecessary }),
+						eip7702: notSupportedWithRef({ ref: refNotNecessary }),
+						rawErc4337: notSupportedWithRef({ ref: refNotNecessary }),
 						defaultAccountType: AccountType.eoa,
 					},
 					notSupported,
@@ -209,13 +222,14 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 				),
 				evaluateTransactionBatching(
 					{
-						eoa: notSupported,
-						mpc: notSupported,
+						eoa: notSupportedWithRef({ ref: refNotNecessary }),
+						mpc: notSupportedWithRef({ ref: refNotNecessary }),
 						safe: notSupported,
 						eip7702: supported({
+							ref: refNotNecessary,
 							contract: 'UNKNOWN',
 						}),
-						rawErc4337: notSupported,
+						rawErc4337: notSupportedWithRef({ ref: refNotNecessary }),
 						defaultAccountType: AccountType.eip7702,
 					},
 					notSupported,
@@ -228,16 +242,18 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 			),
 			evaluateTransactionBatching(
 				{
-					eoa: notSupported,
-					mpc: notSupported,
+					eoa: notSupportedWithRef({ ref: refNotNecessary }),
+					mpc: notSupportedWithRef({ ref: refNotNecessary }),
 					safe: notSupported,
 					eip7702: supported({
+						ref: refNotNecessary,
 						contract: 'UNKNOWN',
 					}),
-					rawErc4337: notSupported,
+					rawErc4337: notSupportedWithRef({ ref: refNotNecessary }),
 					defaultAccountType: AccountType.eip7702,
 				},
 				supported({
+					ref: refNotNecessary,
 					atomicMultiTransactions: notSupported,
 				}),
 			),
@@ -248,16 +264,18 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 			),
 			evaluateTransactionBatching(
 				{
-					eoa: notSupported,
-					mpc: notSupported,
+					eoa: notSupportedWithRef({ ref: refNotNecessary }),
+					mpc: notSupportedWithRef({ ref: refNotNecessary }),
 					safe: notSupported,
 					eip7702: supported({
+						ref: refNotNecessary,
 						contract: 'UNKNOWN',
 					}),
-					rawErc4337: notSupported,
+					rawErc4337: notSupportedWithRef({ ref: refNotNecessary }),
 					defaultAccountType: AccountType.eip7702,
 				},
 				supported({
+					ref: refNotNecessary,
 					atomicMultiTransactions: featureSupported,
 				}),
 			),

--- a/src/schema/attributes/privacy/app-isolation.ts
+++ b/src/schema/attributes/privacy/app-isolation.ts
@@ -8,13 +8,20 @@ import {
 } from '@/schema/attributes'
 import { type ResolvedFeatures } from '@/schema/features'
 import {
+	appConnectionNotSupported,
 	type AppIsolation,
 	ExposedAccountsBehavior,
 	type ExposedAccountSet,
+	isAppConnectionSupportedInAppIsolation,
 	sameExposedAccountSet,
 } from '@/schema/features/privacy/app-isolation'
-import { featureSupported, isSupported, notSupported, supported } from '@/schema/features/support'
-import { type FullyQualifiedReference, mergeRefs } from '@/schema/reference'
+import {
+	featureSupportedNoRef,
+	isSupported,
+	notSupported,
+	supported,
+} from '@/schema/features/support'
+import { type FullyQualifiedReference, mergeRefs, refNotNecessary } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
@@ -26,7 +33,9 @@ export type AppIsolationValue = Value & {
 	__brand: 'attributes.privacy.app_isolation'
 }
 
-function rateAppIsolation(appIsolation: AppIsolation): Evaluation<AppIsolationValue> {
+function rateAppIsolation(
+	appIsolation: Exclude<AppIsolation, typeof appConnectionNotSupported>,
+): Evaluation<AppIsolationValue> {
 	let references: FullyQualifiedReference[] = []
 
 	if (!isSupported(appIsolation.createInAppConnectionFlow)) {
@@ -278,13 +287,15 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 				`),
 				rateAppIsolation({
 					ethAccounts: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
 					erc7846WalletConnect: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
 					createInAppConnectionFlow: notSupported,
-					useAppSpecificLastConnectedAddresses: featureSupported,
+					useAppSpecificLastConnectedAddresses: featureSupportedNoRef,
 				}),
 			),
 			exampleRating(
@@ -294,12 +305,14 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 				`),
 				rateAppIsolation({
 					ethAccounts: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.APP_SPECIFIC_ACCOUNT,
 					}),
 					erc7846WalletConnect: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.APP_SPECIFIC_ACCOUNT,
 					}),
-					createInAppConnectionFlow: featureSupported,
+					createInAppConnectionFlow: featureSupportedNoRef,
 					useAppSpecificLastConnectedAddresses: notSupported,
 				}),
 			),
@@ -310,13 +323,15 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 				`),
 				rateAppIsolation({
 					ethAccounts: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
 					erc7846WalletConnect: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.ACTIVE_ACCOUNT_ONLY,
 					}),
-					createInAppConnectionFlow: featureSupported,
-					useAppSpecificLastConnectedAddresses: featureSupported,
+					createInAppConnectionFlow: featureSupportedNoRef,
+					useAppSpecificLastConnectedAddresses: featureSupportedNoRef,
 				}),
 			),
 			exampleRating(
@@ -336,13 +351,15 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 				`),
 				rateAppIsolation({
 					ethAccounts: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.APP_SPECIFIC_ACCOUNT,
 					}),
 					erc7846WalletConnect: supported({
+						ref: refNotNecessary,
 						defaultBehavior: ExposedAccountsBehavior.APP_SPECIFIC_ACCOUNT,
 					}),
-					createInAppConnectionFlow: featureSupported,
-					useAppSpecificLastConnectedAddresses: featureSupported,
+					createInAppConnectionFlow: featureSupportedNoRef,
+					useAppSpecificLastConnectedAddresses: featureSupportedNoRef,
 				}),
 			),
 		],
@@ -361,7 +378,7 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 			return unrated(appIsolation, brand, null)
 		}
 
-		if (features.privacy.appIsolation === 'APP_CONNECTION_NOT_SUPPORTED') {
+		if (isAppConnectionSupportedInAppIsolation(features.privacy.appIsolation)) {
 			return exempt(
 				appIsolation,
 				sentence('{{WALLET_NAME}} does not support connecting to apps.'),

--- a/src/schema/attributes/privacy/hardware-privacy.ts
+++ b/src/schema/attributes/privacy/hardware-privacy.ts
@@ -5,7 +5,6 @@ import {
 	type HardwarePrivacySupport,
 	HardwarePrivacyType,
 } from '@/schema/features/privacy/hardware-privacy'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -107,8 +106,7 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<HardwarePrivacySupport>(hwPrivacy)
-		const rating = evaluateHardwarePrivacy(withoutRefs)
+		const rating = evaluateHardwarePrivacy(hwPrivacy)
 
 		return {
 			value: {
@@ -116,12 +114,12 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
 				rating,
 				displayName: 'Hardware Privacy',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} hardware privacy.`),
-				...withoutRefs,
+				...hwPrivacy, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} hardware privacy evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/privacy/private-transfers.ts
+++ b/src/schema/attributes/privacy/private-transfers.ts
@@ -42,7 +42,7 @@ import { isNonEmptyArray, type NonEmptyArray, nonEmptyFirst } from '@/types/util
 import { commaListFormat, markdownListFormat } from '@/types/utils/text'
 
 import { entityMarkdownLink } from '../../entity'
-import { mergeRefs, type ReferenceArray, refs } from '../../reference'
+import { mergeRefs, type ReferenceArray, refNotNecessary, refs } from '../../reference'
 import { pickWorstRating, unrated } from '../common'
 
 const brand = 'attributes.privacy.private_transfers'
@@ -240,10 +240,11 @@ function rateStealthAddressSupport(
 	stealthAddresses: Supported<StealthAddressSupport>,
 ): Evaluation<PrivateTransfersValue> {
 	const references: ReferenceArray = mergeRefs(
+		stealthAddresses.ref,
 		stealthAddresses.recipientAddressResolution.ref,
 		stealthAddresses.balanceLookup.ref,
 		stealthAddresses.privateKeyDerivation.ref,
-		isSupported(stealthAddresses.userLabeling) ? stealthAddresses.userLabeling.ref : null,
+		isSupported(stealthAddresses.userLabeling) ? stealthAddresses.userLabeling.ref : undefined,
 	)
 	const { sendingPrivacy, sendingDetails, sendingImprovements } = ((): {
 		sendingPrivacy: PrivateTransfersPrivacyLevel
@@ -1306,7 +1307,9 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 				`),
 				rateStealthAddressSupport(
 					supported({
+						ref: refNotNecessary,
 						balanceLookup: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_SERVICE',
 							externalService: exampleNodeCompany,
 							learns: {
@@ -1315,6 +1318,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						recipientAddressResolution: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_RESOLVER',
 							externalResolver: exampleNodeCompany,
 							learns: {
@@ -1325,6 +1329,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						privateKeyDerivation: {
+							ref: refNotNecessary,
 							type: 'LOCALLY',
 						},
 						userLabeling: notSupported,
@@ -1341,7 +1346,9 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 				`),
 				rateStealthAddressSupport(
 					supported({
+						ref: refNotNecessary,
 						balanceLookup: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_SERVICE',
 							externalService: exampleNodeCompany,
 							learns: {
@@ -1350,6 +1357,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						recipientAddressResolution: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_RESOLVER',
 							externalResolver: exampleNodeCompany,
 							learns: {
@@ -1360,9 +1368,11 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						privateKeyDerivation: {
+							ref: refNotNecessary,
 							type: 'LOCALLY',
 						},
 						userLabeling: supported({
+							ref: refNotNecessary,
 							unlabeledBehavior: StealthAddressUnlabeledBehavior.MUST_LABEL_BEFORE_SPENDING,
 						}),
 						fees: fullySponsoredFees,
@@ -1377,7 +1387,9 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 				`),
 				rateStealthAddressSupport(
 					supported({
+						ref: refNotNecessary,
 						balanceLookup: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_SERVICE',
 							externalService: exampleNodeCompany,
 							learns: {
@@ -1386,6 +1398,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						recipientAddressResolution: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_RESOLVER',
 							externalResolver: exampleNodeCompany,
 							learns: {
@@ -1396,9 +1409,11 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						privateKeyDerivation: {
+							ref: refNotNecessary,
 							type: 'LOCALLY',
 						},
 						userLabeling: supported({
+							ref: refNotNecessary,
 							unlabeledBehavior: StealthAddressUnlabeledBehavior.MUST_LABEL_BEFORE_SPENDING,
 						}),
 						fees: fullySponsoredFees,
@@ -1414,7 +1429,9 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 				`),
 				rateStealthAddressSupport(
 					supported({
+						ref: refNotNecessary,
 						balanceLookup: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_SERVICE',
 							externalService: exampleNodeCompany,
 							learns: {
@@ -1423,6 +1440,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						recipientAddressResolution: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_RESOLVER',
 							externalResolver: exampleNodeCompany,
 							learns: {
@@ -1433,9 +1451,11 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						privateKeyDerivation: {
+							ref: refNotNecessary,
 							type: 'LOCALLY',
 						},
 						userLabeling: supported({
+							ref: refNotNecessary,
 							unlabeledBehavior: StealthAddressUnlabeledBehavior.MUST_LABEL_BEFORE_SPENDING,
 						}),
 						fees: fullySponsoredFees,
@@ -1456,7 +1476,9 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 				`),
 				rateStealthAddressSupport(
 					supported({
+						ref: refNotNecessary,
 						balanceLookup: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_SERVICE',
 							externalService: exampleNodeCompany,
 							learns: {
@@ -1465,6 +1487,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						recipientAddressResolution: {
+							ref: refNotNecessary,
 							type: 'EXTERNAL_RESOLVER',
 							externalResolver: exampleNodeCompany,
 							learns: {
@@ -1475,9 +1498,11 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 							},
 						},
 						privateKeyDerivation: {
+							ref: refNotNecessary,
 							type: 'LOCALLY',
 						},
 						userLabeling: supported({
+							ref: refNotNecessary,
 							unlabeledBehavior: StealthAddressUnlabeledBehavior.MUST_LABEL_BEFORE_SPENDING,
 						}),
 						fees: fullySponsoredFees,

--- a/src/schema/attributes/security/firmware.ts
+++ b/src/schema/attributes/security/firmware.ts
@@ -2,7 +2,6 @@ import { type Attribute, type Evaluation, Rating, type Value } from '@/schema/at
 import { exampleRating } from '@/schema/attributes'
 import type { ResolvedFeatures } from '@/schema/features'
 import { type FirmwareSupport, FirmwareType } from '@/schema/features/security/firmware'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -113,8 +112,7 @@ export const firmware: Attribute<FirmwareValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<FirmwareSupport>(firmwareFeature)
-		const rating = evaluateFirmware(withoutRefs)
+		const rating = evaluateFirmware(firmwareFeature)
 
 		if (rating === Rating.UNRATED) {
 			return unrated(firmware, brand, {
@@ -131,12 +129,12 @@ export const firmware: Attribute<FirmwareValue> = {
 				rating,
 				displayName: 'Firmware',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} firmware.`),
-				...withoutRefs,
+				...firmwareFeature, // TODO: Filter fields.
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} firmware evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: References.
 		}
 	},
 }

--- a/src/schema/attributes/security/hardware-wallet-support.ts
+++ b/src/schema/attributes/security/hardware-wallet-support.ts
@@ -16,7 +16,7 @@ import {
 	supportsHardwareWalletTypesMarkdown,
 } from '@/schema/features/security/hardware-wallet-support'
 import { isSupported, notSupported, supported } from '@/schema/features/support'
-import { popRefs } from '@/schema/reference'
+import { popRefs, refNotNecessary } from '@/schema/reference'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
@@ -149,6 +149,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 				The wallet integrates any type of hardware wallet.
 			`),
 			directHardwareWalletSupport({
+				ref: refNotNecessary,
 				wallets: {
 					[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 						connectionTypes: [HardwareWalletConnection.USB],
@@ -164,6 +165,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 				(e.g. WalletConnect).
 			`),
 				indirectHardwareWalletSupport({
+					ref: refNotNecessary,
 					wallets: {
 						[HardwareWalletType.LEDGER]: supported<SupportedHardwareWallet>({
 							connectionTypes: [HardwareWalletConnection.WALLET_CONNECT],
@@ -177,7 +179,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 				paragraph(`
 					The wallet does not support any hardware wallets.
 				`),
-				noHardwareWalletSupport({ wallets: {} }),
+				noHardwareWalletSupport({ wallets: {}, ref: refNotNecessary }),
 			),
 		],
 	},
@@ -190,7 +192,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 					'This attribute is not applicable for {{WALLET_NAME}} as it is a hardware wallet itself.',
 				),
 				brand,
-				{ hardwareWalletSupport: { wallets: {} } },
+				{ hardwareWalletSupport: { wallets: {}, ref: refNotNecessary } },
 			)
 		}
 
@@ -198,7 +200,9 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 		// 	all such wallets have the opportunity to support hardware wallets to provide better security for the user
 
 		if (features.security.hardwareWalletSupport === null) {
-			return unrated(hardwareWalletSupport, brand, { hardwareWalletSupport: { wallets: {} } })
+			return unrated(hardwareWalletSupport, brand, {
+				hardwareWalletSupport: { wallets: {}, ref: refNotNecessary },
+			})
 		}
 
 		// Extract references from the hardware wallet support feature
@@ -211,7 +215,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 
 		const result = (() => {
 			if (numSupported === 0) {
-				return noHardwareWalletSupport(withoutRefs)
+				return noHardwareWalletSupport(features.security.hardwareWalletSupport)
 			}
 
 			if (
@@ -224,14 +228,14 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 					),
 				).length === numSupported
 			) {
-				return indirectHardwareWalletSupport(withoutRefs)
+				return indirectHardwareWalletSupport(features.security.hardwareWalletSupport)
 			}
 
-			return directHardwareWalletSupport(withoutRefs)
+			return directHardwareWalletSupport(features.security.hardwareWalletSupport)
 		})()
 
 		if (numSupported === 0) {
-			return noHardwareWalletSupport(withoutRefs)
+			return noHardwareWalletSupport(features.security.hardwareWalletSupport)
 		}
 
 		return {

--- a/src/schema/attributes/security/keys-handling.ts
+++ b/src/schema/attributes/security/keys-handling.ts
@@ -5,7 +5,6 @@ import {
 	type KeysHandlingSupport,
 	KeysHandlingType,
 } from '@/schema/features/security/keys-handling'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -116,8 +115,7 @@ export const keysHandling: Attribute<KeysHandlingValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<KeysHandlingSupport>(keysHandlingFeature)
-		const rating = evaluateKeysHandling(withoutRefs)
+		const rating = evaluateKeysHandling(keysHandlingFeature)
 
 		return {
 			value: {
@@ -125,12 +123,12 @@ export const keysHandling: Attribute<KeysHandlingValue> = {
 				rating,
 				displayName: 'Keys Handling',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} key handling.`),
-				...withoutRefs,
+				...keysHandlingFeature, // TODO: Filter fields.
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} key handling evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -14,7 +14,7 @@ import { scamAlertsDetailsContent } from '@/types/content/scam-alert-details'
 import { isNonEmptyArray, type NonEmptyArray } from '@/types/utils/non-empty'
 import { commaListFormat } from '@/types/utils/text'
 
-import { mergeRefs, type WithRef } from '../../reference'
+import { mergeRefs, refNotNecessary, type WithRef } from '../../reference'
 import { pickWorstRating, unrated } from '../common'
 
 export type ScamAlertSupport = WithRef<{
@@ -61,6 +61,7 @@ function rateSendTransactionWarning(scamAlerts: ScamAlerts): ScamAlertSupport & 
 		return {
 			supported: false,
 			privacyPreserving: true,
+			ref: refNotNecessary,
 			...baseProps,
 		}
 	}
@@ -102,6 +103,7 @@ function rateContractTransactionWarning(scamAlerts: ScamAlerts): ScamAlertSuppor
 		return {
 			supported: false,
 			privacyPreserving: true,
+			ref: refNotNecessary,
 			...baseProps,
 		}
 	}
@@ -145,6 +147,7 @@ function rateScamUrlWarning(scamAlerts: ScamAlerts): ScamAlertSupport & {
 		return {
 			supported: false,
 			privacyPreserving: true,
+			ref: refNotNecessary,
 			...baseProps,
 		}
 	}
@@ -462,6 +465,7 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 				evaluateScamAlerts(WalletProfile.GENERIC, {
 					contractTransactionWarning: notSupported,
 					scamUrlWarning: supported({
+						ref: refNotNecessary,
 						leaksVisitedUrl: 'FULL_URL',
 						leaksUserAddress: false,
 						leaksIp: false,
@@ -476,11 +480,13 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 				evaluateScamAlerts(WalletProfile.GENERIC, {
 					contractTransactionWarning: notSupported,
 					scamUrlWarning: supported({
+						ref: refNotNecessary,
 						leaksVisitedUrl: 'NO',
 						leaksUserAddress: false,
 						leaksIp: true,
 					}),
 					sendTransactionWarning: supported({
+						ref: refNotNecessary,
 						newRecipientWarning: true,
 						userWhitelist: false,
 						leaksRecipient: false,
@@ -495,6 +501,7 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 				),
 				evaluateScamAlerts(WalletProfile.GENERIC, {
 					contractTransactionWarning: supported({
+						ref: refNotNecessary,
 						contractRegistry: true,
 						previousContractInteractionWarning: true,
 						recentContractWarning: false,
@@ -503,11 +510,13 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 						leaksUserIp: true,
 					}),
 					scamUrlWarning: supported({
+						ref: refNotNecessary,
 						leaksVisitedUrl: 'NO',
 						leaksUserAddress: true,
 						leaksIp: true,
 					}),
 					sendTransactionWarning: supported({
+						ref: refNotNecessary,
 						newRecipientWarning: true,
 						userWhitelist: false,
 						leaksRecipient: false,
@@ -523,6 +532,7 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 			),
 			evaluateScamAlerts(WalletProfile.GENERIC, {
 				contractTransactionWarning: supported({
+					ref: refNotNecessary,
 					contractRegistry: true,
 					previousContractInteractionWarning: true,
 					recentContractWarning: false,
@@ -531,11 +541,13 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 					leaksUserIp: false,
 				}),
 				scamUrlWarning: supported({
+					ref: refNotNecessary,
 					leaksVisitedUrl: 'PARTIAL_HASH_OF_DOMAIN',
 					leaksUserAddress: false,
 					leaksIp: true,
 				}),
 				sendTransactionWarning: supported({
+					ref: refNotNecessary,
 					newRecipientWarning: true,
 					userWhitelist: false,
 					leaksRecipient: true,

--- a/src/schema/attributes/security/supply-chain-diy.ts
+++ b/src/schema/attributes/security/supply-chain-diy.ts
@@ -12,7 +12,6 @@ import {
 	type SupplyChainDIYSupport,
 	SupplyChainDIYType,
 } from '@/schema/features/security/supply-chain-diy'
-import { popRefs } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { WalletMetadata } from '@/schema/wallet'
 import { WalletType } from '@/schema/wallet-types'
@@ -135,8 +134,7 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<SupplyChainDIYSupport>(diyFeature)
-		const rating = evaluateSupplyChainDIY(withoutRefs)
+		const rating = evaluateSupplyChainDIY(diyFeature)
 
 		return {
 			value: {
@@ -144,12 +142,12 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 				rating,
 				displayName: 'Supply Chain DIY',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} DIY supply chain.`),
-				...withoutRefs,
+				...diyFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} DIY supply chain evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/security/supply-chain-factory.ts
+++ b/src/schema/attributes/security/supply-chain-factory.ts
@@ -12,7 +12,6 @@ import {
 	type SupplyChainFactorySupport,
 	SupplyChainFactoryType,
 } from '@/schema/features/security/supply-chain-factory'
-import { popRefs } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { WalletMetadata } from '@/schema/wallet'
 import { WalletType } from '@/schema/wallet-types'
@@ -166,8 +165,7 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<SupplyChainFactorySupport>(factoryFeature)
-		const rating = evaluateSupplyChainFactory(withoutRefs)
+		const rating = evaluateSupplyChainFactory(factoryFeature)
 
 		return {
 			value: {
@@ -177,14 +175,14 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 				shortExplanation: sentence(
 					`{{WALLET_NAME}} has ${rating.toLowerCase()} factory supply chain.`,
 				),
-				...withoutRefs,
+				...factoryFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(
 				`{{WALLET_NAME}} factory supply chain evaluation is ${rating.toLowerCase()}.`,
 			),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/security/user-safety.ts
+++ b/src/schema/attributes/security/user-safety.ts
@@ -7,7 +7,6 @@ import {
 } from '@/schema/attributes'
 import type { ResolvedFeatures } from '@/schema/features'
 import { type UserSafetySupport, UserSafetyType } from '@/schema/features/security/user-safety'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -199,26 +198,25 @@ export const userSafety: Attribute<UserSafetyValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<UserSafetySupport>(userSafetyFeature)
-		const rating = evaluateUserSafety(withoutRefs)
+		const rating = evaluateUserSafety(userSafetyFeature)
 
 		const passCount = [
-			withoutRefs.readableAddress,
-			withoutRefs.contractLabeling,
-			withoutRefs.rawTxReview,
-			withoutRefs.readableTx,
-			withoutRefs.txCoverageExtensibility,
-			withoutRefs.txExpertMode,
-			withoutRefs.rawEip712,
-			withoutRefs.readableEip712,
-			withoutRefs.eip712CoverageExtensibility,
-			withoutRefs.eip712ExpertMode,
-			withoutRefs.riskAnalysis,
-			withoutRefs.riskAnalysisLocal,
-			withoutRefs.fullyLocalRiskAnalysis,
-			withoutRefs.txSimulation,
-			withoutRefs.txSimulationLocal,
-			withoutRefs.fullyLocalTxSimulation,
+			userSafetyFeature.readableAddress,
+			userSafetyFeature.contractLabeling,
+			userSafetyFeature.rawTxReview,
+			userSafetyFeature.readableTx,
+			userSafetyFeature.txCoverageExtensibility,
+			userSafetyFeature.txExpertMode,
+			userSafetyFeature.rawEip712,
+			userSafetyFeature.readableEip712,
+			userSafetyFeature.eip712CoverageExtensibility,
+			userSafetyFeature.eip712ExpertMode,
+			userSafetyFeature.riskAnalysis,
+			userSafetyFeature.riskAnalysisLocal,
+			userSafetyFeature.fullyLocalRiskAnalysis,
+			userSafetyFeature.txSimulation,
+			userSafetyFeature.txSimulationLocal,
+			userSafetyFeature.fullyLocalTxSimulation,
 		].filter(r => r === UserSafetyType.PASS).length
 
 		const detailsText = `{{WALLET_NAME}} user safety evaluation is ${rating.toLowerCase()}.${
@@ -236,11 +234,11 @@ export const userSafety: Attribute<UserSafetyValue> = {
 				rating,
 				displayName: 'User Safety',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} user safety.`),
-				...withoutRefs,
+				...userSafetyFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(detailsText),
-			references: extractedRefs,
+			// TODO: Add references
 			howToImprove:
 				rating === Rating.PASS || rating === Rating.EXEMPT
 					? undefined

--- a/src/schema/attributes/self-sovereignty/account-portability.ts
+++ b/src/schema/attributes/self-sovereignty/account-portability.ts
@@ -793,10 +793,12 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 		}
 
 		const allRefs = mergeRefs(
-			refs(features.accountSupport.eoa),
-			refs(features.accountSupport.mpc),
-			refs(features.accountSupport.rawErc4337),
-			refs(features.accountSupport.eip7702),
+			isSupported(features.accountSupport.eoa) ? refs(features.accountSupport.eoa) : [],
+			isSupported(features.accountSupport.mpc) ? refs(features.accountSupport.mpc) : [],
+			isSupported(features.accountSupport.rawErc4337)
+				? refs(features.accountSupport.rawErc4337)
+				: [],
+			isSupported(features.accountSupport.eip7702) ? refs(features.accountSupport.eip7702) : [],
 		)
 		const evaluations: Array<Evaluation<AccountPortabilityValue>> = []
 		let defaultEvaluation: Evaluation<AccountPortabilityValue> | null = null

--- a/src/schema/attributes/self-sovereignty/interoperability.ts
+++ b/src/schema/attributes/self-sovereignty/interoperability.ts
@@ -5,7 +5,6 @@ import {
 	type InteroperabilitySupport,
 	InteroperabilityType,
 } from '@/schema/features/self-sovereignty/interoperability'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -96,9 +95,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } =
-			popRefs<InteroperabilitySupport>(interoperabilityFeature)
-		const rating = evaluateInteroperability(withoutRefs)
+		const rating = evaluateInteroperability(interoperabilityFeature)
 
 		return {
 			value: {
@@ -106,12 +103,12 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 				rating,
 				displayName: 'Interoperability',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} interoperability.`),
-				...withoutRefs,
+				...interoperabilityFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} interoperability evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/transparency/fee-transparency.ts
+++ b/src/schema/attributes/transparency/fee-transparency.ts
@@ -128,7 +128,7 @@ function feeDisplayLevelForType(
 					return notSupported
 				}
 
-				return supported(stealthAddr.fees)
+				return supported({ ...stealthAddr.fees, ref: stealthAddr.ref })
 			})()
 		case FeeType.TORNADO_CASH_NOVA_RELAYER:
 			return (() => {

--- a/src/schema/attributes/transparency/maintenance.ts
+++ b/src/schema/attributes/transparency/maintenance.ts
@@ -5,7 +5,6 @@ import {
 	type MaintenanceSupport,
 	MaintenanceType,
 } from '@/schema/features/transparency/maintenance'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -124,8 +123,7 @@ export const maintenance: Attribute<MaintenanceValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<MaintenanceSupport>(maintenanceFeature)
-		const rating = evaluateMaintenance(withoutRefs)
+		const rating = evaluateMaintenance(maintenanceFeature)
 
 		return {
 			value: {
@@ -135,12 +133,12 @@ export const maintenance: Attribute<MaintenanceValue> = {
 				shortExplanation: sentence(
 					`{{WALLET_NAME}} has ${rating.toLowerCase()} maintenance practices.`,
 				),
-				...withoutRefs,
+				...maintenanceFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} maintenance evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/attributes/transparency/open-source.ts
+++ b/src/schema/attributes/transparency/open-source.ts
@@ -13,7 +13,7 @@ import {
 	licenseName,
 	type LicenseWithRef,
 } from '@/schema/features/transparency/license'
-import { refs, toFullyQualified } from '@/schema/reference'
+import { refNotNecessary, refs, toFullyQualified } from '@/schema/reference'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 import { licenseDetailsContent } from '@/types/content/license-details'
 
@@ -137,7 +137,7 @@ export const openSource: Attribute<OpenSourceValue> = {
 		fail: [
 			exampleRating(
 				paragraph('The wallet is licensed under any non-FOSS (proprietary) license.'),
-				proprietary({ license: License.PROPRIETARY }),
+				proprietary({ license: License.PROPRIETARY, ref: refNotNecessary }),
 			),
 			exampleRating(
 				paragraph(

--- a/src/schema/attributes/transparency/reputation.ts
+++ b/src/schema/attributes/transparency/reputation.ts
@@ -2,7 +2,6 @@ import { type Attribute, type Evaluation, Rating, type Value } from '@/schema/at
 import { exampleRating } from '@/schema/attributes'
 import type { ResolvedFeatures } from '@/schema/features'
 import { type ReputationSupport, ReputationType } from '@/schema/features/transparency/reputation'
-import { popRefs } from '@/schema/reference'
 import type { AtLeastOneVariant } from '@/schema/variants'
 import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
@@ -116,8 +115,7 @@ export const reputation: Attribute<ReputationValue> = {
 			})
 		}
 
-		const { withoutRefs, refs: extractedRefs } = popRefs<ReputationSupport>(reputationFeature)
-		const rating = evaluateReputation(withoutRefs)
+		const rating = evaluateReputation(reputationFeature)
 
 		return {
 			value: {
@@ -125,12 +123,12 @@ export const reputation: Attribute<ReputationValue> = {
 				rating,
 				displayName: 'Reputation',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} reputation.`),
-				...withoutRefs,
+				...reputationFeature, // TODO: Filter fields
 				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} reputation evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),
-			...(extractedRefs.length > 0 && { references: extractedRefs }),
+			// TODO: Add references
 		}
 	},
 }

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -9,7 +9,7 @@ import type { SmartWalletContract } from '../contracts'
 import type { WithRef } from '../reference'
 import { isSupported, type NotSupported, type Support, type Supported } from './support'
 
-export type AccountTypeSupport<T extends object> = WithRef<Support<T>>
+export type AccountTypeSupport<T extends object> = Support<WithRef<T>>
 
 /** Type predicate for AccountTypeSupported<T>. */
 export function isAccountTypeSupported<T extends object>(

--- a/src/schema/features/ecosystem/integration.ts
+++ b/src/schema/features/ecosystem/integration.ts
@@ -38,13 +38,13 @@ export interface WalletIntegration {
 	 *  - wallet_showCallsStatus
 	 *  - wallet_getCapabilities
 	 */
-	walletCall: VariantFeature<WithRef<Support<WalletCallIntegration>>>
+	walletCall: VariantFeature<Support<WithRef<WalletCallIntegration>>>
 }
 
 /** Variant-specific resolution of `WalletIntegration`. */
 export interface ResolvedWalletIntegration {
 	browser: WalletIntegration['browser']
-	walletCall: ResolvedFeature<Support<WalletCallIntegration>>
+	walletCall: ResolvedFeature<Support<WithRef<WalletCallIntegration>>>
 }
 
 /** EIP-5792 Wallet Call API support. */
@@ -56,7 +56,7 @@ export interface WalletCallIntegration {
 	 * For the purpose of this attribute, we only look at support on L1.
 	 * A reported value of 'ready' or 'supported' qualifies as supported.
 	 */
-	atomicMultiTransactions: WithRef<Support>
+	atomicMultiTransactions: Support
 }
 
 /** A WalletIntegration stand-in used for non-software wallets. */

--- a/src/schema/features/privacy/data-collection.ts
+++ b/src/schema/features/privacy/data-collection.ts
@@ -724,14 +724,12 @@ export function isWithEndpoint<T extends UserInfo>(
 }
 
 /** What data is collected by an entity; fully qualified. */
-export type QualifiedDataCollection = WithRef<
-	Record<UserInfo, CollectionPolicy> & {
-		/**
-		 * How multiple addresses are handled, if at all.
-		 */
-		multiAddress?: MultiAddressHandling
-	}
->
+export type QualifiedDataCollection = Record<UserInfo, CollectionPolicy> & {
+	/**
+	 * How multiple addresses are handled, if at all.
+	 */
+	multiAddress?: MultiAddressHandling
+}
 
 /**
  * Infer what info is derivable from a given partial set of known collected information.
@@ -743,7 +741,7 @@ export function qualifiedDataCollection<T extends UserInfo>(
 ): QualifiedDataCollection {
 	const get = (info: UserInfo): CollectionPolicy | undefined => {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Safe because L is guaranteed to be non-empty.
-		return (userInfo as NonEmptyRecord<UserInfo, CollectionPolicy>)[info]
+		return (userInfo as WithRef<NonEmptyRecord<UserInfo, CollectionPolicy>>)[info]
 	}
 	const first = (...ls: Array<CollectionPolicy | undefined>): CollectionPolicy | undefined =>
 		ls.find(l => l !== undefined)

--- a/src/schema/features/privacy/transaction-privacy.ts
+++ b/src/schema/features/privacy/transaction-privacy.ts
@@ -86,7 +86,7 @@ export type TransactionPrivacy = {
 	>
 
 /** Support for ERC-5564 stealth addresses. */
-export interface StealthAddressSupport {
+export type StealthAddressSupport = WithRef<{
 	/**
 	 * When sending funds to a stealth meta-address, how is the resolution of
 	 * that stealth meta-address to a specific stealth address done?
@@ -198,7 +198,7 @@ export interface StealthAddressSupport {
 
 	/** When sending transactions, how are fees displayed? */
 	fees: FeeDisplay
-}
+}>
 
 /**
  * When funds are received to a new unlabeled address, and the user

--- a/src/schema/features/security/firmware.ts
+++ b/src/schema/features/security/firmware.ts
@@ -1,5 +1,3 @@
-import type { WithRef } from '@/schema/reference'
-
 export enum FirmwareType {
 	PASS = 'PASS',
 	PARTIAL = 'PARTIAL',
@@ -15,5 +13,3 @@ export interface FirmwareSupport {
 	reproducibleBuilds: FirmwareType | null
 	customFirmware: FirmwareType | null
 }
-
-export type FirmwareImplementation = WithRef<FirmwareSupport>

--- a/src/schema/features/security/scam-alerts.ts
+++ b/src/schema/features/security/scam-alerts.ts
@@ -2,109 +2,109 @@ import type { WithRef } from '@/schema/reference'
 
 import type { Support } from '../support'
 
+export type ScamUrlWarning = WithRef<{
+	/**
+	 * Whether the scam site lookup process leaks the visited URL to an
+	 * external service, as opposed to something like a partial hash match
+	 * like the Google Safe Browsing API for checking spam domains without
+	 * leaking the domains being visited to Google.
+	 */
+	leaksVisitedUrl: 'FULL_URL' | 'DOMAIN_ONLY' | 'PARTIAL_HASH_OF_DOMAIN' | 'NO'
+
+	/**
+	 * Whether the contract lookup process leaks the user's Ethereum address
+	 * to an external service.
+	 */
+	leaksUserAddress: boolean
+
+	/**
+	 * Whether the scam site lookup process leaks the user's IP to an external
+	 * service, as opposed to using an anonymizing proxy.
+	 */
+	leaksIp: boolean
+}>
+
+export type ContractTransactionWarning = WithRef<{
+	/**
+	 * Does the wallet warn the user when they are interacting with a contract
+	 * they have not interacted with before?
+	 */
+	previousContractInteractionWarning: boolean
+
+	/**
+	 * Does the wallet warn the user when they are interacting with a contract
+	 * that has only recently been deployed to the chain.
+	 */
+	recentContractWarning: boolean
+
+	/**
+	 * Does the wallet check a registry of known scam/non-scam contracts and
+	 * use it to warn the user?
+	 */
+	contractRegistry: boolean
+
+	/**
+	 * Whether the contract lookup process leaks the contract address to an
+	 * external service, as opposed to something like a partial match against
+	 * a static list.
+	 */
+	leaksContractAddress: boolean
+
+	/**
+	 * Whether the contract lookup process leaks the user's Ethereum address
+	 * to an external service.
+	 */
+	leaksUserAddress: boolean
+
+	/**
+	 * Whether the contract lookup process leaks the user's IP address to an
+	 * external service.
+	 */
+	leaksUserIp: boolean
+}>
+
+export type SendTransactionWarning = WithRef<{
+	/**
+	 * Does the wallet feature a user-editable whitelist, outside of which
+	 * the wallet warns when sending to other addresses?
+	 */
+	userWhitelist: boolean
+
+	/**
+	 * Does the wallet warn the user when they are sending to an address they
+	 * have not sent funds to before?
+	 */
+	newRecipientWarning: boolean
+
+	/**
+	 * Whether the lookup process leaks the recipient address to an external
+	 * service.
+	 */
+	leaksRecipient: boolean
+
+	/**
+	 * Whether the lookup process leaks the user's Ethereum address to an
+	 * external service.
+	 */
+	leaksUserAddress: boolean
+
+	/**
+	 * Whether the lookup process leaks the user's IP address to an external
+	 * service.
+	 */
+	leaksUserIp: boolean
+}>
+
 /**
  * Whether the wallet supports scam alerts.
  */
 export interface ScamAlerts {
 	/** Does the wallet warn the user when visiting a known-scam site? */
-	scamUrlWarning: Support<
-		WithRef<{
-			/**
-			 * Whether the scam site lookup process leaks the visited URL to an
-			 * external service, as opposed to something like a partial hash match
-			 * like the Google Safe Browsing API for checking spam domains without
-			 * leaking the domains being visited to Google.
-			 */
-			leaksVisitedUrl: 'FULL_URL' | 'DOMAIN_ONLY' | 'PARTIAL_HASH_OF_DOMAIN' | 'NO'
-
-			/**
-			 * Whether the contract lookup process leaks the user's Ethereum address
-			 * to an external service.
-			 */
-			leaksUserAddress: boolean
-
-			/**
-			 * Whether the scam site lookup process leaks the user's IP to an external
-			 * service, as opposed to using an anonymizing proxy.
-			 */
-			leaksIp: boolean
-		}>
-	>
+	scamUrlWarning: Support<ScamUrlWarning>
 
 	/** Does the wallet warn the user before executing a contract transaction? */
-	contractTransactionWarning: Support<
-		WithRef<{
-			/**
-			 * Does the wallet warn the user when they are interacting with a contract
-			 * they have not interacted with before?
-			 */
-			previousContractInteractionWarning: boolean
-
-			/**
-			 * Does the wallet warn the user when they are interacting with a contract
-			 * that has only recently been deployed to the chain.
-			 */
-			recentContractWarning: boolean
-
-			/**
-			 * Does the wallet check a registry of known scam/non-scam contracts and
-			 * use it to warn the user?
-			 */
-			contractRegistry: boolean
-
-			/**
-			 * Whether the contract lookup process leaks the contract address to an
-			 * external service, as opposed to something like a partial match against
-			 * a static list.
-			 */
-			leaksContractAddress: boolean
-
-			/**
-			 * Whether the contract lookup process leaks the user's Ethereum address
-			 * to an external service.
-			 */
-			leaksUserAddress: boolean
-
-			/**
-			 * Whether the contract lookup process leaks the user's IP address to an
-			 * external service.
-			 */
-			leaksUserIp: boolean
-		}>
-	>
+	contractTransactionWarning: Support<ContractTransactionWarning>
 
 	/** Does the wallet warn the user before executing a send transaction? */
-	sendTransactionWarning: Support<
-		WithRef<{
-			/**
-			 * Does the wallet feature a user-editable whitelist, outside of which
-			 * the wallet warns when sending to other addresses?
-			 */
-			userWhitelist: boolean
-
-			/**
-			 * Does the wallet warn the user when they are sending to an address they
-			 * have not sent funds to before?
-			 */
-			newRecipientWarning: boolean
-
-			/**
-			 * Whether the lookup process leaks the recipient address to an external
-			 * service.
-			 */
-			leaksRecipient: boolean
-
-			/**
-			 * Whether the lookup process leaks the user's Ethereum address to an
-			 * external service.
-			 */
-			leaksUserAddress: boolean
-
-			/**
-			 * Whether the lookup process leaks the user's IP address to an external
-			 * service.
-			 */
-			leaksUserIp: boolean
-		}>
-	>
+	sendTransactionWarning: Support<SendTransactionWarning>
 }

--- a/src/schema/features/support.ts
+++ b/src/schema/features/support.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyRecord } from '@/types/utils/non-empty'
 
-import type { WithRef } from '../reference'
+import { refNotNecessary, type WithRef } from '../reference'
 
 /** A supported feature. */
 export type Supported<T extends object = object> = T & {
@@ -37,6 +37,12 @@ export const notSupported: NotSupported = { support: 'NOT_SUPPORTED' } as const
 
 /** The feature is supported. */
 export const featureSupported: Supported = { support: 'SUPPORTED' } as const
+
+/** The feature is supported without reference necessary. */
+export const featureSupportedNoRef: WithRef<Supported> = {
+	support: 'SUPPORTED',
+	ref: refNotNecessary,
+} as const
 
 /** The feature is unsupported but still carries additional data. */
 export function notSupportedWith<T = object>(obj: T): NotSupported & T {

--- a/src/schema/features/transparency/fee-display.ts
+++ b/src/schema/features/transparency/fee-display.ts
@@ -47,17 +47,19 @@ export interface FeeDisplay {
 }
 
 /** Shorthand for fees that are comprehensive by default. */
-export const comprehensiveFeesShownByDefault: FeeDisplay = {
+export const comprehensiveFeesShownByDefault: WithRef<FeeDisplay> = {
 	byDefault: FeeDisplayLevel.COMPREHENSIVE,
 	afterSingleAction: FeeDisplayLevel.COMPREHENSIVE,
 	fullySponsored: false,
+	ref: [],
 }
 
 /** Shorthand for fees that are fully sponsored and not shown. */
-export const fullySponsoredFees: FeeDisplay = {
+export const fullySponsoredFees: WithRef<FeeDisplay> = {
 	byDefault: FeeDisplayLevel.NONE,
 	afterSingleAction: FeeDisplayLevel.NONE,
 	fullySponsored: true,
+	ref: [],
 }
 
 /**

--- a/src/types/utils/nullable.ts
+++ b/src/types/utils/nullable.ts
@@ -1,0 +1,13 @@
+export type NullableObject = object | null
+
+export type Nullable<T extends NullableObject> = { [K in keyof T]: T[K] | null } | null
+
+export type NonNull<T extends NullableObject> = { [K in keyof T]: Exclude<T[K], null> }
+
+export function isNonNull<T extends NullableObject>(obj: Nullable<T>): obj is NonNull<T> {
+	if (obj === null) {
+		return false
+	}
+
+	return !Object.values(obj).includes(null)
+}


### PR DESCRIPTION
`ref`s being explicit makes it clear where we're missing references and why.

`Nullable` fields allow some wallet feature fields to be partially specified in `data`, while preserving non-partial-null-ness in attribute evaluation logic. This makes it possible to input partial data for wallet data entry without adding special logic to handle this for attributes.

FYI @darrylyeo this may be disruptive.