### PR TITLE
Feat: Add secure element to hardware wallet security features

### DIFF
--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -209,6 +209,7 @@ export const bitboxWallet: HardwareWallet = {
 			},
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: null,
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -15,7 +15,6 @@ import {
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -188,7 +187,13 @@ export const cypherockWallet: HardwareWallet = {
 				},
 			],
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'X1 Vault is open source and stores 1 of the 5 shards and the 4 X1 Cards have EAL 6+ secure elements and store the remaining 4 of the 5 shards.',
+						url: 'https://docs.cypherock.com/security-overview/introduction',
+					},
+				],
 				secureElementType: SecureElementType.EAL_6_PLUS,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -12,8 +12,10 @@ import {
 	noCalldataDecoding,
 	noDataExtraction,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -185,6 +187,10 @@ export const cypherockWallet: HardwareWallet = {
 					variantsScope: { [Variant.HARDWARE]: true },
 				},
 			],
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -81,6 +81,7 @@ export const fireflyWallet: HardwareWallet = {
 			},
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: null,
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -150,7 +150,13 @@ export const gridplusWallet: HardwareWallet = {
 			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'The Lattice1 meets stringent security industry standards including FIPS, PCI, and EAL 6+ and is the only hardware wallet designed to safeguard against edge case risks such as attackers remotely accessing a users secrets via RF emissions.',
+						url: 'https://www.prnewswire.com/news-releases/gridplus-sets-a-new-standard-for-blockchain-security-with-the-release-of-the-enterprise-grade-lattice1-wireless-hardware-wallet-301186849.html',
+					},
+				],
 				secureElementType: SecureElementType.EAL_6_PLUS,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -11,6 +11,7 @@ import {
 	DataExtraction,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
@@ -148,6 +149,10 @@ export const gridplusWallet: HardwareWallet = {
 			},
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -182,6 +182,7 @@ export const imkeyWallet: HardwareWallet = {
 			lightClient: { ethereumL1: null },
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: null,
 			supplyChainDIY: null,
 			supplyChainFactory: {
 				type: SupplyChainFactoryType.PASS,

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -182,7 +182,13 @@ export const keystoneWallet: HardwareWallet = {
 				},
 			],
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'Keystone 3 incorporates a PCI-grade anti-tampering feature, with an intricate ‘security house’ of circuitry encompassing the core IC and SE chips.',
+						url: 'https://blog.keyst.one/secure-elements-the-bedrock-of-hardware-wallet-security-1dd8cbdef461',
+					},
+				],
 				secureElementType: SecureElementType.PCI,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -12,6 +12,7 @@ import {
 	DataExtraction,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
@@ -180,6 +181,10 @@ export const keystoneWallet: HardwareWallet = {
 					variantsScope: { [Variant.HARDWARE]: true },
 				},
 			],
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.PCI,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -12,6 +12,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
@@ -162,6 +163,10 @@ export const ledgerWallet: HardwareWallet = {
 				library: PasskeyVerificationLibrary.NONE,
 			},
 			publicSecurityAudits: null,
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -164,7 +164,13 @@ export const ledgerWallet: HardwareWallet = {
 			},
 			publicSecurityAudits: null,
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'Ledger devices have an EAL 5+ or an EAL 6+ certification depending on which device you get.',
+						url: 'https://www.ledger.com/academy/security/the-secure-element-whistanding-security-attacks',
+					},
+				],
 				secureElementType: SecureElementType.EAL_6_PLUS,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -11,6 +11,7 @@ import {
 	noCalldataDecoding,
 	noDataExtraction,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
@@ -144,6 +145,10 @@ export const ngrave: HardwareWallet = {
 			},
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -146,8 +146,13 @@ export const ngrave: HardwareWallet = {
 			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: supported({
-				ref: refTodo,
-				secureElementType: SecureElementType.EAL_6_PLUS,
+				ref: [
+					{
+						explanation: 'The only crypto hardware wallet that achieved EAL7 certification.',
+						url: 'https://ngrave.io/en/zero',
+					},
+				],
+				secureElementType: SecureElementType.EAL_7,
 			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -11,6 +11,7 @@ import {
 	displaysFullTransactionDetails,
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
@@ -174,6 +175,10 @@ export const onekeyWallet: HardwareWallet = {
 					variantsScope: { [Variant.HARDWARE]: true },
 				},
 			],
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -176,7 +176,13 @@ export const onekeyWallet: HardwareWallet = {
 				},
 			],
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'Built with an EAL 6+ Secure Element, the same level of chip security used in government IDs, passports, and EMV bank cards.',
+						url: 'https://onekey.so/products/onekey-classic-1s-hardware-wallet/',
+					},
+				],
 				secureElementType: SecureElementType.EAL_6_PLUS,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -161,7 +161,13 @@ export const trezorWallet: HardwareWallet = {
 			},
 			publicSecurityAudits: null,
 			secureElement: supported({
-				ref: refTodo,
+				ref: [
+					{
+						explanation:
+							'Equipped with features including the Secure Element (EAL6+) and device-entry passphrase, it’s an impenetrable security pair.',
+						url: 'https://trezor.io/trezor-safe-3?',
+					},
+				],
 				secureElementType: SecureElementType.EAL_6_PLUS,
 			}),
 			supplyChainDIY: null,

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -12,6 +12,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/hardware-wallet-app-signing'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
+import { SecureElementType } from '@/schema/features/security/secure-element'
 import { notSupported, supported } from '@/schema/features/support'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
@@ -159,6 +160,10 @@ export const trezorWallet: HardwareWallet = {
 				library: PasskeyVerificationLibrary.NONE,
 			},
 			publicSecurityAudits: null,
+			secureElement: supported({
+				ref: refTodo,
+				secureElementType: SecureElementType.EAL_6_PLUS,
+			}),
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/data/hardware-wallets/unrated.tmpl.ts
+++ b/data/hardware-wallets/unrated.tmpl.ts
@@ -85,6 +85,7 @@ export const unratedHardwareTemplate: HardwareWallet = {
 			},
 			passkeyVerification: null,
 			publicSecurityAudits: null,
+			secureElement: null,
 			supplyChainDIY: null,
 			supplyChainFactory: null,
 			userSafety: null,

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -79,9 +79,6 @@ export interface WalletBaseFeatures {
 		 */
 		publicSecurityAudits: SecurityAudit[] | null
 
-		/** Secure element support */
-		secureElement: VariantFeature<Support<SecureElementSupport>>
-
 		/** Bug bounty program implementation */
 		bugBountyProgram: VariantFeature<Support<BugBountyProgramImplementation>>
 
@@ -211,6 +208,8 @@ export type WalletHardwareFeatures = WalletBaseFeatures & {
 		supplyChainDIY: VariantFeature<SupplyChainDIYSupport>
 		supplyChainFactory: VariantFeature<SupplyChainFactorySupport>
 		userSafety: VariantFeature<UserSafetySupport>
+		/** Secure element support */
+		secureElement: VariantFeature<Support<SecureElementSupport>>
 	}
 	privacy: WalletBaseFeatures['privacy'] & {
 		hardwarePrivacy: VariantFeature<HardwarePrivacySupport>

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -24,6 +24,7 @@ import type { KeysHandlingSupport } from './features/security/keys-handling'
 import type { EthereumL1LightClientSupport } from './features/security/light-client'
 import type { PasskeyVerificationImplementation } from './features/security/passkey-verification'
 import type { ScamAlerts } from './features/security/scam-alerts'
+import type { SecureElementSupport } from './features/security/secure-element'
 import type { SecurityAudit } from './features/security/security-audits'
 import type { SupplyChainDIYSupport } from './features/security/supply-chain-diy'
 import type { SupplyChainFactorySupport } from './features/security/supply-chain-factory'
@@ -50,7 +51,6 @@ import {
 	type VariantFeature,
 } from './variants'
 import { variantToWalletType, type WalletType } from './wallet-types'
-import type { SecureElementSupport } from './features/security/secure-element'
 
 /**
  * A set of features about any type of wallet.

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -50,6 +50,7 @@ import {
 	type VariantFeature,
 } from './variants'
 import { variantToWalletType, type WalletType } from './wallet-types'
+import type { SecureElementSupport } from './features/security/secure-element'
 
 /**
  * A set of features about any type of wallet.
@@ -77,6 +78,9 @@ export interface WalletBaseFeatures {
 		 * the fact that we haven't checked whether there have been any audit.
 		 */
 		publicSecurityAudits: SecurityAudit[] | null
+
+		/** Secure element support */
+		secureElement: VariantFeature<Support<SecureElementSupport>>
 
 		/** Bug bounty program implementation */
 		bugBountyProgram: VariantFeature<Support<BugBountyProgramImplementation>>

--- a/src/schema/features/security/secure-element.ts
+++ b/src/schema/features/security/secure-element.ts
@@ -1,4 +1,4 @@
-import type { WithRef } from "@/schema/reference";
+import type { WithRef } from '@/schema/reference'
 export type SecureElementSupport = WithRef<{
 	secureElementType: SecureElementType
 }>

--- a/src/schema/features/security/secure-element.ts
+++ b/src/schema/features/security/secure-element.ts
@@ -4,6 +4,7 @@ export type SecureElementSupport = WithRef<{
 }>
 
 export enum SecureElementType {
-	SE = 'SE',
-	HSM = 'HSM',
+	EAL_6_PLUS = 'EAL 6+',
+	EAL_5_PLUS = 'EAL 5+',
+	PCI = 'PCI',
 }

--- a/src/schema/features/security/secure-element.ts
+++ b/src/schema/features/security/secure-element.ts
@@ -4,6 +4,7 @@ export type SecureElementSupport = WithRef<{
 }>
 
 export enum SecureElementType {
+	EAL_7 = 'EAL 7',
 	EAL_6_PLUS = 'EAL 6+',
 	EAL_5_PLUS = 'EAL 5+',
 	PCI = 'PCI',

--- a/src/schema/features/security/secure-element.ts
+++ b/src/schema/features/security/secure-element.ts
@@ -1,0 +1,9 @@
+import type { WithRef } from "@/schema/reference";
+export type SecureElementSupport = WithRef<{
+	secureElementType: SecureElementType
+}>
+
+export enum SecureElementType {
+	SE = 'SE',
+	HSM = 'HSM',
+}


### PR DESCRIPTION
Fixes #361 
Adds tracking for secure element chips in hardware wallets as an important security feature. Secure elements provide hardware-based isolation that protects private keys from various attack vectors.

### Updates
- Created `SecureElementType` enum
```ts
export enum SecureElementType {
	EAL_7 = 'EAL 7',
	EAL_6_PLUS = 'EAL 6+',
	EAL_5_PLUS = 'EAL 5+',
	PCI = 'PCI',
}
```
### Future considerations
- Add getter functions to query secure element properties
- Update frontend to include the secure element feature. I'm thinking a non-paragraph UI (like a container that only contains the secure element)