### PR TITLE
Refactor: Passkey verification

### DIFF
--- a/data/embedded-wallets/unrated.tmpl.ts
+++ b/data/embedded-wallets/unrated.tmpl.ts
@@ -64,6 +64,7 @@ export const unratedEmbeddedTemplate: EmbeddedWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
+			passkeyVerification: null,
 			publicSecurityAudits: null,
 			transactionLegibility: null,
 		},

--- a/data/embedded-wallets/unrated.tmpl.ts
+++ b/data/embedded-wallets/unrated.tmpl.ts
@@ -64,7 +64,6 @@ export const unratedEmbeddedTemplate: EmbeddedWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			transactionLegibility: null,
 		},

--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -203,7 +203,6 @@ export const bitboxWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: null,
 			supplyChainDIY: null,

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -150,7 +150,6 @@ export const cypherockWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: [
 				{
 					ref: [

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -71,7 +71,6 @@ export const fireflyWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: null,
 			supplyChainDIY: null,

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -129,7 +129,6 @@ export const gridplusWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -130,7 +130,6 @@ export const imkeyWallet: HardwareWallet = {
 			},
 			keysHandling: null,
 			lightClient: { ethereumL1: null },
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: null,
 			supplyChainDIY: null,

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -133,7 +133,6 @@ export const keystoneWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: [
 				{
 					ref: [

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -156,7 +156,6 @@ export const ledgerWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -13,7 +13,6 @@ import {
 	type BugBountyProgramImplementation,
 	LegalProtectionType,
 } from '@/schema/features/security/bug-bounty-program'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	DataExtraction,
@@ -21,7 +20,7 @@ import {
 	noCalldataDecoding,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
-import { refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -157,10 +156,7 @@ export const ledgerWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -132,7 +132,6 @@ export const ngrave: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -146,7 +146,6 @@ export const onekeyWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: [
 				{
 					ref: [

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -13,7 +13,6 @@ import {
 	type BugBountyProgramImplementation,
 	LegalProtectionType,
 } from '@/schema/features/security/bug-bounty-program'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	DataExtraction,
@@ -22,7 +21,7 @@ import {
 	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
-import { refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { HardwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -148,10 +147,7 @@ export const trezorWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -147,7 +147,6 @@ export const trezorWallet: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			secureElement: supported({
 				ref: [

--- a/data/hardware-wallets/unrated.tmpl.ts
+++ b/data/hardware-wallets/unrated.tmpl.ts
@@ -101,7 +101,6 @@ export const unratedHardwareTemplate: HardwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: null,
 			publicSecurityAudits: null,
 			secureElement: null,
 			supplyChainDIY: null,

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -29,7 +29,6 @@ import {
 	KeyGenerationLocation,
 	MultiPartyKeyReconstruction,
 } from '@/schema/features/security/keys-handling'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import type { SecurityAudit } from '@/schema/features/security/security-audits'
 import {
@@ -40,7 +39,7 @@ import { TransactionSubmissionL2Support } from '@/schema/features/self-sovereign
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { type References, refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { type References, refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -483,10 +482,7 @@ export const ambire: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: v2Audits,
 			scamAlerts: {
 				contractTransactionWarning: notSupported,

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -371,7 +371,7 @@ export const daimo: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
+			passkeyVerification: supported({
 				ref: [
 					{
 						explanation:
@@ -383,7 +383,7 @@ export const daimo: SoftwareWallet = {
 					'Daimo uses a verifier based on FreshCryptoLib for passkey verification in their P256Verifier contract.',
 				library: PasskeyVerificationLibrary.DAIMO_P256_VERIFIER,
 				libraryUrl: 'https://github.com/daimo-eth/p256-verifier/blob/master/src/P256Verifier.sol',
-			},
+			}),
 			publicSecurityAudits: [
 				{
 					ref: 'https://github.com/daimo-eth/daimo/blob/master/audits/2023-10-veridise-daimo.pdf',

--- a/data/software-wallets/elytro.ts
+++ b/data/software-wallets/elytro.ts
@@ -108,7 +108,7 @@ export const elytro: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
+			passkeyVerification: supported({
 				ref: [
 					{
 						explanation:
@@ -120,7 +120,7 @@ export const elytro: SoftwareWallet = {
 				library: PasskeyVerificationLibrary.OPEN_ZEPPELIN_P256_VERIFIER,
 				libraryUrl:
 					'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/P256.sol',
-			},
+			}),
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/family.ts
+++ b/data/software-wallets/family.ts
@@ -2,10 +2,9 @@ import { lucemans } from '@/data/contributors/lucemans'
 import { AccountType } from '@/schema/features/account-support'
 import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
 import { WalletProfile } from '@/schema/features/profile'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
-import { refNotNecessary, refTodo } from '@/schema/reference'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -104,10 +103,7 @@ export const family: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -9,14 +9,13 @@ import {
 	HardwareWalletType,
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import {
 	type ChainConfigurability,
 	RpcEndpointConfiguration,
 } from '@/schema/features/self-sovereignty/chain-configurability'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
-import { refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -149,10 +148,7 @@ export const frame: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/gem.ts
+++ b/data/software-wallets/gem.ts
@@ -3,12 +3,11 @@ import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
 import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
 import { WalletProfile } from '@/schema/features/profile'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { refNotNecessary, refTodo } from '@/schema/reference'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -128,10 +127,7 @@ export const gemwallet: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: {
 				contractTransactionWarning: supported({

--- a/data/software-wallets/imtoken.ts
+++ b/data/software-wallets/imtoken.ts
@@ -22,7 +22,6 @@ import {
 	HardwareWalletType,
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { type ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import {
 	type ChainConfigurability,
@@ -297,12 +296,7 @@ export const imtoken: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
-				[Variant.MOBILE]: {
-					ref: refNotNecessary,
-					library: PasskeyVerificationLibrary.NONE,
-				},
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: [
 				{
 					ref: [

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -14,7 +14,6 @@ import {
 	KeyGenerationLocation,
 	MultiPartyKeyReconstruction,
 } from '@/schema/features/security/keys-handling'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { displaysFullCallData } from '@/schema/features/security/transaction-legibility'
 import {
@@ -321,20 +320,7 @@ export const metamask: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
-				[Variant.BROWSER]: {
-					ref: refTodo,
-					details:
-						'MetaMask browser extension does not currently implement passkey verification. Phase 2 seedless onboarding has passkey scheduled for extension.',
-					library: PasskeyVerificationLibrary.NONE,
-				},
-				[Variant.MOBILE]: {
-					ref: refTodo,
-					details:
-						'MetaMask mobile uses biometrics that leverage the hardware enclave similar to passkeys. Standard passkey verification is not yet implemented.',
-					library: PasskeyVerificationLibrary.NONE,
-				},
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: [
 				{
 					ref: 'https://assets.ctfassets.net/clixtyxoaeas/21m4LE3WLYbgWjc33aDcp2/8252073e115688b1dc1500a9c2d33fe4/metamask-delegator-framework-audit-2024-10.pdf',

--- a/data/software-wallets/mtpelerin.ts
+++ b/data/software-wallets/mtpelerin.ts
@@ -7,7 +7,6 @@ import {
 	BugBountyProgramAvailability,
 	type BugBountyProgramImplementation,
 } from '@/schema/features/security/bug-bounty-program'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
@@ -140,10 +139,7 @@ export const mtpelerin: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -7,7 +7,6 @@ import {
 	HardwareWalletType,
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
@@ -123,10 +122,7 @@ export const phantom: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -22,7 +22,6 @@ import {
 	KeyGenerationLocation,
 	MultiPartyKeyReconstruction,
 } from '@/schema/features/security/keys-handling'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { SecurityFlawSeverity } from '@/schema/features/security/security-audits'
 import { displaysFullTransactionDetails } from '@/schema/features/security/transaction-legibility'
@@ -49,7 +48,7 @@ import {
 	LicensingType,
 	SourceAvailableNonFOSSLicense,
 } from '@/schema/features/transparency/license'
-import { refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -412,10 +411,7 @@ export const rabby: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: [
 				{
 					ref: 'https://github.com/RabbyHub/Rabby/blob/develop/audits/2021/%5B20210623%5DRabby%20chrome%20extension%20Penetration%20Testing%20Report.pdf',

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -7,11 +7,10 @@ import {
 	HardwareWalletType,
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { refNotNecessary, refTodo } from '@/schema/reference'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -131,10 +130,7 @@ export const rainbow: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -206,7 +206,7 @@ export const safe: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
+			passkeyVerification: supported({
 				ref: [
 					{
 						url: 'https://github.com/safe-fndn/safe-modules/tree/main/modules/passkey/contracts/vendor/FCL',
@@ -220,7 +220,7 @@ export const safe: SoftwareWallet = {
 				library: PasskeyVerificationLibrary.FRESH_CRYPTO_LIB,
 				libraryUrl:
 					'https://github.com/safe-fndn/safe-modules/tree/main/modules/passkey/contracts/vendor/FCL',
-			},
+			}),
 			publicSecurityAudits: [
 				{
 					ref: 'https://github.com/safe-fndn/safe-smart-account/blob/main/docs/Safe_Audit_Report_1_5_0_Certora.pdf',

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -7,10 +7,9 @@ import {
 	HardwareWalletType,
 	type SupportedHardwareWallet,
 } from '@/schema/features/security/hardware-wallet-support'
-import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { notSupported, supported } from '@/schema/features/support'
-import { refNotNecessary, refTodo } from '@/schema/reference'
+import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -128,10 +127,7 @@ export const zerion: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: null,
 			},
-			passkeyVerification: {
-				ref: refNotNecessary,
-				library: PasskeyVerificationLibrary.NONE,
-			},
+			passkeyVerification: notSupported,
 			publicSecurityAudits: null,
 			scamAlerts: null,
 			transactionLegibility: null,

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -13,10 +13,9 @@ import {
 import { isSupported } from '@/schema/features/support'
 import { popRefs } from '@/schema/reference'
 import { type AtLeastOneVariant } from '@/schema/variants'
-import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content'
 
-import { exempt, pickWorstRating, unrated } from '../common'
+import { pickWorstRating, unrated } from '../common'
 
 const brand = 'attributes.security.passkey_implementation'
 

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -307,18 +307,6 @@ export const passkeyImplementation: Attribute<PasskeyImplementationValue> = {
 	aggregate: (perVariant: AtLeastOneVariant<Evaluation<PasskeyImplementationValue>>) =>
 		pickWorstRating<PasskeyImplementationValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<PasskeyImplementationValue> => {
-		// Hardware wallets don't use passkeys
-		if (features.type === WalletType.HARDWARE) {
-			return exempt(
-				passkeyImplementation,
-				sentence(
-					"This attribute is not applicable for {{WALLET_NAME}} as it is a hardware wallet and doesn't use passkeys.",
-				),
-				brand,
-				{ library: null },
-			)
-		}
-
 		const passkeyVerification = features.security.passkeyVerification
 
 		if (passkeyVerification === null) {
@@ -327,19 +315,6 @@ export const passkeyImplementation: Attribute<PasskeyImplementationValue> = {
 
 		if (!isSupported(passkeyVerification)) {
 			return noPasskeyImplementation()
-		}
-
-		// If the library is explicitly set to NONE, this means the wallet doesn't support passkeys
-		// This handles EOA-only wallets like Frame, Rabby, Rainbow, etc.
-		if (passkeyVerification.library === null) {
-			return exempt(
-				passkeyImplementation,
-				sentence(
-					"This attribute is not applicable for {{WALLET_NAME}} as it doesn't implement passkeys.",
-				),
-				brand,
-				{ library: null },
-			)
 		}
 
 		const { withoutRefs, refs: extractedRefs } =

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -98,9 +98,6 @@ export interface WalletBaseFeatures {
 			ethereumL1: VariantFeature<Support<WithRef<EthereumL1LightClientSupport>>>
 		}
 
-		/** Passkey verification implementation */
-		passkeyVerification: VariantFeature<Support<PasskeyVerificationImplementation>>
-
 		/** How can users of the wallet recover their account? */
 		accountRecovery: VariantFeature<AccountRecovery>
 
@@ -403,7 +400,7 @@ export function resolveFeatures(
 				'security.transactionLegibility',
 				features => features.security.transactionLegibility,
 			),
-			passkeyVerification: baseFeat(
+			passkeyVerification: softwareFeat(
 				'passkeyVerification',
 				features => features.security.passkeyVerification,
 			),

--- a/src/schema/features.ts
+++ b/src/schema/features.ts
@@ -99,7 +99,7 @@ export interface WalletBaseFeatures {
 		}
 
 		/** Passkey verification implementation */
-		passkeyVerification: VariantFeature<PasskeyVerificationImplementation>
+		passkeyVerification: VariantFeature<Support<PasskeyVerificationImplementation>>
 
 		/** How can users of the wallet recover their account? */
 		accountRecovery: VariantFeature<AccountRecovery>
@@ -164,7 +164,7 @@ export type WalletSoftwareFeatures = WalletBaseFeatures & {
 		hardwareWalletSupport: VariantFeature<HardwareWalletSupport>
 
 		/** Passkey verification implementation */
-		passkeyVerification: VariantFeature<PasskeyVerificationImplementation>
+		passkeyVerification: VariantFeature<Support<PasskeyVerificationImplementation>>
 		transactionLegibility: WalletBaseFeatures['security']['transactionLegibility'] &
 			VariantFeature<SoftwareTransactionLegibilityImplementation>
 	}
@@ -288,7 +288,7 @@ export interface ResolvedFeatures {
 		transactionLegibility: ResolvedFeature<
 			HardwareTransactionLegibilityImplementation | SoftwareTransactionLegibilityImplementation
 		>
-		passkeyVerification: ResolvedFeature<PasskeyVerificationImplementation>
+		passkeyVerification: ResolvedFeature<Support<PasskeyVerificationImplementation>>
 		bugBountyProgram: ResolvedFeature<Support<BugBountyProgramImplementation>>
 		firmware: ResolvedFeature<FirmwareSupport>
 		keysHandling: ResolvedFeature<WithRef<KeysHandlingSupport>>

--- a/src/schema/features/security/passkey-verification.ts
+++ b/src/schema/features/security/passkey-verification.ts
@@ -10,7 +10,6 @@ export enum PasskeyVerificationLibrary {
 	OPEN_ZEPPELIN_P256_VERIFIER = 'OPEN_ZEPPELIN_P256_VERIFIER',
 	WEB_AUTHN_SOL = 'WEB_AUTHN_SOL',
 	OTHER = 'OTHER',
-	NONE = 'NONE',
 }
 
 /**


### PR DESCRIPTION
Changes:
- Removed passkeyImplemtation for hardware wallets as they are exempted from the rating
- Added type Support<> to PasskeyImplementation to allow wallets to have `notSupported`