### PR TITLE
Disable Edgeserver v0.2 step; appears broken.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,14 +30,14 @@ jobs:
       #     token: ${{ secrets.EDGE_TOKEN }}
       #     directory: dist
       #     context: true
-      - name: Edgeserver v0.2 Upload
-        uses: v3xlabs/edgeserver-upload@v0.2.1-pre.4
-        with:
-          site_id: s_305c36a033
-          server: https://edgeserver.dev/api
-          token: ${{ secrets.EDGE_TOKEN2 }}
-          directory: dist
-          context: true
+      # - name: Edgeserver v0.2 Upload
+      #   uses: v3xlabs/edgeserver-upload@v0.2.1-pre.4
+      #   with:
+      #     site_id: s_305c36a033
+      #     server: https://edgeserver.dev/api
+      #     token: ${{ secrets.EDGE_TOKEN2 }}
+      #     directory: dist
+      #     context: true
       - name: Deploy to Orbiter
         run: ./deploy/deploy-orbiter.sh
         env:


### PR DESCRIPTION
FYI @lucemans
Latest deployment attempts have been outputting this:

```
🚀 Deploying
   ----------------------------------------
   Loading blob....
   Blob size: 36338612
   Uploading blob....
   Uploading files for deployment ID: d_6326466126
   Unauthorized.... Check your auth token's validity.
```