### PR TITLE
Display transaction batching ratings in the EIP-7702 table

### DIFF
--- a/src/views/Eip7702Table.svelte
+++ b/src/views/Eip7702Table.svelte
@@ -7,6 +7,7 @@
 	import { AccountType } from '@/schema/features/account-support'
 	import type { Variant } from '@/schema/variants'
 	import type { RatedWallet } from '@/schema/wallet'
+	import { Rating } from '@/schema/attributes'
 
 	const WalletTypeFor7702 = {
 		EIP7702: 'EIP7702',
@@ -179,7 +180,7 @@
 				{
 					id: 'batching',
 					name: 'Batching',
-					value: () => 'Coming soon',
+					value: wallet => wallet.overall.ecosystem.transactionBatching?.evaluation?.value?.rating ?? undefined,
 				},
 			]}
 		>
@@ -320,9 +321,15 @@
 					{/if}
 
 				{:else if column.id === 'batching'}
-					<!-- {@const contract = getWalletContract(wallet)} -->
+					{@const batchingRating = wallet.overall.ecosystem.transactionBatching?.evaluation?.value?.rating}
 
-					<span class="muted-text">Coming soon</span>
+					{#if batchingRating === Rating.PASS}
+						✅
+					{:else if batchingRating === Rating.FAIL}
+						❌
+					{:else}
+						<span class="muted-text">–</span>
+					{/if}
 
 				{:else}
 					{value}


### PR DESCRIPTION
Replace the "coming soon" placeholder in the batching column with actual transaction batching ratings from wallet evaluations.

The column now displays:
- ✅ for wallets that pass transaction batching
- ❌ for wallets that fail transaction batching  
- "-" for other cases (partial, unrated, exempt, or undefined)

This change was triggered by a confused user. I was surprised to find that batching data existed, but the table did not show it. Which made it look like batching was unsupported.