### PR TITLE
Wallet Security News: improve data / layout

### DIFF
--- a/data/news/2025-12-25-browser-extension-v268-incident.ts
+++ b/data/news/2025-12-25-browser-extension-v268-incident.ts
@@ -6,8 +6,8 @@ import {
 	type WalletSecurityNews,
 } from '@/types/content/news'
 
-export const browserExtensionIncident: WalletSecurityNews = {
-	name: 'browser-extension-v268-incident',
+export default {
+	slug: 'browser-extension-v268-incident',
 	type: NewsType.HACK,
 	ref: {
 		label: 'Trust Wallet Browser Extension v2.68 Incident: Community Update',
@@ -24,8 +24,4 @@ export const browserExtensionIncident: WalletSecurityNews = {
 		'A malicious version of Trust Wallet Browser Extension (v2.68) was published to the Chrome Web Store on December 24, 2025, through a compromised API key. The attack, linked to the industry-wide Sha1-Hulud supply chain incident, affected users who logged in during December 24-26, 2025. Approximately 2,520 wallet addresses were impacted with $8.5M in losses. Trust Wallet has committed to reimbursing all affected users.',
 	title: 'Trust Wallet Browser Extension v2.68 Supply Chain Attack',
 	updatedAt: '2026-01-06',
-}
-
-export const trustWalletNewsRegistry = {
-	'browser-extension-v268-incident': browserExtensionIncident,
-} as const
+} as const satisfies WalletSecurityNews

--- a/data/news/2026-01-06-global-e-breach.ts
+++ b/data/news/2026-01-06-global-e-breach.ts
@@ -8,8 +8,8 @@ import {
 
 import { ledgerWalletMetadata } from '../hardware-wallets/ledger'
 
-export const globalEBreach: WalletSecurityNews = {
-	name: 'global-e-breach',
+export default {
+	slug: 'global-e-breach',
 	type: NewsType.DATA_BREACH,
 	ref: {
 		label: 'ZachXBT tweet about Ledger data breach',
@@ -27,8 +27,4 @@ export const globalEBreach: WalletSecurityNews = {
 	title: 'Global-e Independent Provider Data Breach Affecting Ledger Customers',
 	updatedAt: '2026-01-06',
 	wallet: ledgerWalletMetadata,
-}
-
-export const ledgerNewsRegistry = {
-	'ledger-global-e-breach': globalEBreach,
-} as const
+} as const satisfies WalletSecurityNews

--- a/data/news/index.ts
+++ b/data/news/index.ts
@@ -1,11 +1,15 @@
-import { ledgerNewsRegistry } from './ledger'
-import { trustWalletNewsRegistry } from './trust-wallet'
+import type { WalletSecurityNews } from '@/types/content/news'
 
 /**
- * Registry of all security news items about wallets
- * Compiled from wallet-specific news registries
+ * All news articles about wallet security incidents, sorted by date (newest first)
+ * Compiled from individual news files
  */
-export const newsRegistry = {
-	...ledgerNewsRegistry,
-	...trustWalletNewsRegistry,
-} as const
+export const allWalletSecurityNews: WalletSecurityNews[] = (
+	[
+		(await import('./2025-12-25-browser-extension-v268-incident')).default,
+		(await import('./2026-01-06-global-e-breach')).default,
+	]
+		.sort((a, b) => (
+			b.publishedAt.localeCompare(a.publishedAt)
+		))
+)

--- a/data/news/index.ts
+++ b/data/news/index.ts
@@ -4,12 +4,7 @@ import type { WalletSecurityNews } from '@/types/content/news'
  * All news articles about wallet security incidents, sorted by date (newest first)
  * Compiled from individual news files
  */
-export const allWalletSecurityNews: WalletSecurityNews[] = (
-	[
-		(await import('./2025-12-25-browser-extension-v268-incident')).default,
-		(await import('./2026-01-06-global-e-breach')).default,
-	]
-		.sort((a, b) => (
-			b.publishedAt.localeCompare(a.publishedAt)
-		))
-)
+export const allWalletSecurityNews: WalletSecurityNews[] = [
+	(await import('./2025-12-25-browser-extension-v268-incident')).default,
+	(await import('./2026-01-06-global-e-breach')).default,
+].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ import svelteConfig from './svelte.config.js'
 
 const firstOrderedKeys = [
 	'id',
+	'slug',
 	'name',
 	'displayName',
 	'legalName',

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -74,7 +74,7 @@ export const navigationFarcasterChannel = {
 export const navigationNews = {
 	id: 'news',
 	icon: NewsPaperIcon,
-	title: 'Wallet News',
+	title: 'Wallet Security News',
 	href: '/news',
 } as const satisfies NavigationItem
 
@@ -182,9 +182,9 @@ export const defaultNavigationItems = [
 	},
 	// 	],
 	// },
+	navigationNews,
 	navigationAbout,
 	navigationFaq,
 	navigationRepository,
 	navigationFarcasterChannel,
-	navigationNews,
 ] as const satisfies NavigationItem[]

--- a/src/global.css
+++ b/src/global.css
@@ -631,15 +631,20 @@ summary {
 }
 
 [data-badge] {
+	--badge-backgroundColor: color-mix(in srgb, var(--accent) 33%, transparent);
+	--badge-borderColor: color-mix(in srgb, var(--accent) 40%, transparent);
+	--badge-textColor: currentColor;
+
 	flex-shrink: 0;
 	flex-basis: auto;
 
 	column-gap: 0;
 
 	border-radius: 0.375em;
-	background-color: color-mix(in srgb, var(--accent) 33%, transparent);
-	border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+	background-color: var(--badge-backgroundColor);
+	border: 1px solid var(--badge-borderColor);
 
+	color: var(--badge-textColor);
 	font-weight: 600;
 	line-height: 1;
 

--- a/src/global.css
+++ b/src/global.css
@@ -554,6 +554,12 @@ summary {
 	> [data-row-item~="basis-5"] {
 		flex-basis: 40ch;
 	}
+	> [data-row-item~="basis-6"] {
+		flex-basis: 46ch;
+	}
+	> [data-row-item~="basis-full"] {
+		flex-basis: 100%;
+	}
 
 	> [data-row-item~="wrap-start"],
 	&[data-row~="wrap-first-last"] > :first-child {

--- a/src/global.css
+++ b/src/global.css
@@ -276,7 +276,7 @@ details {
 
 	&[data-card] {
 		padding: 0;
-		gap: 0;
+		gap: 0 !important;
 
 		> summary {
 			padding: var(--card-padding);

--- a/src/global.css
+++ b/src/global.css
@@ -624,6 +624,12 @@ summary {
 	&[data-card~='padding-6'] {
 		--card-padding: 1.5em;
 	}
+	&[data-card~='padding-7'] {
+		--card-padding: 1.75em;
+	}
+	&[data-card~='padding-8'] {
+		--card-padding: 2em;
+	}
 
 	&[data-card~='border-accent'] {
 		border: 2px solid color-mix(in srgb, var(--accent) 90%, transparent);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,9 @@ import Metadata from '@/layouts/Metadata.astro'
 		<script is:inline>
 			// `color-scheme` override
 			const colorScheme = localStorage.getItem('theme')
-			if (colorScheme) document.documentElement.style.colorScheme = colorScheme
+			if (colorScheme) {
+				document.documentElement.style.colorScheme = colorScheme
+			}
 		</script>
 
 		{

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,11 +1,12 @@
 ---
 // Constants
 import {
+	navigationHome,
 	navigationAbout,
 	navigationFaq,
+	navigationNews,
 	navigationRepository,
 	navigationFarcasterChannel,
-	navigationHome,
 } from '@/constants/navigation'
 
 // Layouts
@@ -31,6 +32,7 @@ import HelpCircleIcon from 'lucide-static/icons/circle-help.svg?raw'
 			navigationHome,
 			navigationAbout,
 			navigationFaq,
+			navigationNews,
 			navigationRepository,
 			navigationFarcasterChannel,
 		]}
@@ -70,15 +72,14 @@ import HelpCircleIcon from 'lucide-static/icons/circle-help.svg?raw'
 			</p>
 
 			<p>
-				Where there is inherent subjectivity, such as in the decision of <em>which</em> criteria are
-				used to rate and categorize wallets, Walletbeat aims to follow Ethereum's ethos and cypherpunk
-				values as a guiding principle. See <a
+				Where there is inherent subjectivity, such as in the decision of <em>which</em> criteria are used
+				to rate and categorize wallets, Walletbeat aims to follow Ethereum's ethos and cypherpunk values
+				as a guiding principle. See <a
 					href='https://vitalik.eth.limo/general/2024/12/03/wallets.html'
 					target='_blank'
 					rel='noopener noreferrer'
 					>Vitalik's blog post on wallets <span set:html={ExternalLinkIcon} /></a
-				> and the <a href='/faq/'><span set:html={HelpCircleIcon} />Walletbeat FAQ page</a> for more
-				details.
+				> and the <a href='/faq/'><span set:html={HelpCircleIcon} />Walletbeat FAQ page</a> for more details.
 			</p>
 		</section>
 

--- a/src/pages/embedded/[attrGroupId].astro
+++ b/src/pages/embedded/[attrGroupId].astro
@@ -24,7 +24,9 @@ const attrGroup = getAttributeGroupById(
 	representativeWalletForType(WalletType.EMBEDDED).overall,
 )
 
-if (!attrGroup) throw new Error('Invalid attribute group')
+if (!attrGroup) {
+	throw new Error('Invalid attribute group')
+}
 
 // Components
 import Layout from '@/layouts/Layout.astro'

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -264,10 +264,11 @@ import Navigation from '@/views/Navigation.astro'
 import Typography from '@/components/Typography.svelte'
 
 import {
-	navigationAbout,
-	navigationFarcasterChannel,
 	navigationHome,
+	navigationAbout,
+	navigationNews,
 	navigationRepository,
+	navigationFarcasterChannel,
 } from '@/constants/navigation'
 
 import HelpCircleIcon from 'lucide-static/icons/circle-help.svg?raw'
@@ -297,6 +298,7 @@ import HelpOutlineIcon from '@material-icons/svg/svg/help_outline/baseline.svg?r
 					})),
 				],
 			},
+			navigationNews,
 			navigationRepository,
 			navigationFarcasterChannel,
 		]}

--- a/src/pages/hww/[attrGroupId].astro
+++ b/src/pages/hww/[attrGroupId].astro
@@ -25,7 +25,9 @@ const attrGroup = getAttributeGroupById(
 	representativeWalletForType(WalletType.HARDWARE).overall,
 )
 
-if (!attrGroup) throw new Error('Invalid attribute group')
+if (!attrGroup) {
+	throw new Error('Invalid attribute group')
+}
 
 // Components
 import Layout from '@/layouts/Layout.astro'

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -86,16 +86,16 @@ import Navigation from '@/views/Navigation.astro'
 									data-row-item="wrap-end flexible basis-3"
 									data-row="end wrap gap-1"
 								>
-									<span>Published <time datetime={news.publishedAt}>{formatDate(news.publishedAt)}</time></span>
+									<time datetime={news.publishedAt}>{formatDate(news.publishedAt)}</time>
 
 									{news.publishedAt !== news.updatedAt && (
-										<span class="gap-1">
+										<small class="gap-1">
 											<span>・</span>
 											<span>Updated <time datetime={news.updatedAt}>{formatDate(news.updatedAt)}</time></span>
-										</span>
+										</small>
 									)}
 								</div>
-						</summary>
+							</summary>
 
 							<div
 								class="article-content"
@@ -232,7 +232,6 @@ import Navigation from '@/views/Navigation.astro'
 			text-align: end;
 			font-size: 0.9em;
 			color: var(--text-secondary);
-			font-style: italic;
 		}
 
 		.article-content {

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,76 +1,35 @@
 ---
-// Constants
+// Types/constants
 import { defaultNavigationItems } from '@/constants/navigation'
+import { allWalletSecurityNews } from '@/data/news'
+import {
+	impactCategories,
+	incidentStatuses,
+	newsTypes,
+	severities,
+} from '@/types/content/news'
 
-import { newsRegistry } from '@/data/news'
-import { IncidentStatus, NewsType, Severity } from '@/types/content/news'
+
+// Functions
 import { refs } from '@/schema/reference'
 
-// Layouts
-import Layout from '@/layouts/Layout.astro'
-
-// Components
-import Navigation from '@/views/Navigation.astro'
-
-import ShieldAlertIcon from 'lucide-static/icons/shield-alert.svg?raw'
-import ShieldCheckIcon from 'lucide-static/icons/shield-check.svg?raw'
-import TriangleAlertIcon from 'lucide-static/icons/triangle-alert.svg?raw'
-import InfoIcon from 'lucide-static/icons/info.svg?raw'
-
-// Convert registry object to array and sort by date (newest first)
-const allNews = Object.values(newsRegistry).sort((a, b) => {
-	return b.publishedAt.localeCompare(a.publishedAt)
-})
-
-// Helper functions for rendering
-function getSeverityColor(severity: Severity) {
-	switch (severity) {
-		case Severity.CRITICAL:
-			return 'var(--color-critical)'
-		case Severity.HIGH:
-			return 'var(--color-high)'
-		case Severity.MEDIUM:
-			return 'var(--color-medium)'
-		case Severity.LOW:
-			return 'var(--color-low)'
-	}
-}
-
-function getStatusIcon(status: IncidentStatus) {
-	switch (status) {
-		case IncidentStatus.RESOLVED:
-			return ShieldCheckIcon
-		case IncidentStatus.MITIGATED:
-			return ShieldAlertIcon
-		case IncidentStatus.ONGOING:
-			return TriangleAlertIcon
-		case IncidentStatus.DISPUTED:
-			return InfoIcon
-	}
-}
-
-function formatDate(dateString: string) {
-	const date = new Date(dateString)
-	return date.toLocaleDateString('en-US', {
+const formatDate = (dateString: string) => (
+	new Date(dateString).toLocaleDateString('en-US', {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',
 	})
-}
+)
 
-function getTypeLabel(type: NewsType) {
-	switch (type) {
-		case NewsType.HACK:
-			return 'Hack'
-		case NewsType.DATA_BREACH:
-			return 'Data Breach'
-		case NewsType.VULNERABILITY:
-			return 'Vulnerability'
-		case NewsType.INCIDENT:
-			return 'Incident'
-	}
-}
+
+// Layouts
+import Layout from '@/layouts/Layout.astro'
+
+
+// Components
+import Navigation from '@/views/Navigation.astro'
 ---
+
 
 <Layout
 	metadata={{
@@ -80,9 +39,9 @@ function getTypeLabel(type: NewsType) {
 >
 	<Navigation navigationItems={defaultNavigationItems} />
 
-	<main data-sticky-container data-column='gap-8'>
-		<header data-scroll-item='inline-detached padding-match-start'>
-			<hgroup data-column='gap-4'>
+	<main data-sticky-container data-column="gap-8">
+		<header data-scroll-item="inline-detached padding-match-start">
+			<hgroup data-column="gap-4">
 				<h1>Wallet Security News</h1>
 				<p>Security incidents, vulnerabilities, and data breaches affecting Ethereum wallets</p>
 			</hgroup>
@@ -90,122 +49,153 @@ function getTypeLabel(type: NewsType) {
 
 		<hr />
 
-		{
-			allNews.length === 0 ? (
-				<section data-scroll-item='inline-detached' data-column='gap-5'>
-					<p>No security news items currently tracked.</p>
-				</section>
-			) : (
-				allNews.map((news, index) => (
-					<>
-						<section id={news.name} data-scroll-item='inline-detached' class='news-item'>
-							{news.wallet && (
-								<div class='wallet-info'>
-									<img
-										src={`/images/wallets/${news.wallet.id}.${news.wallet.iconExtension}`}
-										alt={news.wallet.displayName}
-									/>
-									<span class='wallet-name'>{news.wallet.displayName}</span>
-								</div>
-							)}
-
-							<button
-								class='news-header'
-								data-news-toggle={`news-${index}`}
-								aria-expanded='false'
-								aria-controls={`news-content-${index}`}
-							>
-								<h2>{news.title}</h2>
-								<svg
-									class='chevron'
-									width='24'
-									height='24'
-									viewBox='0 0 24 24'
-									fill='none'
-									stroke='currentColor'
-									stroke-width='2'
-									stroke-linecap='round'
-									stroke-linejoin='round'
-								>
-									<polyline points='6 9 12 15 18 9' />
-								</svg>
-							</button>
-
-							<div class='news-content' id={`news-content-${index}`} data-collapsed='true'>
-								<div class='news-content-inner'>
-									<time datetime={news.publishedAt}>
-										Published {formatDate(news.publishedAt)}
-										{news.publishedAt !== news.updatedAt && (
-											<> • Updated {formatDate(news.updatedAt)}</>
-										)}
-									</time>
-
-									<p class='summary'>{news.summary}</p>
-
-									<div class='metadata-section'>
-										<div class='metadata-row'>
-											<div class='metadata-item'>
-												<span class='metadata-label'>Type</span>
-												<span class='type-badge'>{getTypeLabel(news.type)}</span>
-											</div>
-											<div class='metadata-item'>
-												<span class='metadata-label'>Severity</span>
-												<span
-													class='severity-badge'
-													style={`--severity-color: ${getSeverityColor(news.severity)}`}
-												>
-													{news.severity}
-												</span>
-											</div>
-											<div class='metadata-item'>
-												<span class='metadata-label'>Status</span>
-												<span class='status-badge' data-status={news.status.toLowerCase()}>
-													<span set:html={getStatusIcon(news.status)} />
-													{news.status}
-												</span>
-											</div>
-										</div>
-										<div class='impact-info'>
-											<strong>Impact:</strong>
-											<ul>
-												<li>Funds: {news.impact.fundsImpacted ? 'Affected' : 'Not affected'}</li>
-												<li>Category: {news.impact.category.replace(/_/g, ' ').toLowerCase()}</li>
-											</ul>
-										</div>
+		{allWalletSecurityNews.map((news) => (
+			<>
+				<div data-scroll-item="inline-detached">
+					<article id={news.slug}>
+						<details
+							data-card="padding-6"
+							data-column="gap-6"
+						>
+							<summary data-row="wrap wrap-first-last">
+								{news.wallet && (
+									<div
+										data-row-item="basis-full"
+									>
+										<a
+											class="wallet-link"
+											href={`/${news.wallet.id}`}
+											data-link="camouflaged"
+											data-badge="medium"
+										>
+											<img
+												src={`/images/wallets/${news.wallet.id}.${news.wallet.iconExtension}`}
+												alt={news.wallet.displayName}
+											/>
+											<span>{news.wallet.displayName}</span>
+										</a>
 									</div>
+								)}
 
-									{refs(news).length > 0 && (
-										<div class='references'>
-											<strong>Sources:</strong>
-											<ul>
-												{refs(news).map(ref =>
-													ref.urls.map(url => (
-														<li>
-															<a href={url.url} target='_blank' rel='noopener noreferrer'>
-																{url.label} →
-															</a>
-														</li>
-													)),
-												)}
-											</ul>
-										</div>
+								<h2 data-row-item="flexible basis-3">
+									{news.title}
+								</h2>
+
+								<div
+									class="metadata-dates"
+									data-row-item="wrap-end flexible basis-3"
+									data-row="end wrap gap-1"
+								>
+									<span>Published <time datetime={news.publishedAt}>{formatDate(news.publishedAt)}</time></span>
+
+									{news.publishedAt !== news.updatedAt && (
+										<span class="gap-1">
+											<span>・</span>
+											<span>Updated <time datetime={news.updatedAt}>{formatDate(news.updatedAt)}</time></span>
+										</span>
 									)}
 								</div>
+						</summary>
+
+							<div
+								class="article-content"
+								data-column="gap-5"
+							>
+								<hr>
+
+								<dl
+									class="metadata"
+									data-row="start wrap gap-6"
+								>
+									<div data-column="gap-2">
+										<dt>Type</dt>
+										<dd>
+											<span
+												class="type-badge"
+												data-badge="medium"
+											>
+												{newsTypes[news.type].label}
+											</span>
+										</dd>
+									</div>
+
+									<div data-column="gap-2">
+										<dt>Severity</dt>
+										<dd>
+											<span
+												class="severity-badge"
+												data-badge="medium"
+												style={`--severity-color: ${severities[news.severity].color}`}
+											>
+												{severities[news.severity].label}
+											</span>
+										</dd>
+									</div>
+
+									<div data-column="gap-2">
+										<dt>Status</dt>
+										<dd>
+											<span
+												class="status-badge"
+												data-badge="medium"
+												style={`--status-color: ${incidentStatuses[news.status].color}`}
+											>
+												<span set:html={incidentStatuses[news.status].icon} />
+												{incidentStatuses[news.status].label}
+											</span>
+										</dd>
+									</div>
+								</dl>
+
+								<p>{news.summary}</p>
+
+								<div
+									data-card="secondary padding-4 radius-4"
+									data-column="gap-3"
+								>
+									<h4>Impact</h4>
+									<ul>
+										<li>Funds: {news.impact.fundsImpacted ? 'Affected' : 'Not Affected'}</li>
+										<li>Category: {impactCategories[news.impact.category].label}</li>
+									</ul>
+								</div>
+
+								<hr>
+
+								{refs(news).length > 0 && (
+									<footer data-column="gap-3">
+										<h4>Sources</h4>
+										<ul>
+											{refs(news).map(ref =>
+												ref.urls.map(url => (
+													<li>
+														<a href={url.url} target="_blank" rel="noopener noreferrer">
+															{url.label} →
+														</a>
+													</li>
+												)),
+											)}
+										</ul>
+									</footer>
+								)}
 							</div>
-						</section>
+						</details>
+					</article>
+				</div>
 
-						<hr />
-					</>
-				))
-			)
-		}
+				<hr />
+			</>
+		))}
 
-		<section data-scroll-item='inline-detached padding-match-end' data-column='gap-5'>
+		<section
+			data-scroll-item="inline-detached padding-match-end"
+			data-column="gap-5"
+		>
 			<p>
 				Know about a security incident affecting a wallet? Please help by <a
-					href='https://github.com/walletbeat/walletbeat'
-					target='_blank'
-					rel='noopener noreferrer'>contributing to our repository</a
+					href="https://github.com/walletbeat/walletbeat"
+					target="_blank"
+					rel="noopener noreferrer">contributing to our repository</a
 				>!
 			</p>
 		</section>
@@ -215,7 +205,7 @@ function getTypeLabel(type: NewsType) {
 <style>
 	main {
 		&[data-sticky-container] {
-			--scrollItem-inlineDetached-maxSize: 48rem;
+			--scrollItem-inlineDetached-maxSize: 52rem;
 			--scrollItem-inlineDetached-maxPaddingMatchStart: 5rem;
 			--scrollItem-inlineDetached-maxPaddingMatchEnd: 5rem;
 		}
@@ -227,256 +217,66 @@ function getTypeLabel(type: NewsType) {
 			color: var(--text-secondary);
 			opacity: 0.85;
 		}
+	}	
 
-		.news-item {
-			display: flex;
-			flex-direction: column;
-			gap: 0.75rem;
-
-			.wallet-info {
-				display: flex;
-				align-items: center;
-				gap: 0.5rem;
-				padding: 0.5rem 0.75rem;
-				background: var(--background-secondary, rgba(0, 0, 0, 0.1));
-				border-radius: 0.375rem;
-				width: fit-content;
-
-				img {
-					width: 1.5rem;
-					height: 1.5rem;
-					border-radius: 0.25rem;
-				}
-
-				.wallet-name {
-					font-size: 0.9rem;
-					font-weight: 600;
-					color: var(--text-primary);
-				}
-			}
-
-			.news-header {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-				gap: 1rem;
-				width: 100%;
-				background: transparent;
-				border: none;
-				padding: 0;
-				cursor: pointer;
-				text-align: left;
-				transition: opacity 0.2s;
-
-				&:hover {
-					opacity: 0.8;
-				}
-
-				h2 {
-					font-size: 1.5rem;
-					margin: 0;
-					line-height: 1.3;
-					flex: 1;
-					color: var(--text-primary);
-				}
-
-				.chevron {
-					flex-shrink: 0;
-					color: var(--text-secondary);
-					transition: transform 0.3s ease;
-				}
-
-				&[aria-expanded='true'] .chevron {
-					transform: rotate(180deg);
-				}
-			}
-
-			.news-content {
-				overflow: hidden;
-				transition:
-					max-height 0.3s ease,
-					opacity 0.3s ease;
-
-				&[data-collapsed='true'] {
-					max-height: 0;
-					opacity: 0;
-				}
-
-				&[data-collapsed='false'] {
-					max-height: 5000px;
-					opacity: 1;
-				}
-			}
-
-			.news-content-inner {
-				display: flex;
-				flex-direction: column;
-				gap: 1rem;
-				padding-top: 0.5rem;
-			}
-
-			time {
-				font-size: 0.9rem;
-				color: var(--text-secondary);
-				font-style: italic;
-			}
-
-			.summary {
-				margin: 0;
-				font-size: 1.05rem;
-				line-height: 1.7;
-			}
-
-			.metadata-section {
-				display: flex;
-				flex-direction: column;
-				gap: 1rem;
-			}
-
-			.metadata-row {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 1.5rem;
-			}
-
-			.metadata-item {
-				display: flex;
-				flex-direction: column;
-				gap: 0.5rem;
-
-				.metadata-label {
-					font-size: 0.75rem;
-					font-weight: 600;
-					text-transform: uppercase;
-					letter-spacing: 0.05em;
-					color: var(--text-secondary);
-					opacity: 0.8;
-				}
-			}
-
-			.impact-info {
-				background: var(--background-secondary, rgba(0, 0, 0, 0.1));
-				padding: 1rem;
-				border-radius: 0.5rem;
-				font-size: 0.95rem;
-
-				strong {
-					display: block;
-					margin-bottom: 0.5rem;
-				}
-
-				ul {
-					margin: 0;
-					padding-inline-start: 1.5em;
-					line-height: 1.6;
-
-					li {
-						text-transform: capitalize;
-					}
-				}
-			}
-
-			.references {
-				strong {
-					display: block;
-					margin-bottom: 0.5rem;
-				}
-
-				ul {
-					margin: 0;
-					padding-inline-start: 1.5em;
-
-					a {
-						color: var(--accent);
-						text-decoration: none;
-
-						&:hover {
-							text-decoration: underline;
-						}
-					}
-				}
+	article {
+		.wallet-link {
+			&[data-badge] {
+				--badge-backgroundColor: var(--background-secondary);
+				--badge-borderColor: transparent;
+				--badge-textColor: currentColor;
 			}
 		}
 
-		.type-badge,
-		.severity-badge,
-		.status-badge {
-			display: inline-flex;
-			align-items: center;
-			gap: 0.375rem;
-			padding: 0.375rem 0.75rem;
-			border-radius: 0.375rem;
-			font-size: 0.85rem;
-			font-weight: 700;
-			text-transform: uppercase;
-			letter-spacing: 0.025em;
-			width: fit-content;
-		}
-
-		.type-badge {
-			background: var(--background-tertiary, rgba(0, 0, 0, 0.15));
+		.metadata-dates {
+			text-align: end;
+			font-size: 0.9em;
 			color: var(--text-secondary);
+			font-style: italic;
 		}
 
-		.severity-badge {
-			background: var(--severity-color, var(--text-secondary));
-			color: white;
+		.article-content {
+			line-height: 1.75;
 		}
 
-		.status-badge {
-			display: inline-flex;
-			align-items: center;
-			gap: 0.375rem;
+		dl.metadata {
+			text-transform: uppercase;
 
-			span {
-				display: inline-flex;
-				width: 1rem;
-				height: 1rem;
+			dt {
+				font-size: 0.75rem;
+				font-weight: 600;
+				letter-spacing: 0.05em;
+				color: var(--text-secondary);
+				opacity: 0.8;
+			}
 
-				:global(svg) {
-					width: 100%;
-					height: 100%;
+			.type-badge {
+				&[data-badge] {
+					--badge-backgroundColor: var(--background-secondary);
+					--badge-borderColor: transparent;
+					--badge-textColor: var(--text-secondary);
 				}
 			}
 
-			&[data-status='resolved'] {
-				background: #10b981;
-				color: white;
+			.severity-badge {
+				&[data-badge] {
+					--badge-backgroundColor: var(--severity-color, var(--text-secondary));
+					--badge-borderColor: transparent;
+					--badge-textColor: white;
+				}
 			}
 
-			&[data-status='mitigated'] {
-				background: #f59e0b;
-				color: white;
+			.status-badge {
+				&[data-badge] {
+					--badge-textColor: white;
+					--badge-borderColor: transparent;
+					--badge-backgroundColor: var(--status-color);
+				}
 			}
+		}
 
-			&[data-status='ongoing'] {
-				background: #ef4444;
-				color: white;
-			}
-
-			&[data-status='disputed'] {
-				background: #6b7280;
-				color: white;
-			}
+		ul {
+			padding-inline-start: 1.5em;
 		}
 	}
 </style>
-
-<script>
-	document.addEventListener('DOMContentLoaded', () => {
-		const toggleButtons = document.querySelectorAll('[data-news-toggle]')
-
-		toggleButtons.forEach(button => {
-			button.addEventListener('click', () => {
-				const isExpanded = button.getAttribute('aria-expanded') === 'true'
-				const contentId = button.getAttribute('aria-controls')
-				const content = document.getElementById(contentId!)
-
-				if (content) {
-					button.setAttribute('aria-expanded', (!isExpanded).toString())
-					content.setAttribute('data-collapsed', isExpanded.toString())
-				}
-			})
-		})
-	})
-</script>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -2,35 +2,25 @@
 // Types/constants
 import { defaultNavigationItems } from '@/constants/navigation'
 import { allWalletSecurityNews } from '@/data/news'
-import {
-	impactCategories,
-	incidentStatuses,
-	newsTypes,
-	severities,
-} from '@/types/content/news'
-
+import { impactCategories, incidentStatuses, newsTypes, severities } from '@/types/content/news'
 
 // Functions
 import { refs } from '@/schema/reference'
 
-const formatDate = (dateString: string) => (
+const formatDate = (dateString: string) =>
 	new Date(dateString).toLocaleDateString('en-US', {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',
 	})
-)
-
 
 // Layouts
 import Layout from '@/layouts/Layout.astro'
-
 
 // Components
 import Navigation from '@/views/Navigation.astro'
 import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 ---
-
 
 <Layout
 	metadata={{
@@ -40,9 +30,9 @@ import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 >
 	<Navigation navigationItems={defaultNavigationItems} />
 
-	<main data-sticky-container data-column="gap-8">
-		<header data-scroll-item="inline-detached padding-match-start">
-			<hgroup data-column="gap-4">
+	<main data-sticky-container data-column='gap-8'>
+		<header data-scroll-item='inline-detached padding-match-start'>
+			<hgroup data-column='gap-4'>
 				<h1>Wallet Security News</h1>
 				<p>Security incidents, vulnerabilities, and data breaches affecting Ethereum wallets</p>
 			</hgroup>
@@ -50,154 +40,137 @@ import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 
 		<hr />
 
-		{allWalletSecurityNews.map((news) => (
-			<>
-				<div data-scroll-item="inline-detached">
-					<article id={news.slug}>
-						<details
-							data-card="padding-6"
-							data-column="gap-6"
-						>
-							<summary data-row="wrap wrap-first-last">
-								{news.wallet && (
+		{
+			allWalletSecurityNews.map(news => (
+				<>
+					<div data-scroll-item='inline-detached'>
+						<article id={news.slug}>
+							<details data-card='padding-6' data-column='gap-6'>
+								<summary data-row='wrap wrap-first-last'>
+									{news.wallet && (
+										<div data-row-item='basis-full'>
+											<a
+												class='wallet-link'
+												href={`/${news.wallet.id}`}
+												data-link='camouflaged'
+												data-badge='medium'
+											>
+												<img
+													src={`/images/wallets/${news.wallet.id}.${news.wallet.iconExtension}`}
+													alt={news.wallet.displayName}
+												/>
+												<span>{news.wallet.displayName}</span>
+											</a>
+										</div>
+									)}
+
+									<h2 data-row-item='flexible basis-3'>{news.title}</h2>
+
 									<div
-										data-row-item="basis-full"
+										class='metadata-dates'
+										data-row-item='wrap-end flexible basis-3'
+										data-row='end wrap gap-1'
 									>
-										<a
-											class="wallet-link"
-											href={`/${news.wallet.id}`}
-											data-link="camouflaged"
-											data-badge="medium"
-										>
-											<img
-												src={`/images/wallets/${news.wallet.id}.${news.wallet.iconExtension}`}
-												alt={news.wallet.displayName}
-											/>
-											<span>{news.wallet.displayName}</span>
-										</a>
+										<time datetime={news.publishedAt}>{formatDate(news.publishedAt)}</time>
+
+										{news.publishedAt !== news.updatedAt && (
+											<small class='gap-1'>
+												<span>・</span>
+												<span>
+													Updated{' '}
+													<time datetime={news.updatedAt}>{formatDate(news.updatedAt)}</time>
+												</span>
+											</small>
+										)}
 									</div>
-								)}
+								</summary>
 
-								<h2 data-row-item="flexible basis-3">
-									{news.title}
-								</h2>
+								<div class='article-content' data-column='gap-5'>
+									<hr />
 
-								<div
-									class="metadata-dates"
-									data-row-item="wrap-end flexible basis-3"
-									data-row="end wrap gap-1"
-								>
-									<time datetime={news.publishedAt}>{formatDate(news.publishedAt)}</time>
+									<dl class='metadata' data-row='start wrap gap-6'>
+										<div data-column='gap-2'>
+											<dt>Type</dt>
+											<dd>
+												<span class='type-badge' data-badge='medium'>
+													{newsTypes[news.type].label}
+												</span>
+											</dd>
+										</div>
 
-									{news.publishedAt !== news.updatedAt && (
-										<small class="gap-1">
-											<span>・</span>
-											<span>Updated <time datetime={news.updatedAt}>{formatDate(news.updatedAt)}</time></span>
-										</small>
+										<div data-column='gap-2'>
+											<dt>Severity</dt>
+											<dd>
+												<span
+													class='severity-badge'
+													data-badge='medium'
+													style={`--severity-color: ${severities[news.severity].color}`}
+												>
+													{severities[news.severity].label}
+												</span>
+											</dd>
+										</div>
+
+										<div data-column='gap-2'>
+											<dt>Status</dt>
+											<dd>
+												<span
+													class='status-badge'
+													data-badge='medium'
+													style={`--status-color: ${incidentStatuses[news.status].color}`}
+												>
+													<span set:html={incidentStatuses[news.status].icon} />
+													{incidentStatuses[news.status].label}
+												</span>
+											</dd>
+										</div>
+									</dl>
+
+									<p>{news.summary}</p>
+
+									<div data-card='secondary padding-4 radius-4' data-column='gap-3'>
+										<h4>Impact</h4>
+										<ul>
+											<li>Funds: {news.impact.fundsImpacted ? 'Affected' : 'Not Affected'}</li>
+											<li>Category: {impactCategories[news.impact.category].label}</li>
+										</ul>
+									</div>
+
+									<hr />
+
+									{refs(news).length > 0 && (
+										<footer data-column='gap-3'>
+											<h4>Sources</h4>
+											<ul>
+												{refs(news).map(ref =>
+													ref.urls.map(url => (
+														<li>
+															<a href={url.url} target='_blank' rel='noopener noreferrer'>
+																{url.label}
+																<span set:html={ExternalLinkIcon} />
+															</a>
+														</li>
+													)),
+												)}
+											</ul>
+										</footer>
 									)}
 								</div>
-							</summary>
+							</details>
+						</article>
+					</div>
 
-							<div
-								class="article-content"
-								data-column="gap-5"
-							>
-								<hr>
+					<hr />
+				</>
+			))
+		}
 
-								<dl
-									class="metadata"
-									data-row="start wrap gap-6"
-								>
-									<div data-column="gap-2">
-										<dt>Type</dt>
-										<dd>
-											<span
-												class="type-badge"
-												data-badge="medium"
-											>
-												{newsTypes[news.type].label}
-											</span>
-										</dd>
-									</div>
-
-									<div data-column="gap-2">
-										<dt>Severity</dt>
-										<dd>
-											<span
-												class="severity-badge"
-												data-badge="medium"
-												style={`--severity-color: ${severities[news.severity].color}`}
-											>
-												{severities[news.severity].label}
-											</span>
-										</dd>
-									</div>
-
-									<div data-column="gap-2">
-										<dt>Status</dt>
-										<dd>
-											<span
-												class="status-badge"
-												data-badge="medium"
-												style={`--status-color: ${incidentStatuses[news.status].color}`}
-											>
-												<span set:html={incidentStatuses[news.status].icon} />
-												{incidentStatuses[news.status].label}
-											</span>
-										</dd>
-									</div>
-								</dl>
-
-								<p>{news.summary}</p>
-
-								<div
-									data-card="secondary padding-4 radius-4"
-									data-column="gap-3"
-								>
-									<h4>Impact</h4>
-									<ul>
-										<li>Funds: {news.impact.fundsImpacted ? 'Affected' : 'Not Affected'}</li>
-										<li>Category: {impactCategories[news.impact.category].label}</li>
-									</ul>
-								</div>
-
-								<hr>
-
-								{refs(news).length > 0 && (
-									<footer data-column="gap-3">
-										<h4>Sources</h4>
-										<ul>
-											{refs(news).map(ref =>
-												ref.urls.map(url => (
-													<li>
-														<a href={url.url} target="_blank" rel="noopener noreferrer">
-															{url.label}
-															<span set:html={ExternalLinkIcon} />
-														</a>
-													</li>
-												)),
-											)}
-										</ul>
-									</footer>
-								)}
-							</div>
-						</details>
-					</article>
-				</div>
-
-				<hr />
-			</>
-		))}
-
-		<section
-			data-scroll-item="inline-detached padding-match-end"
-			data-column="gap-5"
-		>
+		<section data-scroll-item='inline-detached padding-match-end' data-column='gap-5'>
 			<p>
 				Know about a security incident affecting a wallet? Please help by <a
-					href="https://github.com/walletbeat/walletbeat"
-					target="_blank"
-					rel="noopener noreferrer">contributing to our repository</a
+					href='https://github.com/walletbeat/walletbeat'
+					target='_blank'
+					rel='noopener noreferrer'>contributing to our repository</a
 				>!
 			</p>
 		</section>
@@ -219,7 +192,7 @@ import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 			color: var(--text-secondary);
 			opacity: 0.85;
 		}
-	}	
+	}
 
 	article {
 		.wallet-link {

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -28,6 +28,7 @@ import Layout from '@/layouts/Layout.astro'
 
 // Components
 import Navigation from '@/views/Navigation.astro'
+import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 ---
 
 
@@ -170,7 +171,8 @@ import Navigation from '@/views/Navigation.astro'
 												ref.urls.map(url => (
 													<li>
 														<a href={url.url} target="_blank" rel="noopener noreferrer">
-															{url.label} →
+															{url.label}
+															<span set:html={ExternalLinkIcon} />
 														</a>
 													</li>
 												)),

--- a/src/pages/wallet/[attrGroupId].astro
+++ b/src/pages/wallet/[attrGroupId].astro
@@ -24,7 +24,9 @@ const attrGroup = getAttributeGroupById(
 	representativeWalletForType(WalletType.SOFTWARE).overall,
 )
 
-if (!attrGroup) throw new Error('Invalid attribute group')
+if (!attrGroup) {
+	throw new Error('Invalid attribute group')
+}
 
 // Components
 import Layout from '@/layouts/Layout.astro'

--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -402,18 +402,17 @@ export interface MaintenanceEvaluations extends EvaluatedGroup<MaintenanceValues
 }
 
 /** Evaluated attributes for a single wallet. */
-export interface EvaluationTree
-	extends NonEmptyRecord<
-		string,
-		EvaluatedGroup<
-			| SecurityValues
-			| PrivacyValues
-			| SelfSovereigntyValues
-			| TransparencyValues
-			| EcosystemValues
-			| MaintenanceValues
-		>
-	> {
+export interface EvaluationTree extends NonEmptyRecord<
+	string,
+	EvaluatedGroup<
+		| SecurityValues
+		| PrivacyValues
+		| SelfSovereigntyValues
+		| TransparencyValues
+		| EcosystemValues
+		| MaintenanceValues
+	>
+> {
 	security: SecurityEvaluations
 	privacy: PrivacyEvaluations
 	selfSovereignty: SelfSovereigntyEvaluations

--- a/src/types/content/account-unruggability-details.ts
+++ b/src/types/content/account-unruggability-details.ts
@@ -3,8 +3,7 @@ import type { AccountUnruggabilityValue } from '@/schema/attributes/self-soverei
 
 import { component, type Content } from '../content'
 
-export interface AccountUnruggabilityDetailsProps
-	extends EvaluationData<AccountUnruggabilityValue> {}
+export interface AccountUnruggabilityDetailsProps extends EvaluationData<AccountUnruggabilityValue> {}
 
 export interface AccountUnruggabilityDetailsContent {
 	component: 'AccountUnruggabilityDetails'

--- a/src/types/content/news.ts
+++ b/src/types/content/news.ts
@@ -1,6 +1,5 @@
 import type { WithRef } from '@/schema/reference'
 import type { WalletMetadata } from '@/schema/wallet'
-
 import type { CalendarDate } from '../date'
 
 /**
@@ -17,6 +16,36 @@ export enum IncidentStatus {
 	DISPUTED = 'DISPUTED',
 }
 
+export const incidentStatuses = {
+	[IncidentStatus.RESOLVED]: {
+		label: 'Resolved',
+		icon: (await import('lucide-static/icons/shield-check.svg?raw')).default,
+		color: '#10b981',
+	},
+	[IncidentStatus.MITIGATED]: {
+		label: 'Mitigated',
+		icon: (await import('lucide-static/icons/shield-alert.svg?raw')).default,
+		color: '#f59e0b',
+	},
+	[IncidentStatus.ONGOING]: {
+		label: 'Ongoing',
+		icon: (await import('lucide-static/icons/triangle-alert.svg?raw')).default,
+		color: '#ef4444',
+	},
+	[IncidentStatus.DISPUTED]: {
+		label: 'Disputed',
+		icon: (await import('lucide-static/icons/info.svg?raw')).default,
+		color: '#6b7280',
+	},
+} as const satisfies Record<
+	IncidentStatus,
+	{
+		label: string
+		icon: string
+		color: string
+	}
+>
+
 /**
  * Category of security-related news event
  */
@@ -31,6 +60,26 @@ export enum NewsType {
 	INCIDENT = 'INCIDENT',
 }
 
+export const newsTypes = {
+	[NewsType.HACK]: {
+		label: 'Hack',
+	},
+	[NewsType.DATA_BREACH]: {
+		label: 'Data Breach',
+	},
+	[NewsType.VULNERABILITY]: {
+		label: 'Vulnerability',
+	},
+	[NewsType.INCIDENT]: {
+		label: 'Incident',
+	},
+} as const satisfies Record<
+	NewsType,
+	{
+		label: string
+	}
+>
+
 /**
  * Severity level of a security incident
  */
@@ -44,6 +93,31 @@ export enum Severity {
 	/** Low severity - minor impact or informational */
 	LOW = 'LOW',
 }
+
+export const severities = {
+	[Severity.CRITICAL]: {
+		label: 'Critical',
+		color: 'var(--color-critical)',
+	},
+	[Severity.HIGH]: {
+		label: 'High',
+		color: 'var(--color-high)',
+	},
+	[Severity.MEDIUM]: {
+		label: 'Medium',
+		color: 'var(--color-medium)',
+	},
+	[Severity.LOW]: {
+		label: 'Low',
+		color: 'var(--color-low)',
+	},
+} as const satisfies Record<
+	Severity,
+	{
+		label: string
+		color: string
+	}
+>
 
 /**
  * Category of impact from a security incident
@@ -65,10 +139,39 @@ export enum ImpactCategory {
 	OTHER = 'OTHER',
 }
 
+export const impactCategories = {
+	[ImpactCategory.SEED_PHRASE_LEAK]: {
+		label: 'Seed Phrase Leak',
+	},
+	[ImpactCategory.PRIVATE_KEY_LEAK]: {
+		label: 'Private Key Leak',
+	},
+	[ImpactCategory.SIGNING_BUG]: {
+		label: 'Signing Bug',
+	},
+	[ImpactCategory.SUPPLY_CHAIN]: {
+		label: 'Supply Chain',
+	},
+	[ImpactCategory.PRIVACY_LEAK]: {
+		label: 'Privacy Leak',
+	},
+	[ImpactCategory.PHISHING_RELATED]: {
+		label: 'Phishing Related',
+	},
+	[ImpactCategory.OTHER]: {
+		label: 'Other',
+	},
+} as const satisfies Record<
+	ImpactCategory,
+	{
+		label: string
+	}
+>
+
 /** Represents a security-related news item about a wallet */
 export type WalletSecurityNews = WithRef<{
-	/** Identifier name for the news item */
-	name: string
+	/** Identifier slug for the news item */
+	slug: string
 	/** Category of security event */
 	type: NewsType
 	/** Severity level of the incident */

--- a/src/types/content/news.ts
+++ b/src/types/content/news.ts
@@ -97,19 +97,19 @@ export enum Severity {
 export const severities = {
 	[Severity.CRITICAL]: {
 		label: 'Critical',
-		color: 'var(--color-critical)',
+		color: '#ef4444',
 	},
 	[Severity.HIGH]: {
 		label: 'High',
-		color: 'var(--color-high)',
+		color: '#f59e0b',
 	},
 	[Severity.MEDIUM]: {
 		label: 'Medium',
-		color: 'var(--color-medium)',
+		color: '#fbbf24',
 	},
 	[Severity.LOW]: {
 		label: 'Low',
-		color: 'var(--color-low)',
+		color: '#3b82f6',
 	},
 } as const satisfies Record<
 	Severity,

--- a/src/types/content/news.ts
+++ b/src/types/content/news.ts
@@ -1,5 +1,6 @@
 import type { WithRef } from '@/schema/reference'
 import type { WalletMetadata } from '@/schema/wallet'
+
 import type { CalendarDate } from '../date'
 
 /**

--- a/src/types/content/transaction-inclusion-details.ts
+++ b/src/types/content/transaction-inclusion-details.ts
@@ -7,8 +7,7 @@ import type { TransactionSubmissionL2Type } from '@/schema/features/self-soverei
 
 import { component, type Content } from '../content'
 
-export interface TransactionInclusionDetailsProps
-	extends EvaluationData<TransactionInclusionValue> {
+export interface TransactionInclusionDetailsProps extends EvaluationData<TransactionInclusionValue> {
 	supportsL1Broadcast: L1BroadcastSupport
 	supportAnyL2Transactions: TransactionSubmissionL2Type[]
 	supportForceWithdrawal: TransactionSubmissionL2Type[]

--- a/src/views/NavigationItems.svelte
+++ b/src/views/NavigationItems.svelte
@@ -194,14 +194,14 @@
 				<span class="icon">{@html item.icon}</span>
 			{/if}
 
-			<span>{@html effectiveSearchValue ? highlightText(item.title, effectiveSearchValue) : item.title}</span>
+			<span data-row-item="flexible">{@html effectiveSearchValue ? highlightText(item.title, effectiveSearchValue) : item.title}</span>
 		</a>
 	{:else}
 		{#if item.icon}
 			<span class="icon">{@html item.icon}</span>
 		{/if}
 
-		<span>{@html effectiveSearchValue ? highlightText(item.title, effectiveSearchValue) : item.title}</span>
+		<span data-row-item="flexible">{@html effectiveSearchValue ? highlightText(item.title, effectiveSearchValue) : item.title}</span>
 	{/if}
 {/snippet}
 


### PR DESCRIPTION
## Data

* News articles
  * reorganize news articles as individual files with a default export (naming convention: `${publishedAt}-${slug}.ts`)
  * colocate mapping constants associated with `enum`s

## Pages

* Wallet Security News
  * restructure Wallet Security News page to use `<details>`, layout attribute primitives,  external link icon

## Views

* Navigation
  * include "Wallet Security News" in all navigation menus
  * `<NavigationItems>`
    * use `[data-row-item="flexible"]` for labels

## Layout primitives

* `<details>`
  * enforce `gap` override
* `[data-badge]`
  * make colors configurable
* `[data-card]`
  * add more padding variants
* `[data-row-item]`
  * add more basis variants
