### PR TITLE
Add imKey as an independent hardware wallet type, improving imToken's hardware wallet interoperability rating

### DIFF
--- a/data/software-wallets/imtoken.ts
+++ b/data/software-wallets/imtoken.ts
@@ -268,7 +268,7 @@ export const imtoken: SoftwareWallet = {
 					ref: [
 						{
 							explanation:
-								'imToken works with the imKey Bluetooth hardware wallet, and with Keystone via QR codes.',
+								'imToken works with the imKey hardware wallet via Bluetooth, and with Keystone via QR codes.',
 							url: 'https://support.token.im/hc/en-us/articles/25985632007193-imToken-and-Hardware-Wallets-Uncompromised-Protection-Unparalleled-Convenience',
 						},
 					],
@@ -276,7 +276,7 @@ export const imtoken: SoftwareWallet = {
 						[HardwareWalletType.KEYSTONE]: supported<SupportedHardwareWallet>({
 							connectionTypes: [HardwareWalletConnection.QR],
 						}),
-						[HardwareWalletType.OTHER]: supported<SupportedHardwareWallet>({
+						[HardwareWalletType.IMKEY]: supported<SupportedHardwareWallet>({
 							connectionTypes: [HardwareWalletConnection.bluetooth],
 						}),
 					},

--- a/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
+++ b/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
@@ -36,6 +36,7 @@ const majorHardwareWalletManufacturers: NonEmptyArray<HardwareWalletType> = [
 	HardwareWalletType.TREZOR,
 	HardwareWalletType.KEYSTONE,
 	HardwareWalletType.GRIDPLUS,
+	HardwareWalletType.IMKEY,
 ]
 
 const minMajorHardwareWalletManufacturers: number = 3

--- a/src/schema/features/security/hardware-wallet-support.ts
+++ b/src/schema/features/security/hardware-wallet-support.ts
@@ -21,6 +21,7 @@ export enum HardwareWalletType {
 	FIREFLY = 'FIREFLY',
 	ONEKEY = 'ONEKEY',
 	BITBOX = 'BITBOX',
+	IMKEY = 'IMKEY',
 	OTHER = 'OTHER',
 }
 
@@ -36,6 +37,7 @@ export const hardwareWalletType = new Enum<HardwareWalletType>({
 	[HardwareWalletType.FIREFLY]: true,
 	[HardwareWalletType.ONEKEY]: true,
 	[HardwareWalletType.BITBOX]: true,
+	[HardwareWalletType.IMKEY]: true,
 	[HardwareWalletType.OTHER]: true,
 })
 
@@ -65,6 +67,8 @@ export function hardwareWalletTypeToString(
 			return 'OneKey'
 		case HardwareWalletType.FIREFLY:
 			return 'Firefly'
+		case HardwareWalletType.IMKEY:
+			return 'imKey'
 		case HardwareWalletType.OTHER:
 			if (ifOther === null) {
 				throw new Error('Unexpected "OTHER" hardware wallet type')


### PR DESCRIPTION
This update separates imKey from the generic "OTHER" category and tracks it as an independent hardware wallet type.
## Why this change?
imKey is a mainstream hardware wallet (incubated by the imToken team) and already has its own hardware wallet data file. Previously, it was categorized as "OTHER", which prevented it from being properly reflected in the hardware wallet interoperability rating. By making it independent, we can more accurately reflect a wallet's support for mainstream hardware wallets.

## What changed:
- Added IMKEY type to the hardware wallet type enum
- Updated the display function to correctly show "imKey" name
- Changed imToken's hardware wallet support from OTHER to IMKEY
- Added imKey to the list of major hardware wallet manufacturers

## Rating impact:
imToken's hardware wallet interoperability rating improves from FAIL to PARTIAL. imToken now supports 2 major hardware wallet manufacturers (Keystone and imKey), which more accurately reflects its hardware wallet support capabilities.