### PR TITLE
Feat: Add cypherock monetization

### DIFF
--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -14,7 +14,6 @@ import {
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -60,7 +59,12 @@ export const cypherockWallet: HardwareWallet = {
 			},
 		},
 		monetization: {
-			ref: refTodo,
+			ref: [
+				{
+					explanation: 'Hardware wallet startup Cypherock raises $1 Mn',
+					url: 'https://entrackr.com/2022/12/hardware-wallet-startup-cypherock-raises-1-mn/',
+				},
+			],
 			revenueBreakdownIsPublic: false,
 			strategies: {
 				donations: null,
@@ -71,7 +75,7 @@ export const cypherockWallet: HardwareWallet = {
 				publicOffering: null,
 				selfFunded: null,
 				transparentConvenienceFees: null,
-				ventureCapital: null,
+				ventureCapital: true,
 			},
 		},
 		multiAddress: null,


### PR DESCRIPTION
Entrackr posted a blog that mentions Cypherock raises 1 million co-led by Consensys Mesh, Infinite Capital, Gnosis, Stefan George, Sandeep Nailwal, Mahin Gupta, OrangeDAO, Prasanna Sankar, and Furqan Rydhan.
Reference:
- https://entrackr.com/2022/12/hardware-wallet-startup-cypherock-raises-1-mn/