### PR TITLE
Rename `RpcEndpointConfiguration` enum values to make their values more clear.

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -261,10 +261,10 @@ export const ambire: SoftwareWallet = {
 			},
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -75,10 +75,10 @@ export const frame: SoftwareWallet = {
 			],
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/imtoken.ts
+++ b/data/software-wallets/imtoken.ts
@@ -141,10 +141,10 @@ export const imtoken: SoftwareWallet = {
 			],
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -130,22 +130,23 @@ export const metamask: SoftwareWallet = {
 			ref: [
 				{
 					explanation: `
-						MetaMask allows users to configure custom RPC endpoints for any network,
-						including Ethereum mainnet, but contacts \`mainnet.infura.io\` and
-						some L2s (e.g. \`polygon-mainnet.infura.io\`,
-						\`arbitrum-mainnet.infura.io\`) to perform \`eth_blockNumber\` and
-						\`net_version\` JSON RPCs before the user is able to customize the
-						endpoints to use for these chains.
+						MetaMask allows users to configure custom RPC endpoints for any
+						network, including Ethereum mainnet, though it contacts the
+						default \`mainnet.infura.io\` and some L2s (e.g
+						\`polygon-mainnet.infura.io\`, \`arbitrum-mainnet.infura.io\`) to
+						perform non-sensitive RPCs (\`eth_blockNumber\` and \`net_version\`)
+						before the user is able to customize the endpoints to use for
+						these chains.
 					`,
 					url: 'https://support.metamask.io/configure/networks/how-to-add-a-custom-network-rpc/',
 				},
 			],
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -151,10 +151,10 @@ export const rabby: SoftwareWallet = {
 			ref: refTodo,
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -92,10 +92,10 @@ export const safe: SoftwareWallet = {
 			ref: refTodo,
 			customChainRpcEndpoint: notSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
 			}),
 		}),
 		ecosystem: {

--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -58,8 +58,8 @@ function noChainVerification(
 				: chainConfigurability.l1.rpcEndpointConfiguration
 
 		return (
-			l1Configurability === RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST ||
-			l1Configurability === RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS
+			l1Configurability === RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST ||
+			l1Configurability === RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS
 		)
 	})()
 

--- a/src/schema/attributes/self-sovereignty/self-hosted-node.ts
+++ b/src/schema/attributes/self-sovereignty/self-hosted-node.ts
@@ -186,14 +186,14 @@ export const selfHostedNode: Attribute<SelfHostedNodeValue> = {
 
 		if (
 			features.chainConfigurability.l1.rpcEndpointConfiguration ===
-			RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST
+			RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST
 		) {
 			return supportsSelfHostedNode(allRefs)
 		}
 
 		if (
 			features.chainConfigurability.l1.rpcEndpointConfiguration ===
-			RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS
+			RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS
 		) {
 			return supportsSelfHostedNodeAfterRequests(allRefs)
 		}

--- a/src/schema/features/self-sovereignty/chain-configurability.ts
+++ b/src/schema/features/self-sovereignty/chain-configurability.ts
@@ -11,7 +11,7 @@ export enum RpcEndpointConfiguration {
 	 * "Sensitive request" is defined as containing any user data, such as the
 	 * user's wallet address.
 	 */
-	YES_BEFORE_ANY_REQUEST = 'YES_BEFORE_ANY_REQUEST',
+	YES_BEFORE_ANY_SENSITIVE_REQUEST = 'YES_BEFORE_ANY_SENSITIVE_REQUEST',
 
 	/**
 	 * It is possible to set a custom RPC endpoint address, but the wallet makes
@@ -21,7 +21,7 @@ export enum RpcEndpointConfiguration {
 	 * "Sensitive request" is defined as containing any user data, such as the
 	 * user's wallet address.
 	 */
-	YES_AFTER_OTHER_REQUESTS = 'YES_AFTER_OTHER_REQUESTS',
+	YES_AFTER_OTHER_SENSITIVE_REQUESTS = 'YES_AFTER_OTHER_SENSITIVE_REQUESTS',
 
 	/** The RPC endpoint is not configurable by the user. */
 	NO = 'NO',

--- a/src/schema/stages/software-wallet-stages.ts
+++ b/src/schema/stages/software-wallet-stages.ts
@@ -204,9 +204,9 @@ export const softwareWalletStageOne: WalletStage = {
 											'{{WALLET_NAME}} does not allow users to use their own Ethereum node.',
 										),
 									}
-								case RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS:
+								case RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS:
 								// Fallthrough.
-								case RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST:
+								case RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST:
 									return {
 										rating: StageCriterionRating.PASS,
 										explanation: sentence(
@@ -392,9 +392,9 @@ const softwareWalletStageTwo: WalletStage = {
 											'{{WALLET_NAME}} does not allow users to customize non-L1 chain endpoints.',
 										),
 									}
-								case RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS:
+								case RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS:
 								// Fallthrough.
-								case RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST:
+								case RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST:
 									return {
 										rating: StageCriterionRating.PASS,
 										explanation: sentence(


### PR DESCRIPTION
Update MetaMask data accordingly; the chain RPCs it makes before configurability are non-sensitive.