### PR TITLE
Feat: Add message signing & improve transaction legibility attribute

### DIFF
--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -23,9 +23,9 @@ import {
 } from '@/schema/features/security/bug-bounty-program'
 import { FirmwareType } from '@/schema/features/security/firmware'
 import {
+	DataDisplayOptions,
 	DataExtraction,
 	noCalldataDecoding,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
@@ -221,12 +221,12 @@ export const bitboxWallet: HardwareWallet = {
 					[DataExtraction.QRCODE]: false,
 				},
 				detailsDisplayed: {
-					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					nonce: DataDisplayOptions.NOT_IN_UI,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
 				messageSigningLegibility: null,

--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -229,6 +229,7 @@ export const bitboxWallet: HardwareWallet = {
 					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -14,9 +14,9 @@ import {
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
+	DataDisplayOptions,
 	DataExtraction,
 	noCalldataDecoding,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
@@ -203,12 +203,12 @@ export const cypherockWallet: HardwareWallet = {
 					[DataExtraction.QRCODE]: false,
 				},
 				detailsDisplayed: {
-					chain: TransactionDisplayOptions.NOT_IN_UI,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT, // derivation path counts
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT, // tx fee
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT, // contract address
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.NOT_IN_UI,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT, // derivation path counts
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT, // tx fee
+					nonce: DataDisplayOptions.NOT_IN_UI,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT, // contract address
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
 				messageSigningLegibility: null,

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -211,6 +211,7 @@ export const cypherockWallet: HardwareWallet = {
 					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -80,6 +80,7 @@ export const fireflyWallet: HardwareWallet = {
 				dataExtraction: noDataExtraction,
 				detailsDisplayed: null,
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -15,7 +15,7 @@ import {
 } from '@/schema/features/security/bug-bounty-program'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	CalldataDecoded,
+	DataDecoded,
 	CalldataDecoding,
 	type CalldataDecodingSupport,
 	DataExtraction,
@@ -165,20 +165,20 @@ export const gridplusWallet: HardwareWallet = {
 				legibility: {
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported<WithRef<CalldataDecodingSupport>>({
 						ref: refNotNecessary,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.ZKSYNC_USDC_TRANSFER]: supported({
 						ref: refNotNecessary,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.USDC_APPROVAL]: notSupported,
 					[CalldataDecoding.AAVE_SUPPLY]: supported({
 						ref: refNotNecessary,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED]: supported({
 						ref: refNotNecessary,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
 						notSupported,

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -183,6 +183,7 @@ export const gridplusWallet: HardwareWallet = {
 					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
 						notSupported,
 				},
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -15,9 +15,9 @@ import {
 } from '@/schema/features/security/bug-bounty-program'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	DataDecoded,
 	CalldataDecoding,
 	type CalldataDecodingSupport,
+	DataDecoded,
 	DataExtraction,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/transaction-legibility'

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -4,7 +4,7 @@ import { HardwareWalletManufactureType, WalletProfile } from '@/schema/features/
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SupplyChainFactoryType } from '@/schema/features/security/supply-chain-factory'
 import {
-	CalldataDecoded,
+	DataDecoded,
 	CalldataDecoding,
 	DataExtraction,
 	displaysFullTransactionDetails,
@@ -169,11 +169,11 @@ export const imkeyWallet: HardwareWallet = {
 				legibility: {
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported({
 						ref: refTodo,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.ZKSYNC_USDC_TRANSFER]: supported({
 						ref: refTodo,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.USDC_APPROVAL]: notSupported,
 					[CalldataDecoding.AAVE_SUPPLY]: notSupported,

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -181,6 +181,7 @@ export const imkeyWallet: HardwareWallet = {
 					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
 						notSupported,
 				},
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -6,9 +6,9 @@ import { SupplyChainFactoryType } from '@/schema/features/security/supply-chain-
 import {
 	CalldataDecoding,
 	DataDecoded,
+	DataDisplayOptions,
 	DataExtraction,
 	displaysFullTransactionDetails,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { InteroperabilityType } from '@/schema/features/self-sovereignty/interoperability'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
@@ -164,7 +164,7 @@ export const imkeyWallet: HardwareWallet = {
 				},
 				detailsDisplayed: {
 					...displaysFullTransactionDetails,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
+					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
 				legibility: {
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported({

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -4,8 +4,8 @@ import { HardwareWalletManufactureType, WalletProfile } from '@/schema/features/
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SupplyChainFactoryType } from '@/schema/features/security/supply-chain-factory'
 import {
-	DataDecoded,
 	CalldataDecoding,
+	DataDecoded,
 	DataExtraction,
 	displaysFullTransactionDetails,
 	TransactionDisplayOptions,

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -12,8 +12,8 @@ import {
 } from '@/schema/features/security/keys-handling'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	DataDecoded,
 	CalldataDecoding,
+	DataDecoded,
 	DataExtraction,
 	noCalldataDecoding,
 	TransactionDisplayOptions,

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -242,6 +242,7 @@ export const keycardShell: HardwareWallet = {
 						decoded: DataDecoded.ON_DEVICE,
 					}),
 				},
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -14,9 +14,9 @@ import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	CalldataDecoding,
 	DataDecoded,
+	DataDisplayOptions,
 	DataExtraction,
 	noCalldataDecoding,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { InteroperabilityType } from '@/schema/features/self-sovereignty/interoperability'
 import { featureSupported, supported } from '@/schema/features/support'
@@ -224,12 +224,12 @@ export const keycardShell: HardwareWallet = {
 					[DataExtraction.QRCODE]: true,
 				},
 				detailsDisplayed: {
-					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					nonce: DataDisplayOptions.NOT_IN_UI,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: {
 					...noCalldataDecoding,

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -12,7 +12,7 @@ import {
 } from '@/schema/features/security/keys-handling'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	CalldataDecoded,
+	DataDecoded,
 	CalldataDecoding,
 	DataExtraction,
 	noCalldataDecoding,
@@ -235,11 +235,11 @@ export const keycardShell: HardwareWallet = {
 					...noCalldataDecoding,
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported({
 						ref: 'https://github.com/keycard-tech/eth-abi-repo',
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.USDC_APPROVAL]: supported({
 						ref: 'https://github.com/keycard-tech/eth-abi-repo',
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 				},
 			},

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -15,7 +15,7 @@ import {
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	CalldataDecoded,
+	DataDecoded,
 	CalldataDecoding,
 	DataExtraction,
 	displaysFullTransactionDetails,
@@ -199,16 +199,16 @@ export const keystoneWallet: HardwareWallet = {
 				legibility: {
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported({
 						ref: refTodo,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.ZKSYNC_USDC_TRANSFER]: supported({
 						ref: refTodo,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.USDC_APPROVAL]: notSupported,
 					[CalldataDecoding.AAVE_SUPPLY]: supported({
 						ref: refTodo,
-						decoded: CalldataDecoded.ON_DEVICE,
+						decoded: DataDecoded.ON_DEVICE,
 					}),
 					[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED]: notSupported,
 					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -15,8 +15,8 @@ import {
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
-	DataDecoded,
 	CalldataDecoding,
+	DataDecoded,
 	DataExtraction,
 	displaysFullTransactionDetails,
 	TransactionDisplayOptions,

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -17,9 +17,9 @@ import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	CalldataDecoding,
 	DataDecoded,
+	DataDisplayOptions,
 	DataExtraction,
 	displaysFullTransactionDetails,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo, type WithRef } from '@/schema/reference'
@@ -194,7 +194,7 @@ export const keystoneWallet: HardwareWallet = {
 				},
 				detailsDisplayed: {
 					...displaysFullTransactionDetails,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
+					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
 				legibility: {
 					[CalldataDecoding.ETH_USDC_TRANSFER]: supported({

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -214,6 +214,7 @@ export const keystoneWallet: HardwareWallet = {
 					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
 						notSupported,
 				},
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -193,6 +193,7 @@ export const ledgerWallet: HardwareWallet = {
 				},
 				detailsDisplayed: displaysFullTransactionDetails,
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -13,9 +13,9 @@ import {
 } from '@/schema/features/security/bug-bounty-program'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
+	DataDisplayOptions,
 	noCalldataDecoding,
 	noDataExtraction,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
@@ -154,12 +154,12 @@ export const ngrave: HardwareWallet = {
 				],
 				dataExtraction: noDataExtraction,
 				detailsDisplayed: {
-					chain: TransactionDisplayOptions.NOT_IN_UI,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.NOT_IN_UI,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					nonce: DataDisplayOptions.NOT_IN_UI,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
 				messageSigningLegibility: null,

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -162,6 +162,7 @@ export const ngrave: HardwareWallet = {
 					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -197,6 +197,7 @@ export const onekeyWallet: HardwareWallet = {
 					nonce: TransactionDisplayOptions.NOT_IN_UI,
 				},
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -13,10 +13,10 @@ import {
 import { FirmwareType } from '@/schema/features/security/firmware'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
+	DataDisplayOptions,
 	DataExtraction,
 	displaysFullTransactionDetails,
 	noCalldataDecoding,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
@@ -193,8 +193,8 @@ export const onekeyWallet: HardwareWallet = {
 				},
 				detailsDisplayed: {
 					...displaysFullTransactionDetails,
-					chain: TransactionDisplayOptions.NOT_IN_UI,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
+					chain: DataDisplayOptions.NOT_IN_UI,
+					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
 				legibility: noCalldataDecoding,
 				messageSigningLegibility: null,

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -15,10 +15,10 @@ import {
 } from '@/schema/features/security/bug-bounty-program'
 import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
+	DataDisplayOptions,
 	DataExtraction,
 	displaysFullTransactionDetails,
 	noCalldataDecoding,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo, type WithRef } from '@/schema/reference'
@@ -180,8 +180,8 @@ export const trezorWallet: HardwareWallet = {
 				},
 				detailsDisplayed: {
 					...displaysFullTransactionDetails,
-					chain: TransactionDisplayOptions.NOT_IN_UI,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
+					chain: DataDisplayOptions.NOT_IN_UI,
+					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
 				legibility: noCalldataDecoding,
 				messageSigningLegibility: null,

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -184,6 +184,7 @@ export const trezorWallet: HardwareWallet = {
 					nonce: TransactionDisplayOptions.NOT_IN_UI,
 				},
 				legibility: noCalldataDecoding,
+				messageSigningLegibility: null,
 			},
 			userSafety: null,
 		},

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -31,7 +31,7 @@ import {
 } from '@/schema/features/security/keys-handling'
 import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import type { SecurityAudit } from '@/schema/features/security/security-audits'
-import { TransactionDisplayOptions } from '@/schema/features/security/transaction-legibility'
+import { DataDisplayOptions } from '@/schema/features/security/transaction-legibility'
 import {
 	type ChainConfigurability,
 	RpcEndpointConfiguration,
@@ -528,12 +528,12 @@ export const ambire: SoftwareWallet = {
 				calldataDisplay: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
-					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					nonce: TransactionDisplayOptions.NOT_IN_UI,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					nonce: DataDisplayOptions.NOT_IN_UI,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 			},
 		},

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -526,6 +526,7 @@ export const ambire: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
 					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -16,8 +16,8 @@ import {
 } from '@/schema/features/security/keys-handling'
 import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import {
+	DataDisplayOptions,
 	displaysFullCallData,
-	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import {
 	type ChainConfigurability,
@@ -437,12 +437,12 @@ export const metamask: SoftwareWallet = {
 				calldataDisplay: displaysFullCallData,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
-					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					nonce: TransactionDisplayOptions.SHOWN_OPTIONALLY,
-					to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-					value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					nonce: DataDisplayOptions.SHOWN_OPTIONALLY,
+					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
 			},
 		},

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -435,6 +435,7 @@ export const metamask: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: displaysFullCallData,
+				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
 					from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -635,6 +635,7 @@ export const rabby: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				messageSigningLegibility: null,
 				transactionDetailsDisplay: displaysFullTransactionDetails,
 			},
 		},

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -273,6 +273,7 @@ export const safe: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: displaysFullCallData,
+				messageSigningLegibility: null,
 				transactionDetailsDisplay: displaysFullTransactionDetails,
 			},
 		},

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -23,7 +23,8 @@ import {
 	TransactionDisplayOptions,
 } from '@/schema/features/security/transaction-legibility'
 import { popRefs, refs } from '@/schema/reference'
-import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
+import { markdown, paragraph, sentence } from '@/types/content'
+import { commaListFormat } from '@/types/utils/text'
 
 import { pickWorstRating, unrated } from '../common'
 
@@ -118,11 +119,11 @@ function analyzeHardwareFeatures(
 		const decodingChecks = [
 			{
 				key: CalldataDecoding.ETH_USDC_TRANSFER,
-				label: 'Basic token transfers (ERC-20)',
+				label: 'basic token transfers (ERC-20)',
 			},
 			{
 				key: CalldataDecoding.ZKSYNC_USDC_TRANSFER,
-				label: 'zkSync token transfers',
+				label: 'ZKSync token transfers',
 			},
 			{
 				key: CalldataDecoding.AAVE_SUPPLY,
@@ -130,11 +131,11 @@ function analyzeHardwareFeatures(
 			},
 			{
 				key: CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED,
-				label: 'Nested Safe transactions',
+				label: 'nested Safe transactions',
 			},
 			{
 				key: CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND,
-				label: 'Complex nested multisend transactions',
+				label: 'complex nested multisend transactions',
 			},
 		]
 
@@ -216,62 +217,60 @@ function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): stri
 	const sections: string[] = []
 
 	// Calldata Decoding section
-	if (features.calldataDecoding.supported.length > 0 || features.calldataDecoding.missing.length > 0) {
-		sections.push('**Calldata Decoding:**')
+	if (
+		features.calldataDecoding.supported.length > 0 ||
+		features.calldataDecoding.missing.length > 0
+	) {
+		sections.push('**Calldata Decoding:**\n')
+
 		if (features.calldataDecoding.supported.length > 0) {
-			sections.push(
-				`- ✓ Supported: ${features.calldataDecoding.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.calldataDecoding.supported)}\n`)
 		}
+
 		if (features.calldataDecoding.missing.length > 0) {
-			sections.push(
-				`- ✗ Missing: ${features.calldataDecoding.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.calldataDecoding.missing)}\n`)
 		}
 	}
 
 	// Transaction Details section
-	if (features.transactionDetails.supported.length > 0 || features.transactionDetails.missing.length > 0) {
-		sections.push('\n**Transaction Details Displayed:**')
+	if (
+		features.transactionDetails.supported.length > 0 ||
+		features.transactionDetails.missing.length > 0
+	) {
+		sections.push('\n**Transaction Details Displayed (On-Device)**\n')
+
 		if (features.transactionDetails.supported.length > 0) {
-			sections.push(
-				`- ✓ Shown: ${features.transactionDetails.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.transactionDetails.supported)}\n`)
 		}
+
 		if (features.transactionDetails.missing.length > 0) {
-			sections.push(
-				`- ✗ Not shown: ${features.transactionDetails.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.transactionDetails.missing)}\n`)
 		}
 	}
 
 	// Data Extraction section
 	if (features.dataExtraction.supported.length > 0 || features.dataExtraction.missing.length > 0) {
-		sections.push('\n**Data Extraction Methods:**')
+		sections.push('\n**Data Extraction Methods**\n')
+
 		if (features.dataExtraction.supported.length > 0) {
-			sections.push(
-				`- ✓ Available: ${features.dataExtraction.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.dataExtraction.supported)}\n`)
 		}
+
 		if (features.dataExtraction.missing.length > 0) {
-			sections.push(
-				`- ✗ Not available: ${features.dataExtraction.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.dataExtraction.missing)}\n`)
 		}
 	}
 
 	// Message Signing section
 	if (features.messageSigning.supported.length > 0 || features.messageSigning.missing.length > 0) {
-		sections.push('\n**Message Signing:**')
+		sections.push('\n**Message Signing (On-Device)**\n')
+
 		if (features.messageSigning.supported.length > 0) {
-			sections.push(
-				`- ✓ Displays: ${features.messageSigning.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.messageSigning.supported)}\n`)
 		}
+
 		if (features.messageSigning.missing.length > 0) {
-			sections.push(
-				`- ✗ Missing: ${features.messageSigning.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.messageSigning.missing)}\n`)
 		}
 	}
 
@@ -283,25 +282,25 @@ function generateHardwareHowToImprove(features: HardwareFeatureDetails): string 
 
 	if (features.calldataDecoding.missing.length > 0) {
 		improvements.push(
-			`**Calldata Decoding:** Add on-device support for ${features.calldataDecoding.missing.join(', ').toLowerCase()}`,
+			`**Calldata Decoding:** Add on-device support for ${commaListFormat(features.calldataDecoding.missing)}`,
 		)
 	}
 
 	if (features.transactionDetails.missing.length > 0) {
 		improvements.push(
-			`**Transaction Details:** Display ${features.transactionDetails.missing.join(', ').toLowerCase()} on the device`,
+			`**Transaction Details:** Display ${commaListFormat(features.transactionDetails.missing)} on the device`,
 		)
 	}
 
 	if (features.dataExtraction.missing.length > 0) {
 		improvements.push(
-			`**Data Extraction:** Implement ${features.dataExtraction.missing.join(', ').toLowerCase()} to allow independent verification`,
+			`**Data Extraction:** Implement ${commaListFormat(features.dataExtraction.missing)} to allow independent verification`,
 		)
 	}
 
 	if (features.messageSigning.missing.length > 0) {
 		improvements.push(
-			`**Message Signing:** Add on-device display for ${features.messageSigning.missing.join(', ').toLowerCase()}`,
+			`**Message Signing:** Add on-device display for ${commaListFormat(features.messageSigning.missing)}`,
 		)
 	}
 
@@ -541,47 +540,47 @@ function generateSoftwareDetailsMarkdown(features: SoftwareFeatureDetails): stri
 	const sections: string[] = []
 
 	// Calldata Display section
-	if (features.calldataDisplay.supported.length > 0 || features.calldataDisplay.missing.length > 0) {
-		sections.push('**Calldata Display:**')
+	if (
+		features.calldataDisplay.supported.length > 0 ||
+		features.calldataDisplay.missing.length > 0
+	) {
+		sections.push('**Calldata Display**\n')
+
 		if (features.calldataDisplay.supported.length > 0) {
-			sections.push(
-				`- ✓ Supported: ${features.calldataDisplay.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.calldataDisplay.supported)}\n`)
 		}
+
 		if (features.calldataDisplay.missing.length > 0) {
-			sections.push(
-				`- ✗ Missing: ${features.calldataDisplay.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.calldataDisplay.missing)}\n`)
 		}
 	}
 
 	// Transaction Details section
-	if (features.transactionDetails.supported.length > 0 || features.transactionDetails.missing.length > 0) {
-		sections.push('\n**Transaction Details Displayed:**')
+	if (
+		features.transactionDetails.supported.length > 0 ||
+		features.transactionDetails.missing.length > 0
+	) {
+		sections.push('\n**Transaction Details Displayed**\n')
+
 		if (features.transactionDetails.supported.length > 0) {
-			sections.push(
-				`- ✓ Shown: ${features.transactionDetails.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.transactionDetails.supported)}\n`)
 		}
+
 		if (features.transactionDetails.missing.length > 0) {
-			sections.push(
-				`- ✗ Not shown: ${features.transactionDetails.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.transactionDetails.missing)}\n`)
 		}
 	}
 
 	// Message Signing section
 	if (features.messageSigning.supported.length > 0 || features.messageSigning.missing.length > 0) {
-		sections.push('\n**Message Signing:**')
+		sections.push('\n**Message Signing**\n')
+
 		if (features.messageSigning.supported.length > 0) {
-			sections.push(
-				`- ✓ Displays: ${features.messageSigning.supported.join(', ')}`,
-			)
+			sections.push(`✓ Supported: ${commaListFormat(features.messageSigning.supported)}\n`)
 		}
+
 		if (features.messageSigning.missing.length > 0) {
-			sections.push(
-				`- ✗ Missing: ${features.messageSigning.missing.join(', ')}`,
-			)
+			sections.push(`✗ Missing: ${commaListFormat(features.messageSigning.missing)}\n`)
 		}
 	}
 
@@ -593,19 +592,19 @@ function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string 
 
 	if (features.calldataDisplay.missing.length > 0) {
 		improvements.push(
-			`**Calldata Display:** Implement ${features.calldataDisplay.missing.join(', ').toLowerCase()} for calldata`,
+			`**Calldata Display:** Implement ${commaListFormat(features.calldataDisplay.missing)} for calldata`,
 		)
 	}
 
 	if (features.transactionDetails.missing.length > 0) {
 		improvements.push(
-			`**Transaction Details:** Display ${features.transactionDetails.missing.join(', ').toLowerCase()} in the wallet interface`,
+			`**Transaction Details:** Display ${commaListFormat(features.transactionDetails.missing)} in the wallet interface`,
 		)
 	}
 
 	if (features.messageSigning.missing.length > 0) {
 		improvements.push(
-			`**Message Signing:** Add support for displaying ${features.messageSigning.missing.join(', ').toLowerCase()}`,
+			`**Message Signing:** Add support for displaying ${commaListFormat(features.messageSigning.missing)}`,
 		)
 	}
 

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -23,7 +23,7 @@ import {
 	supportsAnyDataExtraction,
 } from '@/schema/features/security/transaction-legibility'
 import { isSupported } from '@/schema/features/support'
-import { popRefs, refs, refTodo } from '@/schema/reference'
+import { popRefs, refNotNecessary, refs } from '@/schema/reference'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { commaListFormat } from '@/types/utils/text'
 
@@ -48,10 +48,26 @@ function evaluateSoftwareMessageSigning(
 		return false
 	}
 
-	const hasEip712Struct = messageSigningLegibility[MessageSigningDetails.EIP712_STRUCT]
-	const hasDomainHash = messageSigningLegibility[MessageSigningDetails.DOMAIN_HASH]
-	const hasMessageHash = messageSigningLegibility[MessageSigningDetails.MESSAGE_HASH]
-	const hasSafeHash = messageSigningLegibility[MessageSigningDetails.SAFE_HASH]
+	const hasEip712Struct =
+		messageSigningLegibility[MessageSigningDetails.EIP712_STRUCT] ===
+			DataDisplayOptions.SHOWN_BY_DEFAULT ||
+		messageSigningLegibility[MessageSigningDetails.EIP712_STRUCT] ===
+			DataDisplayOptions.SHOWN_OPTIONALLY
+	const hasDomainHash =
+		messageSigningLegibility[MessageSigningDetails.DOMAIN_HASH] ===
+			DataDisplayOptions.SHOWN_BY_DEFAULT ||
+		messageSigningLegibility[MessageSigningDetails.DOMAIN_HASH] ===
+			DataDisplayOptions.SHOWN_OPTIONALLY
+	const hasMessageHash =
+		messageSigningLegibility[MessageSigningDetails.MESSAGE_HASH] ===
+			DataDisplayOptions.SHOWN_BY_DEFAULT ||
+		messageSigningLegibility[MessageSigningDetails.MESSAGE_HASH] ===
+			DataDisplayOptions.SHOWN_OPTIONALLY
+	const hasSafeHash =
+		messageSigningLegibility[MessageSigningDetails.SAFE_HASH] ===
+			DataDisplayOptions.SHOWN_BY_DEFAULT ||
+		messageSigningLegibility[MessageSigningDetails.SAFE_HASH] ===
+			DataDisplayOptions.SHOWN_OPTIONALLY
 
 	// PASS if: EIP-712 struct OR (domainHash AND messageHash) OR safeHash
 	return hasEip712Struct || (hasDomainHash && hasMessageHash) || hasSafeHash
@@ -258,7 +274,6 @@ function analyzeHardwareFeatures({
 function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): string {
 	const sections: string[] = []
 
-	// Calldata Decoding section
 	// Calldata Decoding section
 	if (
 		features.calldataDecoding.supported.length > 0 ||
@@ -976,7 +991,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					detailsDisplayed: null,
 					dataExtraction: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 			exampleRating(
@@ -988,7 +1003,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					calldataDisplay: null,
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 		],
@@ -1003,7 +1018,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					detailsDisplayed: null,
 					dataExtraction: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 			exampleRating(
@@ -1016,7 +1031,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					detailsDisplayed: null,
 					dataExtraction: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 			exampleRating(
@@ -1028,7 +1043,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					calldataDisplay: null,
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 		],
@@ -1042,7 +1057,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					detailsDisplayed: null,
 					dataExtraction: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 			exampleRating(
@@ -1053,7 +1068,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					calldataDisplay: null,
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
-					ref: refTodo,
+					ref: refNotNecessary,
 				}),
 			),
 		],

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -2,7 +2,7 @@ import type { WithRef } from '@/schema/reference'
 
 import { isSupported, notSupported, type Support } from '../support'
 
-export enum TransactionDisplayOptions {
+export enum DataDisplayOptions {
 	/** Shown by default on the transaction approval screen */
 	SHOWN_BY_DEFAULT = 'SHOWN_BY_DEFAULT',
 	/** Available on the transaction approval screen but requires user action (e.g., clicking a button) or enabling in settings */
@@ -15,36 +15,36 @@ export enum TransactionDisplayOptions {
  * How are the essential transaction data displayed by the hardware wallet?
  */
 export interface DisplayedTransactionDetails {
-	gas: TransactionDisplayOptions
-	nonce: TransactionDisplayOptions
-	from: TransactionDisplayOptions
-	to: TransactionDisplayOptions
-	chain: TransactionDisplayOptions
-	value: TransactionDisplayOptions
+	gas: DataDisplayOptions
+	nonce: DataDisplayOptions
+	from: DataDisplayOptions
+	to: DataDisplayOptions
+	chain: DataDisplayOptions
+	value: DataDisplayOptions
 }
 
 /**
  * The wallet displays no transaction details.
  */
 export const displaysNoTransactionDetails: DisplayedTransactionDetails = {
-	gas: TransactionDisplayOptions.NOT_IN_UI,
-	nonce: TransactionDisplayOptions.NOT_IN_UI,
-	from: TransactionDisplayOptions.NOT_IN_UI,
-	to: TransactionDisplayOptions.NOT_IN_UI,
-	chain: TransactionDisplayOptions.NOT_IN_UI,
-	value: TransactionDisplayOptions.NOT_IN_UI,
+	gas: DataDisplayOptions.NOT_IN_UI,
+	nonce: DataDisplayOptions.NOT_IN_UI,
+	from: DataDisplayOptions.NOT_IN_UI,
+	to: DataDisplayOptions.NOT_IN_UI,
+	chain: DataDisplayOptions.NOT_IN_UI,
+	value: DataDisplayOptions.NOT_IN_UI,
 }
 
 /**
  * The wallet displays all the possible transaction details.
  */
 export const displaysFullTransactionDetails: DisplayedTransactionDetails = {
-	gas: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-	nonce: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-	from: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-	to: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-	chain: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
-	value: TransactionDisplayOptions.SHOWN_BY_DEFAULT,
+	gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	nonce: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 }
 
 /**
@@ -205,7 +205,7 @@ export enum DataDecoded {
 /**
  * What does the wallet provide for message signing legibility?
  */
-export enum MessageSigningProvides {
+export enum MessageSigningDetails {
 	/** The wallet provides the EIP-712 struct */
 	EIP712_STRUCT = 'EIP712_STRUCT',
 	/** The wallet provides the domain hash */
@@ -219,14 +219,14 @@ export enum MessageSigningProvides {
 /**
  * For software wallets: track which message signing data types are available
  */
-export type SoftwareMessageSigningLegibility = Record<MessageSigningProvides, boolean> | null
+export type SoftwareMessageSigningLegibility = Record<MessageSigningDetails, boolean> | null
 
 /**
  * For hardware wallets: track which message signing data types are available and where they are displayed
  */
 export interface HardwareMessageSigningLegibility {
 	/** Which message signing data types does the wallet provide? */
-	messageSigningProvides: Record<MessageSigningProvides, boolean>
+	messageSigningDetails: Record<MessageSigningDetails, DataDisplayOptions>
 	/** Where does the message signing data display happen? */
 	decoded: DataDecoded
 }
@@ -380,12 +380,12 @@ export interface SoftwareTransactionLegibilitySupport {
 
 export const isFullTransactionDetails = (details: DisplayedTransactionDetails): boolean => {
 	return (
-		details.gas === TransactionDisplayOptions.SHOWN_BY_DEFAULT &&
-		details.nonce === TransactionDisplayOptions.SHOWN_BY_DEFAULT &&
-		details.from === TransactionDisplayOptions.SHOWN_BY_DEFAULT &&
-		details.to === TransactionDisplayOptions.SHOWN_BY_DEFAULT &&
-		details.chain === TransactionDisplayOptions.SHOWN_BY_DEFAULT &&
-		details.value === TransactionDisplayOptions.SHOWN_BY_DEFAULT
+		details.gas === DataDisplayOptions.SHOWN_BY_DEFAULT &&
+		details.nonce === DataDisplayOptions.SHOWN_BY_DEFAULT &&
+		details.from === DataDisplayOptions.SHOWN_BY_DEFAULT &&
+		details.to === DataDisplayOptions.SHOWN_BY_DEFAULT &&
+		details.chain === DataDisplayOptions.SHOWN_BY_DEFAULT &&
+		details.value === DataDisplayOptions.SHOWN_BY_DEFAULT
 	)
 }
 

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -193,13 +193,42 @@ export type CalldataDecodingTypes = Record<
 /** If a wallet can decode the calldata for a specific transaction, what does that look like? */
 export interface CalldataDecodingSupport {
 	/** Where does the calldata decoding actually happen? */
-	decoded: CalldataDecoded
+	decoded: DataDecoded
 }
 
 /** Where does the calldata decoding actually happen? */
-export enum CalldataDecoded {
+export enum DataDecoded {
 	ON_DEVICE = 'ON_DEVICE',
 	OFF_DEVICE = 'OFF_DEVICE',
+}
+
+/**
+ * What does the wallet provide for message signing legibility?
+ */
+export enum MessageSigningProvides {
+	/** The wallet provides the EIP-712 struct */
+	EIP712_STRUCT = 'EIP712_STRUCT',
+	/** The wallet provides the domain hash */
+	DOMAIN_HASH = 'DOMAIN_HASH',
+	/** The wallet provides the message hash */
+	MESSAGE_HASH = 'MESSAGE_HASH',
+	/** The wallet provides the Safe hash */
+	SAFE_HASH = 'SAFE_HASH',
+}
+
+/**
+ * For software wallets: track which message signing data types are available
+ */
+export type SoftwareMessageSigningLegibility = Record<MessageSigningProvides, boolean> | null
+
+/**
+ * For hardware wallets: track which message signing data types are available and where they are displayed
+ */
+export interface HardwareMessageSigningLegibility {
+	/** Which message signing data types does the wallet provide? */
+	messageSigningProvides: Record<MessageSigningProvides, boolean>
+	/** Where does the message signing data display happen? */
+	decoded: DataDecoded
 }
 /**
  * Shorthand for a wallet that cannot do any calldata decoding.
@@ -283,7 +312,7 @@ export function isSupportedOnDevice(
 		return false
 	}
 
-	return support.decoded === CalldataDecoded.ON_DEVICE
+	return support.decoded === DataDecoded.ON_DEVICE
 }
 
 /**
@@ -303,6 +332,11 @@ export interface HardwareTransactionLegibilitySupport {
 	 * Does a wallet allow for data extraction?
 	 */
 	dataExtraction: DataExtractionMethods | null
+
+	/**
+	 * What message signing data does the hardware wallet provide and where is it displayed?
+	 */
+	messageSigningLegibility: HardwareMessageSigningLegibility | null
 }
 
 /**
@@ -337,6 +371,11 @@ export interface SoftwareTransactionLegibilitySupport {
 	 * Does the software wallet support displaying the transaction details?
 	 */
 	transactionDetailsDisplay: DisplayedTransactionDetails | null
+
+	/**
+	 * What message signing data does the software wallet provide?
+	 */
+	messageSigningLegibility: SoftwareMessageSigningLegibility | null
 }
 
 export const isFullTransactionDetails = (details: DisplayedTransactionDetails): boolean => {

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -219,7 +219,10 @@ export enum MessageSigningDetails {
 /**
  * For software wallets: track which message signing data types are available
  */
-export type SoftwareMessageSigningLegibility = Record<MessageSigningDetails, boolean> | null
+export type SoftwareMessageSigningLegibility = Record<
+	MessageSigningDetails,
+	DataDisplayOptions
+> | null
 
 /**
  * For hardware wallets: track which message signing data types are available and where they are displayed


### PR DESCRIPTION
# Feat: Add message signing & improve transaction legibility attribute

## Added message signing
- Added message signing legibility to both hardware wallets and software wallets
```ts
messageSigningLegibility: {
	[MessageSigningProvides.EIP712_STRUCT] = true,
	[MessageSigningProvides.DOMAIN_HASH] = true,
	[MessageSigningProvides.MESSAGE_HASH] = true,
	[MessageSigningProvides.SAFE_HASH] = true
}
```
  - Difference between hardware wallets and software wallets is that hardware wallets should also dictate the location of message signing decoding.
```ts
messageSigningLegibility: {
    messageSigningProvides: {
    	[MessageSigningProvides.EIP712_STRUCT] = true,
	[MessageSigningProvides.DOMAIN_HASH] = true,
	[MessageSigningProvides.MESSAGE_HASH] = true,
	[MessageSigningProvides.SAFE_HASH] = true
    },
    decoded: DataDecoded.ON_DEVICE
}
```
- Message signing attribute rating
  - Walletbeat should only PASS or FAIL a wallet, there should be no PARTIAL rating for message signing legibility
  - Message signing would only pass if a wallet provides either of the three:
    a - the EIP-712 struct
    b - (domainHash & messageHash)
    c - the safeHash
  - Message signing decoding on hardware wallets **SHOULD** be provided **on the device**, and decoding outside of the device would be rated as **FAIL**

## Updated transaction legibility Details and How To Improve section
- General improvement is to make both sections more detailed, iterating what's provided, what's missing.
- For hardware wallets, added checks if a wallet decodes calldata / message signing. Explicitly mentions if a wallet should improve the location of calldata / message signing decoding 

### Other updates
- Updated `CalldataDataDecoded` to `DataDecoded` to fit message signing decoding location
- Updated existing wallets `transactionLegibility` to add `messageSigningLegibility: null`

Fixes #403 and #404 