### PR TITLE
Update wallet configurations and add new entries to .gitignore

### DIFF
--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -86,13 +86,8 @@ export const rabby: SoftwareWallet = {
 			rawErc4337: notSupported,
 			safe: supported({
 				ref: refTodo,
-				canDeployNew: false,
+				canDeployNew: notSupported,
 				controllingSharesInSelfCustodyByDefault: 'YES',
-				defaultConfig: {
-					modules: [],
-					owners: 1,
-					threshold: 1,
-				},
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -55,14 +55,15 @@ export const safe: SoftwareWallet = {
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 			}),
 			safe: supported({
-				ref: refNotNecessary, // It's Safe Wallet, duh.
-				canDeployNew: true,
+				ref: refNotNecessary,
+				canDeployNew: supported({
+					defaultConfig: {
+						modules: [],
+						owners: 1,
+						threshold: 1,
+					},
+				}),
 				controllingSharesInSelfCustodyByDefault: 'YES',
-				defaultConfig: {
-					modules: [],
-					owners: 1,
-					threshold: 1,
-				},
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {
@@ -114,7 +115,7 @@ export const safe: SoftwareWallet = {
 			walletAppLicense: {
 				ref: [
 					{
-						explanation: 'Safe uses the LGPL-3.0 license for its source code', // keep explanation but change enum if needed
+						explanation: 'Safe uses the LGPL-3.0 license for its source code',
 						label: 'Safe License File',
 						url: 'https://github.com/safe-global/safe-wallet-monorepo',
 					},
@@ -154,7 +155,7 @@ export const safe: SoftwareWallet = {
 				hiddenConvenienceFees: false,
 				publicOffering: false,
 				selfFunded: false,
-				transparentConvenienceFees: true, // based on community-aligned fees
+				transparentConvenienceFees: true,
 				ventureCapital: false,
 			},
 		},

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -226,17 +226,17 @@ export type AccountType7702 = SmartAccountType
 /** Support information for Safe multisig accounts. */
 export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
 	/** Can the wallet deploy new Safe contracts? */
-	canDeployNew: boolean
-
-	/** Default configuration when creating a new Safe. */
-	defaultConfig: {
-		/** Number of owners by default. */
-		owners: number
-		/** Signature threshold by default. */
-		threshold: number
-		/** Enabled modules by default. */
-		modules: string[] // or more specific type if needed
-	}
+	canDeployNew: Support<{
+		/** Default configuration when creating a new Safe. */
+		defaultConfig: {
+			/** Number of owners by default. */
+			owners: number
+			/** Signature threshold by default. */
+			threshold: number
+			/** Enabled modules by default. */
+			modules: string[] // or more specific type if needed
+		}
+	}>
 
 	/** Does the wallet support key rotation without additional modules? */
 	supportsKeyRotationWithoutModules: boolean


### PR DESCRIPTION
Refactors Safe creation feature using `Support` type.

This change refactors `canDeployNew` to use the `Support` type pattern,
so that `defaultConfig` only needs to be specified when the wallet
actually supports deploying Safe contracts.

Refs #305

- Modified `rabby.ts` to change `canDeployNew` to `notSupported` and removed the default configuration.
- Updated `safe.ts` to implement a supported structure for `canDeployNew` with a default configuration.
- Adjusted the `AccountTypeSafe` interface in `account-support.ts` to reflect the new structure for `canDeployNew`.