### PR TITLE
Refactor: Transaction legibility updates

### DIFF
--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -12,12 +12,12 @@ import {
 	type HardwareTransactionLegibilityImplementation,
 	isFullTransactionDetails,
 	isHardwareTransactionLegibility,
+	isSupportedOnDevice,
 	type SoftwareTransactionLegibilityImplementation,
 	supportsAnyCalldataDecoding,
 	supportsAnyDataExtraction,
 	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
-import { isSupported } from '@/schema/features/support'
 import { popRefs, refs } from '@/schema/reference'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
@@ -175,19 +175,20 @@ function evaluateHardwareWalletTransactionLegibility(
 			return Rating.UNRATED
 		}
 
-		// Check if wallet supports calldata decoding for complex transactions
+		// Check if wallet supports calldata decoding for complex transactions (ON_DEVICE)
 		const supportsComplexDecoding: boolean =
 			supportsAnyCalldataDecoding(legibility) &&
-			(isSupported(
-				legibility[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND],
+			(isSupportedOnDevice(
+				legibility,
+				CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND,
 			) ||
-				isSupported(legibility[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED]))
+				isSupportedOnDevice(legibility, CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED))
 
-		// Check if wallet supports basic calldata decoding
+		// Check if wallet supports basic calldata decoding (ON_DEVICE)
 		const supportsBasicDecoding: boolean =
-			isSupported(legibility[CalldataDecoding.ETH_USDC_TRANSFER]) &&
-			isSupported(legibility[CalldataDecoding.ZKSYNC_USDC_TRANSFER]) &&
-			isSupported(legibility[CalldataDecoding.AAVE_SUPPLY])
+			isSupportedOnDevice(legibility, CalldataDecoding.ETH_USDC_TRANSFER) &&
+			isSupportedOnDevice(legibility, CalldataDecoding.ZKSYNC_USDC_TRANSFER) &&
+			isSupportedOnDevice(legibility, CalldataDecoding.AAVE_SUPPLY)
 
 		// Check if all transaction details are displayed
 		const displaysAllDetails: boolean = isFullTransactionDetails(detailsDisplayed)

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -271,6 +271,22 @@ export function supportsAnyDataExtraction(dataExtractionMethods: DataExtractionM
 }
 
 /**
+ * Helper function to check if a calldata decoding is supported and ON_DEVICE
+ */
+export function isSupportedOnDevice(
+	legibility: CalldataDecodingTypes,
+	decoding: CalldataDecoding,
+): boolean {
+	const support = legibility[decoding]
+
+	if (!isSupported(support)) {
+		return false
+	}
+
+	return support.decoded === CalldataDecoded.ON_DEVICE
+}
+
+/**
  * A record of transaction legibility support (both message and transaction)
  */
 export interface HardwareTransactionLegibilitySupport {


### PR DESCRIPTION
### Updates
- Created `isSupportedOnDevice` for checking if calldata decoding is on device
- Walletbeat should only pass a hardware wallet's calldata decoding if calldata decoding is on device itself (not on browser extensions, mobile apps, etc.)