### PR TITLE
Fix: Resolve duplicate key using index

### DIFF
--- a/src/views/ReferenceLinks.svelte
+++ b/src/views/ReferenceLinks.svelte
@@ -19,7 +19,7 @@
 		<!-- <h5>{totalUrls > 1 ? 'Sources' : 'Source'}</h5> -->
 
 		<ul class="references">
-			{#each references as ref (ref.urls.map(url => url.url).toSorted().join('|'))}
+			{#each references as ref, index (index + '::' + ref.urls.map(url => url.url).toSorted().join('|'))}
 				<li data-card="secondary padding-3">
 					{#if ref.explanation}
 						<p>{ref.explanation}</p>


### PR DESCRIPTION
Fixes `each_key_duplicate` error when same URL appears in multiple references. Changed key from URL-based to index-based