### PR TITLE
L1 Provider Independence: Require no requests to L1 endpoint before configuration.

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -275,7 +275,7 @@ export const ambire: SoftwareWallet = {
 			},
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 				withNoConnectivityExceptL1RPCEndpoint: {
 					accountCreation: featureSupported,
 					accountImport: featureSupported,
@@ -285,7 +285,7 @@ export const ambire: SoftwareWallet = {
 				},
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -162,7 +162,7 @@ export const metamask: SoftwareWallet = {
 			],
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 				withNoConnectivityExceptL1RPCEndpoint: {
 					accountCreation: featureSupported,
 					accountImport: featureSupported,
@@ -172,7 +172,7 @@ export const metamask: SoftwareWallet = {
 				},
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -163,7 +163,7 @@ export const rabby: SoftwareWallet = {
 			ref: refTodo,
 			customChainRpcEndpoint: featureSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 				withNoConnectivityExceptL1RPCEndpoint: {
 					accountCreation: featureSupported,
 					accountImport: featureSupported,
@@ -173,7 +173,7 @@ export const rabby: SoftwareWallet = {
 				},
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS,
 			}),
 		}),
 		ecosystem: {

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -97,7 +97,7 @@ export const safe: SoftwareWallet = {
 			ref: refTodo,
 			customChainRpcEndpoint: notSupported,
 			l1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 				withNoConnectivityExceptL1RPCEndpoint: {
 					accountCreation: featureSupported,
 					accountImport: featureSupported,
@@ -107,7 +107,7 @@ export const safe: SoftwareWallet = {
 				},
 			}),
 			nonL1: supported({
-				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST,
+				rpcEndpointConfiguration: RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST,
 			}),
 		}),
 		ecosystem: {

--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -58,8 +58,8 @@ function noChainVerification(
 				: chainConfigurability.l1.rpcEndpointConfiguration
 
 		return (
-			l1Configurability === RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST ||
-			l1Configurability === RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS
+			l1Configurability === RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST ||
+			l1Configurability === RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS
 		)
 	})()
 

--- a/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
+++ b/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
@@ -55,10 +55,12 @@ function supportsSelfHostedNodeAfterRequests(
 			__brand: brand,
 		},
 		details: paragraph(`
-			{{WALLET_NAME}} lets you use a self-hosted Ethereum node, but you cannot configure this before a sensitive request is already made to an external RPC provider.
+			{{WALLET_NAME}} lets you use a self-hosted Ethereum node,
+			but you cannot configure this before the wallet contacts its default RPC provider.
 		`),
 		howToImprove: paragraph(`
-			{{WALLET_NAME}} should modify the wallet setup flow to allow the user to configure the RPC endpoint for L1 before making any requests, or should avoid making any such requests until the user can access the RPC endpoint configuration options.
+			{{WALLET_NAME}} should modify the wallet setup flow to allow the user to configure the RPC endpoint for L1 before making any requests,
+			or should avoid making any such requests until the user can access the RPC endpoint configuration options.
 		`),
 		references,
 	}
@@ -165,7 +167,7 @@ export const l1ProviderIndependence: Attribute<L1ProviderIndependence> = {
 		In order to qualify for this attribute, wallets must:
 
 		- Allow the user to configure the L1 RPC endpoint to a self-hosted node
-		  before any user-data-carrying request is made to that endpoint.
+		  before any request is made to that endpoint.
 		- Support basic functions (account creation/import, balance lookups,
 		  token transfers) using nothing but the self-hosted node
 			(no external services, no non-Ethereum-API calls), and whether
@@ -250,14 +252,14 @@ export const l1ProviderIndependence: Attribute<L1ProviderIndependence> = {
 
 		if (
 			features.chainConfigurability.l1.rpcEndpointConfiguration ===
-			RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST
+			RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST
 		) {
 			return supportsSelfHostedNode(allRefs)
 		}
 
 		if (
 			features.chainConfigurability.l1.rpcEndpointConfiguration ===
-			RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS
+			RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS
 		) {
 			return supportsSelfHostedNodeAfterRequests(allRefs)
 		}

--- a/src/schema/features/self-sovereignty/chain-configurability.ts
+++ b/src/schema/features/self-sovereignty/chain-configurability.ts
@@ -6,22 +6,16 @@ import type { Support } from '../support'
 export enum RpcEndpointConfiguration {
 	/**
 	 * It is possible to set a custom RPC endpoint address before the wallet
-	 * makes any sensitive request to its default RPC endpoint setting.
-	 *
-	 * "Sensitive request" is defined as containing any user data, such as the
-	 * user's wallet address.
+	 * makes any request to its default RPC endpoint setting.
 	 */
-	YES_BEFORE_ANY_SENSITIVE_REQUEST = 'YES_BEFORE_ANY_SENSITIVE_REQUEST',
+	YES_BEFORE_ANY_REQUEST = 'YES_BEFORE_ANY_REQUEST',
 
 	/**
 	 * It is possible to set a custom RPC endpoint address, but the wallet makes
 	 * sensitive requests to its default RPC endpoint before the user has a
 	 * chance to get to the configuration options for RPC endpoints.
-	 *
-	 * "Sensitive request" is defined as containing any user data, such as the
-	 * user's wallet address.
 	 */
-	YES_AFTER_OTHER_SENSITIVE_REQUESTS = 'YES_AFTER_OTHER_SENSITIVE_REQUESTS',
+	YES_AFTER_OTHER_REQUESTS = 'YES_AFTER_OTHER_REQUESTS',
 
 	/** The RPC endpoint is not configurable by the user. */
 	NO = 'NO',

--- a/src/schema/stages/software-wallet-stages.ts
+++ b/src/schema/stages/software-wallet-stages.ts
@@ -204,9 +204,9 @@ export const softwareWalletStageOne: WalletStage = {
 											'{{WALLET_NAME}} does not allow users to use their own Ethereum node.',
 										),
 									}
-								case RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS:
+								case RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS:
 								// Fallthrough.
-								case RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST:
+								case RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST:
 									return {
 										rating: StageCriterionRating.PASS,
 										explanation: sentence(
@@ -392,9 +392,9 @@ const softwareWalletStageTwo: WalletStage = {
 											'{{WALLET_NAME}} does not allow users to customize non-L1 chain endpoints.',
 										),
 									}
-								case RpcEndpointConfiguration.YES_AFTER_OTHER_SENSITIVE_REQUESTS:
+								case RpcEndpointConfiguration.YES_AFTER_OTHER_REQUESTS:
 								// Fallthrough.
-								case RpcEndpointConfiguration.YES_BEFORE_ANY_SENSITIVE_REQUEST:
+								case RpcEndpointConfiguration.YES_BEFORE_ANY_REQUEST:
 									return {
 										rating: StageCriterionRating.PASS,
 										explanation: sentence(


### PR DESCRIPTION
Partial undo of `1b479ed09faf85cc8e8c4900b73829a1028d0bf2` which made the distinction between "sensitive" and "non-sensitive" requests. This distinction is relevant for privacy, not self-sovereignty. The "wallet privacy" attribute already captures the privacy angle of this. The self-sovereignty angle is to ensure that the wallet does not depend on its default L1 RPC endpoint, which is best achieved by being strict about no requests before configurability.

Updates issue #401.