### PR TITLE
Replace use of `undefined` with `null` in `Score`.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,10 @@
 {
 	"recommendations": [
-		"astro-build.astro-vscode",
-		"streetsidesoftware.code-spell-checker",
 		"dbaeumer.vscode-eslint",
-		"rvest.vs-code-prettier-eslint"
+		"astro-build.astro-vscode",
+		"rvest.vs-code-prettier-eslint",
+		"streetsidesoftware.code-spell-checker",
+		"svelte.svelte-vscode"
 	],
 	"unwantedRecommendations": []
 }

--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -7,7 +7,6 @@ import {
 	nonEmptyRemap,
 	nonEmptyValues,
 } from '@/types/utils/non-empty'
-import { objectEntries } from '@/types/utils/object'
 
 import {
 	type Attribute,
@@ -118,7 +117,7 @@ import {
 	type SourceVisibilityValue,
 } from './attributes/transparency/source-visibility'
 import type { ResolvedFeatures } from './features'
-import { type MaybeUnratedScore, type WeightedScore, weightedScore } from './score'
+import { type MaybeUnratedScore, type Score, type WeightedScore, weightedScore } from './score'
 import type { AtLeastOneVariant, Variant } from './variants'
 import type { WalletMetadata } from './wallet'
 
@@ -707,51 +706,34 @@ export function calculateAttributeGroupScore<Vs extends ValueSet>(
 }
 
 /**
- * Filter an evaluation tree to only include specific attribute groups.
- * @param evaluationTree The evaluation tree to filter.
- * @param attributeGroups The attribute groups to include.
- * @returns A filtered evaluation tree containing only the specified groups.
- */
-export const filterEvaluationTree = (
-	evaluationTree: EvaluationTree,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	attributeGroups: AttributeGroup<any>[],
-): Partial<EvaluationTree> => {
-	const groupIds = new Set(attributeGroups.map(group => group.id))
-
-	return Object.fromEntries(
-		Object.entries(evaluationTree).filter(([attrGroupId]) => groupIds.has(attrGroupId)),
-	) as Partial<EvaluationTree>
-}
-
-/**
  * Calculate the overall wallet score by averaging all attribute group scores.
  * @param evaluationTree The evaluation tree to score.
- * @returns The overall score between 0.0 (lowest) and 1.0 (highest), or undefined if no scores.
+ * @param attrGroupPredicate A predicate determining whether the given attribute group should be scored.
+ * @returns The overall score between 0.0 (lowest) and 1.0 (highest), or null if no scores.
  */
 export const calculateOverallScore = (
-	evaluationTree: EvaluationTree | Partial<EvaluationTree>,
+	evaluationTree: EvaluationTree,
+	attrGroupPredicate: <Vs extends ValueSet>(attrGroup: AttributeGroup<Vs>) => boolean,
 ): MaybeUnratedScore => {
-	const scores = objectEntries(attributeTree)
-		.map(
-			([attrGroupId, attrGroup]) =>
-				evaluationTree[attrGroupId] &&
-				calculateAttributeGroupScore(
-					attrGroup.attributeWeights,
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
-					evaluationTree[attrGroupId] as any,
-				),
-		)
-		.filter(
-			(score): score is { score: number; hasUnratedComponent: boolean } =>
-				score?.score !== undefined,
-		)
+	const scores = mapNonExemptAttributeGroupsInTree(
+		evaluationTree,
+		<Vs extends ValueSet>(attrGroup: AttributeGroup<Vs>, evalGroup: EvaluatedGroup<Vs>) => {
+			if (!attrGroupPredicate<Vs>(attrGroup)) {
+				return null
+			}
+
+			return calculateAttributeGroupScore<Vs>(attrGroup.attributeWeights, evalGroup)
+		},
+	).filter((score): score is { score: Score; hasUnratedComponent: boolean } => score !== null)
+
+	if (!isNonEmptyArray(scores)) {
+		return null
+	}
 
 	return {
-		score: scores.length
-			? scores.reduce((sum, { score }) => sum + score, 0) / scores.length
-			: undefined,
-		hasUnratedComponent: scores.some(score => score?.hasUnratedComponent),
+		score:
+			scores.reduce((sum, { score }) => (score === null ? sum : sum + score), 0) / scores.length,
+		hasUnratedComponent: scores.some(score => score.hasUnratedComponent),
 	}
 }
 

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -208,6 +208,10 @@ export function defaultRatingScore(rating: Rating): Score {
 			return 0.5
 		case Rating.PASS:
 			return 1.0
+		case Rating.EXEMPT:
+			return null
+		case Rating.UNRATED:
+			return null
 	}
 }
 

--- a/src/schema/score.ts
+++ b/src/schema/score.ts
@@ -1,7 +1,7 @@
 import { type NonEmptyArray } from '@/types/utils/non-empty'
 
 /** Score is a score between 0.0 (lowest) and 1.0 (highest). */
-export type Score = number | undefined
+export type Score = number | null
 
 /** A score and a weight. */
 export interface WeightedScore {
@@ -20,13 +20,13 @@ export type MaybeUnratedScore = null | {
 
 /** Compute a weighted aggregate score. */
 export const weightedScore = (scores: NonEmptyArray<WeightedScore>): Score => {
-	if (scores.every(({ score }) => score === undefined)) {
-		return undefined
+	if (scores.every(({ score }) => score === null)) {
+		return null
 	}
 
 	const [totalScore, totalWeight] = scores.reduce(
 		([totalScore, totalWeight], { score, weight }) => [
-			totalScore + (score ?? 0) * weight,
+			totalScore + (score === null ? 0 : score) * weight,
 			totalWeight + weight,
 		],
 		[0, 0] as [number, number],

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,7 +1,7 @@
 import type { Score } from '@/schema/score'
 
 export const scoreToColor = (score: Score) =>
-	score !== undefined
+	score !== null
 		? score <= 0.5
 			? `color-mix(in oklch, var(--rating-fail), var(--rating-partial) ${score * 200}%)`
 			: `color-mix(in oklch, var(--rating-partial), var(--rating-pass) ${(score - 0.5) * 200}%)`

--- a/src/views/ScoreBadge.svelte
+++ b/src/views/ScoreBadge.svelte
@@ -18,7 +18,7 @@
 </script>
 
 
-{#if score?.score !== undefined}
+{#if score !== null && score.score !== null}
 	<data
 		data-badge={size}
 		value={score.score}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -137,7 +137,7 @@
 	})
 
 	const overallScore = $derived(
-		calculateOverallScore(wallet.overall)
+		calculateOverallScore(wallet.overall, () => true),
 	)
 </script>
 
@@ -376,7 +376,8 @@
 
 	{#if attributes.length > 0}
 		{@const score = evalGroup ? calculateAttributeGroupScore(attrGroup.attributeWeights, evalGroup) : null}
-		{@const scoreLevel = score?.score ? score.score >= 0.7 ? 'high' : score.score >= 0.4 ? 'medium' : 'low' : undefined}
+		{@const scoreLevel = score === null || score.score === null ? null : (score.score >= 0.7 ? 'high' : score.score >= 0.4 ? 'medium' : 'low')}
+		{@const scoreColor = scoreToColor(score === null ? null : score.score)}
 
 		<hr />
 
@@ -388,7 +389,7 @@
 			data-score={scoreLevel}
 			data-icon={attrGroup.icon}
 			style:--attributeGroup-icon={`'${attrGroup.icon}'`}
-			style:--accent={scoreToColor(score?.score)}
+			style:--accent={scoreColor}
 		>
 			<header data-sticky data-row>
 				<a href={`#${slugifyCamelCase(attrGroup.id)}`}>
@@ -447,7 +448,7 @@
 							{#snippet centerContentSnippet()}
 								<circle
 									r="8"
-									fill={scoreToColor(score?.score)}
+									fill={scoreColor}
 								>
 									{#if score?.hasUnratedComponent}
 										<title>


### PR DESCRIPTION
Forces explicit handling in functions like `defaultRatingScore`.