### PR TITLE
Fix: /about page formatting

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -91,7 +91,10 @@ import HelpCircleIcon from 'lucide-static/icons/circle-help.svg?raw'
 					href='https://github.com/walletbeat/walletbeat'
 					target='_blank'
 					rel='noopener noreferrer'><span set:html={GitHubIcon} />open-source project</a
-				> licensed under the Free and Open-Source MIT license. Discussions are held on the <a
+				> licensed under the Free and Open-Source MIT license.
+			</p>
+			<p>
+				Discussions are held on the <a
 					href='https://warpcast.com/~/channel/walletbeat'
 					target='_blank'
 					rel='noopener noreferrer'
@@ -176,7 +179,10 @@ import HelpCircleIcon from 'lucide-static/icons/circle-help.svg?raw'
 		<section data-scroll-item='inline-detached padding-match-end' data-column='gap-5'>
 			<p>
 				Wallets listed on Walletbeat do not represent an endorsement and is for informational
-				purposes only. If you find that something is wrong, please help Walletbeat by <a
+				purposes only.
+			</p>
+			<p>
+				If you find that something is wrong, please help Walletbeat by <a
 					href='https://github.com/walletbeat/walletbeat'
 					target='_blank'
 					rel='noopener noreferrer'><span set:html={GitHubIcon} />contributing</a


### PR DESCRIPTION
Fixes #386 

Upon investigating, components or sections tagged with `data-column` or `data-card` ids aren't compatible with having only one `<p> </p>` block.

The fix done was to separate big `<p>` blocks into two `<p>` blocks.
### Before fix

<img width="1702" height="893" alt="image" src="https://github.com/user-attachments/assets/94aee5c6-9c20-4960-bc07-d1dc88f0afee" />

### After fix

<img width="1702" height="893" alt="image" src="https://github.com/user-attachments/assets/a4ada48b-4699-4e5a-bd54-5b9155456e60" />
