### PR TITLE
fix: faq padding

### DIFF
--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -347,6 +347,8 @@ import HelpOutlineIcon from '@material-icons/svg/svg/help_outline/baseline.svg?r
 	}
 
 	section {
+		padding: 0 1.5rem 1.5rem 1.5rem !important;
+
 		h2 {
 			position: relative;
 


### PR DESCRIPTION
FAQ page `section` padding style affected by global `section` style

Changes:
- Overwrite `section` padding styling

Current:
<img width="1047" height="946" alt="image" src="https://github.com/user-attachments/assets/36cbdda9-4a0e-4297-9d2b-8d8926732bec" />

After:
<img width="1047" height="946" alt="image" src="https://github.com/user-attachments/assets/e8fa20f1-e42e-4e26-ad3d-6caacb2d02a6" />
