### PR TITLE
Enable cSpell on Astro/Svelte files.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -263,15 +263,12 @@
 	],
 	"flagWords": [],
 	"ignorePaths": [
+		"**/*.css",
 		"dist/**",
 		"public/**/*.svg",
 		"node_modules/**",
 		"src/legacy/**",
 		"src/generated/**",
-		"**/*.css",
-		"**/*.astro",
-		"**/*.svelte",
-		"**/*.svelte.ts",
 		"pnpm-lock.yaml"
 	]
 }


### PR DESCRIPTION
Already passes, no changes needed.