### PR TITLE
List layouts – stages, attribute rating details / methodology, reference links, security audits, scam alerts, Markdown

### DIFF
--- a/src/components/Typography.svelte
+++ b/src/components/Typography.svelte
@@ -39,33 +39,5 @@
 {:else if content.contentType === ContentType.MARKDOWN}
 	{@const text = strings ? renderStrings(content.markdown, strings) : content.markdown}
 
-	<div
-		class="markdown"
-		data-column="gap-5"
-		{...restProps}
-	>
-		{@html parseMarkdown(text)}
-	</div>
+	{@html parseMarkdown(text)}
 {/if}
-
-
-<style>
-	.markdown {
-		:global {
-			ul, ol {
-				list-style-type: revert;
-				padding-inline-start: 1.5em;
-
-				> * + * {
-					margin-top: 1em;
-				}
-			}
-
-			li {
-				> * + * {
-					margin-top: 1em;
-				}
-			}
-		}
-	}
-</style>

--- a/src/global.css
+++ b/src/global.css
@@ -772,19 +772,19 @@ summary {
 ul,
 ol {
 	/* Inputs */
-	--list-gap: 0.25lh;
-	--listItem-marker-inlineSize: 1.15em;
-	--listItem-markerGap: 0.66em;
+	--list-marker-inlineSize: 1.15em;
+	--list-markerGap: 0.66em;
+	--list-gap: 0.5lh;
 
 	/* Rules */
 	display: grid;
 	gap: var(--list-gap);
 	list-style-type: disc;
 	list-style-position: outside;
-	padding-inline-start: var(--listItem-marker-inlineSize);
+	padding-inline-start: var(--list-marker-inlineSize);
 
 	&[data-card] {
-		padding-inline-start: calc(var(--card-padding) + var(--listItem-marker-inlineSize));
+		padding-inline-start: calc(var(--card-padding) + var(--list-marker-inlineSize));
 	}
 
 	&[data-list~='gap-0'] {
@@ -802,25 +802,37 @@ ol {
 	&[data-list~='gap-4'] {
 		--list-gap: 1lh;
 	}
+	&[data-list~='gap-5'] {
+		--list-gap: 1.25lh;
+	}
+	&[data-list~='gap-6'] {
+		--list-gap: 1.5lh;
+	}
 
 	> li,
 	> [data-list-item] {
-		--listItem-gap: 1em;
+		--listItem-gap: 0.25lh;
 
 		&[data-list-item~='gap-0'] {
 			--listItem-gap: 0;
 		}
 		&[data-list-item~='gap-1'] {
-			--listItem-gap: 0.25em;
+			--listItem-gap: 0.25lh;
 		}
 		&[data-list-item~='gap-2'] {
-			--listItem-gap: 0.5em;
+			--listItem-gap: 0.5lh;
 		}
 		&[data-list-item~='gap-3'] {
-			--listItem-gap: 0.75em;
+			--listItem-gap: 0.75lh;
 		}
 		&[data-list-item~='gap-4'] {
-			--listItem-gap: 1em;
+			--listItem-gap: 1lh;
+		}
+		&[data-list-item~='gap-5'] {
+			--listItem-gap: 1.25lh;
+		}
+		&[data-list-item~='gap-6'] {
+			--listItem-gap: 1.5lh;
 		}
 
 		&::marker {
@@ -832,7 +844,7 @@ ol {
 			font-size: 0.875em;
 		}
 
-		padding-inline-start: var(--listItem-markerGap);
+		padding-inline-start: var(--list-markerGap);
 
 		> * + * {
 			margin-top: var(--listItem-gap);

--- a/src/global.css
+++ b/src/global.css
@@ -768,6 +768,78 @@ summary {
 	}
 }
 
+[data-list],
+ul,
+ol {
+	/* Inputs */
+	--list-gap: 0.25lh;
+	--listItem-marker-inlineSize: 1.15em;
+	--listItem-markerGap: 0.66em;
+
+	/* Rules */
+	display: grid;
+	gap: var(--list-gap);
+	list-style-type: disc;
+	list-style-position: outside;
+	padding-inline-start: var(--listItem-marker-inlineSize);
+
+	&[data-card] {
+		padding-inline-start: calc(var(--card-padding) + var(--listItem-marker-inlineSize));
+	}
+
+	&[data-list~='gap-0'] {
+		--list-gap: 0;
+	}
+	&[data-list~='gap-1'] {
+		--list-gap: 0.25lh;
+	}
+	&[data-list~='gap-2'] {
+		--list-gap: 0.5lh;
+	}
+	&[data-list~='gap-3'] {
+		--list-gap: 0.75lh;
+	}
+	&[data-list~='gap-4'] {
+		--list-gap: 1lh;
+	}
+
+	> li,
+	> [data-list-item] {
+		--listItem-gap: 1em;
+
+		&[data-list-item~='gap-0'] {
+			--listItem-gap: 0;
+		}
+		&[data-list-item~='gap-1'] {
+			--listItem-gap: 0.25em;
+		}
+		&[data-list-item~='gap-2'] {
+			--listItem-gap: 0.5em;
+		}
+		&[data-list-item~='gap-3'] {
+			--listItem-gap: 0.75em;
+		}
+		&[data-list-item~='gap-4'] {
+			--listItem-gap: 1em;
+		}
+
+		&::marker {
+			content: '●' ' ';
+			font-size: 1em;
+		}
+		&[data-list-item-marker]::marker {
+			content: attr(data-list-item-marker);
+			font-size: 0.875em;
+		}
+
+		padding-inline-start: var(--listItem-markerGap);
+
+		> * + * {
+			margin-top: var(--listItem-gap);
+		}
+	}
+}
+
 
 /**
  * Scroll Container

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -320,15 +320,9 @@ import HelpOutlineIcon from '@material-icons/svg/svg/help_outline/baseline.svg?r
 							</h2>
 						</header>
 
-						<div
-							data-column="gap-5"
-							data-scroll-item='inline-detached'
-						>
+						<div data-column='gap-5' data-scroll-item='inline-detached'>
 							{/* @ts-expect-error - Astro type checking doesn't fully support Svelte 5 generics yet */}
-							<Typography
-								client:load
-								content={entry.answer}
-							/>
+							<Typography client:load content={entry.answer} />
 						</div>
 					</section>
 				</>

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -320,8 +320,16 @@ import HelpOutlineIcon from '@material-icons/svg/svg/help_outline/baseline.svg?r
 							</h2>
 						</header>
 
-						{/* @ts-expect-error - Astro type checking doesn't fully support Svelte 5 generics yet */}
-						<Typography client:load content={entry.answer} data-scroll-item='inline-detached' />
+						<div
+							data-column="gap-5"
+							data-scroll-item='inline-detached'
+						>
+							{/* @ts-expect-error - Astro type checking doesn't fully support Svelte 5 generics yet */}
+							<Typography
+								client:load
+								content={entry.answer}
+							/>
+						</div>
 					</section>
 				</>
 			))

--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -402,18 +402,17 @@ export interface MaintenanceEvaluations extends EvaluatedGroup<MaintenanceValues
 }
 
 /** Evaluated attributes for a single wallet. */
-export interface EvaluationTree
-	extends NonEmptyRecord<
-		string,
-		EvaluatedGroup<
-			| SecurityValues
-			| PrivacyValues
-			| SelfSovereigntyValues
-			| TransparencyValues
-			| EcosystemValues
-			| MaintenanceValues
-		>
-	> {
+export interface EvaluationTree extends NonEmptyRecord<
+	string,
+	EvaluatedGroup<
+		| SecurityValues
+		| PrivacyValues
+		| SelfSovereigntyValues
+		| TransparencyValues
+		| EcosystemValues
+		| MaintenanceValues
+	>
+> {
 	security: SecurityEvaluations
 	privacy: PrivacyEvaluations
 	selfSovereignty: SelfSovereigntyEvaluations

--- a/src/schema/stages.ts
+++ b/src/schema/stages.ts
@@ -44,6 +44,36 @@ export enum StageCriterionRating {
 	UNRATED = 'UNRATED',
 }
 
+export const stageCriterionRatings = {
+	[StageCriterionRating.PASS]: {
+		icon: '✅',
+		label: 'Criterion passed',
+		color: 'var(--rating-pass)',
+	},
+	[StageCriterionRating.FAIL]: {
+		icon: '❌',
+		label: 'Criterion failed',
+		color: 'var(--rating-fail)',
+	},
+	[StageCriterionRating.EXEMPT]: {
+		icon: '➖',
+		label: 'Criterion exempt',
+		color: 'var(--rating-exempt)',
+	},
+	[StageCriterionRating.UNRATED]: {
+		icon: '❔',
+		label: 'Criterion unrated',
+		color: 'var(--rating-unrated)',
+	},
+} as const satisfies Record<
+	StageCriterionRating,
+	{
+		icon: string
+		label: string
+		color: string
+	}
+>
+
 /**
  * The result of evaluating one specific stage criterion for one specific
  * wallet.

--- a/src/types/content/account-unruggability-details.ts
+++ b/src/types/content/account-unruggability-details.ts
@@ -3,8 +3,7 @@ import type { AccountUnruggabilityValue } from '@/schema/attributes/self-soverei
 
 import { component, type Content } from '../content'
 
-export interface AccountUnruggabilityDetailsProps
-	extends EvaluationData<AccountUnruggabilityValue> {}
+export interface AccountUnruggabilityDetailsProps extends EvaluationData<AccountUnruggabilityValue> {}
 
 export interface AccountUnruggabilityDetailsContent {
 	component: 'AccountUnruggabilityDetails'

--- a/src/types/content/transaction-inclusion-details.ts
+++ b/src/types/content/transaction-inclusion-details.ts
@@ -7,8 +7,7 @@ import type { TransactionSubmissionL2Type } from '@/schema/features/self-soverei
 
 import { component, type Content } from '../content'
 
-export interface TransactionInclusionDetailsProps
-	extends EvaluationData<TransactionInclusionValue> {
+export interface TransactionInclusionDetailsProps extends EvaluationData<TransactionInclusionValue> {
 	supportsL1Broadcast: L1BroadcastSupport
 	supportAnyL2Transactions: TransactionSubmissionL2Type[]
 	supportForceWithdrawal: TransactionSubmissionL2Type[]

--- a/src/views/ReferenceLinks.svelte
+++ b/src/views/ReferenceLinks.svelte
@@ -6,90 +6,99 @@
 	// Props
 	const {
 		references,
+		cardBackground = 'primary',
 	}: {
 		references: FullyQualifiedReference[]
+		cardBackground?: 'primary' | 'secondary'
 	} = $props()
+
+
+	// Components
+	import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 </script>
 
 
 {#if references.length > 0}
-	<!-- {@const totalUrls = references.reduce((count: number, ref: FullyQualifiedReference) => count + ref.urls.length, 0)} -->
+	{@const totalUrls = references.flatMap(ref => ref.urls).length}
 
-	<div>
-		<!-- <h5>{totalUrls > 1 ? 'Sources' : 'Source'}</h5> -->
+	<section
+		class="references"
+		data-card={cardBackground}
+	>
+		<h5>
+			{totalUrls > 1 ? 'Sources' : 'Source'}
+			{#if totalUrls > 1}
+				({totalUrls})
+			{/if}
+		</h5>
 
-		<ul class="references">
+		<ul class="references-list" data-list="gap-2">
 			{#each references as ref, index (index + '::' + ref.urls.map(url => url.url).toSorted().join('|'))}
-				<li data-card="secondary padding-3">
+				{#snippet Url({ url, label }: { url: string, label: string })}
+					<a
+						href={url}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<cite>{label}</cite>
+						<span>{@html ExternalLinkIcon}</span>
+					</a>
+				{/snippet}
+
+				<li data-list-item="gap-2">
 					{#if ref.explanation}
-						<p>{ref.explanation}</p>
+
+						<p class="explanation">
+							{#if ref.urls.length === 1}
+								{@render Url(ref.urls[0])}
+								<br>
+							{/if}
+							{ref.explanation}
+						</p>
 					{/if}
 
-					<div class="urls">
-						<ul data-row="start gap-2">
+					{#if ref.urls.length === 1}
+						{#if !ref.explanation}
+							{@render Url(ref.urls[0])}
+						{/if}
+					{:else}
+						<ul data-list="gap-1">
 							{#each ref.urls as url (url.url)}
-								<li data-card="padding-3">
-									<a
-										href={url.url}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<cite>{url.label}</cite>
-									</a>
+								<li>
+									{@render Url(url)}
 								</li>
 							{/each}
 						</ul>
+					{/if}
 
-						{#if ref.lastRetrieved}
-							as of
-							<time datetime={ref.lastRetrieved}>{ref.lastRetrieved}</time>
-						{/if}
-					</div>
+					{#if ref.lastRetrieved}
+						<small class="last-retrieved">
+							Last retrieved <time datetime={ref.lastRetrieved}>{ref.lastRetrieved}</time>
+						</small>
+					{/if}
 				</li>
 			{/each}
 		</ul>
-	</div>
+	</section>
 {/if}
 
 
 <style>
-	hr {
-		border: none;
-		border-top: 1px solid var(--border);
+	.references {
+		font-size: 0.875em;
+		line-height: 1.7;
 	}
 
-	small {
-		color: var(--text-secondary);
-		line-height: 1.4;
-	}
-
-	ul.references {
-		font-size: smaller;
-		list-style: none;
-
-		> * + * {
-			margin-top: 1em;
-		}
-
-		> li {
-			padding-left: 2em;
-
-			> * + * {
-				margin-top: 1em;
-			}
-
-			ul {
-				list-style: none;
-				padding: 0;
-			}
-		}
+	h5 {
+		font-size: 1em;
 	}
 
 	cite {
 		font-style: normal;
 	}
 
-	p {
-		margin-top: 0.5em;
+	.last-retrieved {
+		color: var(--text-secondary);
+		font-size: 0.875em;
 	}
 </style>

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -786,18 +786,14 @@
 				</header>
 			</summary>
 
-			<div
-				class="rating-display"
+			<ul
+				class="attribute-rating-details"
 				data-rating={evalAttr.evaluation.value.rating.toLowerCase()}
-				data-card
-				data-row="align-start"
+				data-card="padding-5"
 			>
-				<div class="rating-icon" data-row="center">
-					{ratingIcons[evalAttr.evaluation.value.rating as Rating]}
-				</div>
-				<div
-					class="rating-content"
-					data-row-item="flexible"
+				<li
+					data-list-item="gap-3"
+					data-list-item-marker={ratingIcons[evalAttr.evaluation.value.rating as Rating]}
 				>
 					{#if isTypographicContent(evalAttr.evaluation.details)}
 						<Typography
@@ -841,8 +837,8 @@
 							/>
 						</div>
 					{/if}
-				</div>
-			</div>
+				</li>
+			</ul>
 
 			{#if variantSpecificCaption}
 				<div class="variant-caption">
@@ -1746,24 +1742,19 @@
 				color: var(--text-secondary);
 			}
 
-			.rating-display {
-				font-weight: 500;
+			.attribute-rating-details {
+				&:is(ul) {
+					--list-markerGap: 1em;
+				}
+
 				background-color: color-mix(in srgb, var(--accent) 5%, var(--background-secondary));
 				box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 
+				color: var(--text-secondary);
+				font-weight: 500;
+
 				&[data-rating='exempt'] {
 					opacity: 0.7;
-				}
-
-				.rating-icon {
-					width: 1.5rem;
-					height: 1.5rem;
-					font-size: 1.2rem;
-					color: var(--accent);
-				}
-
-				.rating-content > div {
-					color: var(--text-secondary);
 				}
 			}
 

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -1761,8 +1761,6 @@
 
 			.impact {
 				color: var(--text-secondary);
-				font-style: italic;
-				opacity: 0.7;
 			}
 		}
 	}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -809,25 +809,25 @@
 						{@const componentName = evalAttr.evaluation.details.component.component}
 						{@const componentProps = evalAttr.evaluation.details.component.componentProps}
 						{@const value = evalAttr.evaluation.value}
-						{@const references = toFullyQualified(evalAttr.evaluation.references || [])}
+						{@const references = evalAttr.evaluation.references && toFullyQualified(evalAttr.evaluation.references)}
 
 						<div data-column>
 							{#if componentName === 'AddressCorrelationDetails'}
-								<AddressCorrelationDetails {...componentProps} {wallet} {value} {references} />
+								<AddressCorrelationDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'ChainVerificationDetails'}
-								<ChainVerificationDetails {...componentProps} {wallet} {value} {references} />
+								<ChainVerificationDetails {...componentProps} {wallet} {value} refs={references} />
 							{:else if componentName === 'ScamAlertDetails'}
-								<ScamAlertDetails {...componentProps} {wallet} {value} {references} />
+								<ScamAlertDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'SecurityAuditsDetails'}
-								<SecurityAuditsDetails {...componentProps} {wallet} {value} {references} />
+								<SecurityAuditsDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'TransactionInclusionDetails'}
-								<TransactionInclusionDetails {...componentProps} {wallet} {value} {references} />
+								<TransactionInclusionDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'FundingDetails'}
-								<FundingDetails {...componentProps} {wallet} {value} {references} />
+								<FundingDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'AccountRecoveryDetails'}
-								<AccountRecoveryDetails {...componentProps} {wallet} {value} {references} />
+								<AccountRecoveryDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'UnratedAttribute'}
-								<UnratedAttribute {...componentProps} {wallet} {value} {references} />
+								<UnratedAttribute {...componentProps} {wallet} {value} />
 							{/if}
 						</div>
 
@@ -862,7 +862,25 @@
 				</div>
 			{/if}
 
-			<ReferenceLinks references={toFullyQualified(evalAttr.evaluation.references || [])} />
+			{#if (
+				!isTypographicContent(evalAttr.evaluation.details)
+				&& evalAttr.evaluation.references?.length
+				&& !(
+					// Custom components that render their own reference links
+					[
+						'ChainVerificationDetails',
+						'FundingDetails',
+						'ScamAlertDetails',
+						'SecurityAuditsDetails',
+					]
+						.includes(evalAttr.evaluation.details.component.component)
+				)
+			)}
+				<ReferenceLinks
+					references={toFullyQualified(evalAttr.evaluation.references)}
+					cardBackground="secondary"
+				/>
+			{/if}
 
 			{#if attribute.id === 'hardwareWalletSupport' && evalAttr.evaluation.value && typeof evalAttr.evaluation.value === 'object' && 'supportedHardwareWallets' in evalAttr.evaluation.value && Array.isArray(evalAttr.evaluation.value.supportedHardwareWallets) && evalAttr.evaluation.value.supportedHardwareWallets.length > 0}
 				{@const supportedBrands = evalAttr.evaluation.value.supportedHardwareWallets}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -6,6 +6,7 @@
 		type AttributeGroup,
 		type EvaluatedAttribute,
 		type EvaluatedGroup,
+		type ExampleRating,
 		Rating,
 		ratingIcons,
 		ratingToColor,
@@ -930,7 +931,7 @@
 					</summary>
 
 					<section
-						class="methodology"
+						class="attribute-rating-methodology"
 						data-column="gap-6"
 					>
 						{#if attribute.methodology}
@@ -940,80 +941,73 @@
 						{/if}
 
 						{#if attribute.ratingScale}
-							<hr />
-
 							{#if attribute.ratingScale.display === 'simple'}
-								<div class="simple-scale" data-card="radius-4">
-									<Typography content={attribute.ratingScale.content} />
-								</div>
+								<aside
+									data-card="radius-4"
+								>
+									<Typography
+										content={attribute.ratingScale.content}
+									/>
+								</aside>
 							{:else}
-								<div class="example-scale" data-card="radius-4">
+								<aside
+									data-card="radius-4"
+									data-column="gap-5"
+								>
 									{#if attribute.ratingScale.exhaustive}
 										<h5>A few examples:</h5>
 									{/if}
 
-									<ul data-column>
-										{#if attribute.ratingScale.pass}
-											<li data-icon={ratingIcons[Rating.PASS]}>
-												<Typography
-													content={{
-														contentType: ContentType.MARKDOWN,
-														markdown: [
-															'A wallet would get a **passing** rating if...',
-															[attribute.ratingScale.pass]
-																.flat()
-																.map(
-																	example =>
-																		`* ${(example.description.contentType === ContentType.MARKDOWN ? example.description.markdown : example.description.text).trim()}`,
-																)
-																.join('\n'),
-														].join('\n\n'),
-													}}
-												/>
-											</li>
-										{/if}
+									<ul data-list="gap-4">
+										{#each (
+											[
+												{
+													rating: Rating.PASS,
+													label: 'passing',
+													exampleRatings: attribute.ratingScale.pass,
+												},
+												{
+													rating: Rating.PARTIAL,
+													label: 'partial',
+													exampleRatings: attribute.ratingScale.partial,
+												},
+												{
+													rating: Rating.FAIL,
+													label: 'failing',
+													exampleRatings: attribute.ratingScale.fail,
+												},
+											]
+												.filter(({ exampleRatings }) => !!exampleRatings)
+												.map(({ rating, label, exampleRatings }) => ({
+													rating,
+													label,
+													exampleRatings: [exampleRatings].flat() as ExampleRating<any>[],
+												}))
+												.filter(({ exampleRatings }) => exampleRatings.length > 0)
+										) as { rating, label, exampleRatings }}
+											<li
+												data-list-item="gap-3"
+												data-list-item-marker={ratingIcons[rating]}
+											>
+												<p>A wallet would get a <strong>{label}</strong> rating if...</p>
 
-										{#if attribute.ratingScale.partial}
-											<li data-icon={ratingIcons[Rating.PARTIAL]}>
-												<Typography
-													content={{
-														contentType: ContentType.MARKDOWN,
-														markdown: [
-															'A wallet would get a **partial** rating if...',
-															[attribute.ratingScale.partial]
-																.flat()
-																.map(
-																	example =>
-																		`* ${(example.description.contentType === ContentType.MARKDOWN ? example.description.markdown : example.description.text).trim()}`,
-																)
-																.join('\n'),
-														].join('\n\n'),
-													}}
-												/>
+												<ul>
+													{#each exampleRatings as exampleRating}
+														<li>
+															{#if exampleRating.description.contentType === ContentType.MARKDOWN}
+																<Typography
+																	content={exampleRating.description}
+																/>
+															{:else}
+																{exampleRating.description.text}
+															{/if}
+														</li>
+													{/each}
+												</ul>
 											</li>
-										{/if}
-
-										{#if attribute.ratingScale.fail}
-											<li data-icon={ratingIcons[Rating.FAIL]}>
-												<Typography
-													content={{
-														contentType: ContentType.MARKDOWN,
-														markdown: [
-															'A wallet would get a **failing** rating if...',
-															[attribute.ratingScale.fail]
-																.flat()
-																.map(
-																	example =>
-																		`* ${(example.description.contentType === ContentType.MARKDOWN ? example.description.markdown : example.description.text).trim()}`,
-																)
-																.join('\n'),
-														].join('\n\n'),
-													}}
-												/>
-											</li>
-										{/if}
+										{/each}
 									</ul>
-								</div>
+								</aside>
 							{/if}
 						{/if}
 					</section>
@@ -1800,22 +1794,10 @@
 		opacity: 0.7;
 	}
 
-	.methodology {
+	.attribute-rating-methodology {
 		h5 {
 			font-size: 1rem;
 			font-weight: 600;
-		}
-
-		ul {
-			padding-inline-start: 1rem;
-
-			> li {
-				padding-inline-start: 0.5rem;
-
-				&::marker {
-					content: attr(data-icon);
-				}
-			}
 		}
 	}
 

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -851,7 +851,10 @@
 			{/if}
 
 			{#if evalAttr.evaluation.impact}
-				<div class="impact">
+				<div
+					class="impact"
+					data-column="gap-6"
+				>
 					<Typography
 						content={evalAttr.evaluation.impact}
 						strings={{ WALLET_NAME: wallet.metadata.displayName }}
@@ -894,7 +897,7 @@
 						</h4>
 					</summary>
 
-					<section>
+					<section data-column="gap-6">
 						{#if attribute.why}
 							<Typography
 								content={attribute.why}
@@ -912,7 +915,10 @@
 						</h4>
 					</summary>
 
-					<section class="methodology" data-column="gap-6">
+					<section
+						class="methodology"
+						data-column="gap-6"
+					>
 						{#if attribute.methodology}
 							<Typography content={attribute.methodology} />
 						{:else}

--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -1,20 +1,81 @@
 <script lang="ts">
 	// Types/constants
-	import { isTypographicContent } from '@/types/content'
 	import type { RatedWallet } from '@/schema/wallet'
 	import { WalletLadderType, ladders } from '@/schema/ladders'
 	import { StageCriterionRating, type WalletLadderEvaluation, type WalletStage } from '@/schema/stages'
 	import { stageToColor } from '@/utils/colors'
-	import { getCriterionAttributeId } from '@/utils/stage-attributes'
-	import { slugifyCamelCase } from '@/types/utils/text'
-	import { attributeTree } from '@/schema/attribute-groups'
+	import { getCriterionAttributeId, attributesById } from '@/utils/stage-attributes'
+
+	/** Aggregate statuses for stages and stage groups */
+	enum StageStatus {
+		PASS = 'PASS',
+		PARTIAL = 'PARTIAL',
+		FAIL = 'FAIL',
+		UNRATED = 'UNRATED',
+	}
+
+	const stageStatuses = {
+		[StageStatus.PASS]: {
+			icon: '✅',
+			label: 'All criteria passed',
+			color: 'var(--rating-pass)',
+		},
+		[StageStatus.PARTIAL]: {
+			icon: '🟡',
+			label: 'Some criteria passed',
+			color: 'var(--rating-partial)',
+		},
+		[StageStatus.FAIL]: {
+			icon: '❌',
+			label: 'All criteria failed',
+			color: 'var(--rating-fail)',
+		},
+		[StageStatus.UNRATED]: {
+			icon: '❔',
+			label: 'All criteria unrated',
+			color: 'var(--rating-unrated)',
+		},
+	} as const satisfies Record<
+		StageStatus,
+		{
+			icon: string
+			label: string
+			color: string
+		}
+	>
+
+	const stageCriterionRatings = {
+		[StageCriterionRating.PASS]: {
+			icon: '✅',
+			label: 'Criterion passed',
+			color: 'var(--rating-pass)',
+		},
+		[StageCriterionRating.FAIL]: {
+			icon: '❌',
+			label: 'Criterion failed',
+			color: 'var(--rating-fail)',
+		},
+		[StageCriterionRating.EXEMPT]: {
+			icon: '⚠️',
+			label: 'Criterion exempt',
+			color: 'var(--rating-exempt)',
+		},
+		[StageCriterionRating.UNRATED]: {
+			icon: '❔',
+			label: 'Criterion unrated',
+			color: 'var(--rating-unrated)',
+		},
+	} as const satisfies Record<
+		StageCriterionRating,
+		{
+			icon: string
+			label: string
+			color: string
+		}
+	>
 
 
-	// Components
-	import Typography from '@/components/Typography.svelte'
-	
-
-// Props
+	// Props
 	const {
 		wallet,
 		stage,
@@ -27,55 +88,48 @@
 
 
 	// Derived
-	let ladderType = $derived.by(() => {
-		if (!ladderEvaluation) {
-			return null
-		}
+	let ladderType = $derived(
+		!ladderEvaluation ?
+			null
+		:
+			Object.entries(wallet.ladders)
+				.find(([, evaluation]) => evaluation === ladderEvaluation)
+				?.[0] as WalletLadderType
+			?? null
+	)
 
-		for (const [type, evaluation] of Object.entries(wallet.ladders)) {
-			if (evaluation === ladderEvaluation) {
-				return type as WalletLadderType
-			}
-		}
+	let ladderDefinition = $derived(
+		ladderType ? ladders[ladderType] : null
+	)
 
-		return null
-	})
-	let ladderDefinition = $derived.by(() => {
-		if (!ladderType) {
-			return null
-		}
+	let currentStageIndex = $derived(
+		(!stage || typeof stage === 'string' || !ladderDefinition) ?
+			null
+		:
+			ladderDefinition.stages.findIndex(s => s.id === stage.id)
+	)
 
-		return ladders[ladderType]
-	})
-	let stageEvaluatableWallet = $derived(wallet)
-	let currentStageIndex = $derived.by(() => {
-		if (!stage || typeof stage === 'string' || !ladderDefinition) {
-			return null
-		}
+	let defaultOpenStageIndex = $derived(
+		!ladderDefinition ?
+			null
+		: currentStageIndex === null ?
+			ladderDefinition.stages.length - 1
+		:
+			(currentStageIndex + 1 < ladderDefinition.stages.length ? currentStageIndex + 1 : ladderDefinition.stages.length - 1)
+	)
 
-		return ladderDefinition.stages.findIndex(s => s.id === stage.id)
-	})
-	const defaultOpenStageIndex = $derived.by(() => {
-		if (currentStageIndex === null || !ladderDefinition) {
-			return ladderDefinition ? ladderDefinition.stages.length - 1 : null
-		}
 
-		const nextIndex = currentStageIndex + 1
+	// Functions
+	import { isTypographicContent } from '@/types/content'
+	import { slugifyCamelCase } from '@/types/utils/text'
 
-		return nextIndex < ladderDefinition.stages.length ? nextIndex : ladderDefinition.stages.length - 1
-	})
-	const stagesToShow = $derived.by(() => {
-		if (!ladderDefinition) {
-			return []
-		}
 
-		return ladderDefinition.stages
-	})
-
+	// Components
+	import Typography from '@/components/Typography.svelte'
 </script>
 
 
-{#if ladderEvaluation !== null}
+{#if ladderEvaluation && ladderDefinition}
 	<div
 		data-column
 		style:--accent={
@@ -86,12 +140,12 @@
 		}
 	>
 		<div data-column="gap-4">
-			{#each stagesToShow as s, index}
+			{#each ladderDefinition.stages as s, index}
 				{@const stageIndex = index}
 				{@const isCurrent = stage && typeof stage !== 'string' && stage.id === s.id}
 				{@const allCriteria = s.criteriaGroups.flatMap(group => group.criteria)}
 				{@const passedCriteria = allCriteria.filter(criterion => {
-					const evaluation = criterion.evaluate(stageEvaluatableWallet)
+					const evaluation = criterion.evaluate(wallet)
 
 					return evaluation.rating === StageCriterionRating.PASS
 				})}
@@ -99,6 +153,14 @@
 				{@const totalCount = allCriteria.length}
 				{@const allPassed = passedCount === totalCount}
 				{@const isDefaultOpen = defaultOpenStageIndex === stageIndex}
+				{@const stageRating = (
+					allPassed ?
+						StageStatus.PASS
+					: passedCount > 0 ?
+						StageStatus.PARTIAL
+					:
+						StageStatus.FAIL
+				)}
 
 				<details
 					id={`stage-${stageIndex}`}
@@ -125,38 +187,53 @@
 								</data>
 							</a>
 
-							<span data-row-item="flexible basis-3">
-								<strong>
-									{#if isTypographicContent(s.description)}
-										<Typography content={s.description} />
-									{:else}
-										{s.id}
-									{/if}
-								</strong>
-							</span>
+							<h3 data-row-item="flexible basis-3">
+								{#if isTypographicContent(s.description)}
+									<Typography content={s.description} />
+								{:else}
+									{s.id}
+								{/if}
+							</h3>
 
 							<div
 								data-row-item="wrap-end"
 								data-row="gap-2"
 							>
-								<span>{passedCount}/{totalCount}</span>
-								<span>{allPassed ? '✅' : passedCount > 0 ? '⚠️' : '❌'}</span>
+							<span>{passedCount}/{totalCount}</span>
+							<data value={stageRating} title={stageStatuses[stageRating].label}>
+								{stageStatuses[stageRating].icon}
+							</data>
 							</div>
 						</div>
 					</summary>
 
-					<div data-column="gap-6" style:--stage-background={isCurrent ? 'color-mix(in srgb, var(--accent) 5%, var(--background-primary))' : 'color-mix(in srgb, var(--accent) 3%, var(--background-primary))'}>
+					<div
+						data-column="gap-6"
+						style:--stage-background={isCurrent ? 'color-mix(in srgb, var(--accent) 5%, var(--background-primary))' : 'color-mix(in srgb, var(--accent) 3%, var(--background-primary))'}
+					>
 						{#if s.criteriaGroups}
 							<div data-column>
 								{#each s.criteriaGroups as criteriaGroup}
-									{@const groupEvaluations = ladderDefinition ? criteriaGroup.criteria.map(c => c.evaluate(stageEvaluatableWallet)) : []}
+									{@const groupEvaluations = ladderDefinition ? criteriaGroup.criteria.map(c => c.evaluate(wallet)) : []}
 									{@const groupPassedCount = groupEvaluations.filter(e => e?.rating === StageCriterionRating.PASS).length}
 									{@const groupTotalCount = groupEvaluations.length}
-									{@const groupAllPassed = groupTotalCount > 0 && groupPassedCount === groupTotalCount}
+									{@const groupRating = (
+										(groupTotalCount > 0 && groupEvaluations.every(e => e?.rating === StageCriterionRating.UNRATED)) ?
+											StageStatus.UNRATED
+										: groupPassedCount === groupTotalCount ?
+											StageStatus.PASS
+										: groupPassedCount > 0 ?
+											StageStatus.PARTIAL
+										:
+											StageStatus.FAIL
+									)}
 
-									<details data-card="padding-5 secondary radius-4">
+									<details
+										data-card="padding-5 secondary radius-4"
+										style:--accent={stageStatuses[groupRating].color}
+									>
 										<summary>
-											<div data-row="gap-2 wrap">
+											<div data-row="wrap">
 												<h4 data-row-item="flexible basis-2">
 													{#if isTypographicContent(criteriaGroup.description)}
 														<Typography content={criteriaGroup.description} />
@@ -169,71 +246,68 @@
 													data-row="gap-2"
 												>
 													<span>{groupPassedCount}/{groupTotalCount}</span>
-													<span>{groupPassedCount === groupTotalCount ? '✅' : groupPassedCount > 0 ? '⚠️' : '❌'}</span>
+													<data
+														value={groupRating}
+														title={stageStatuses[groupRating].label}
+													>
+														{stageStatuses[groupRating].icon}
+													</data>
 												</div>
 											</div>
 										</summary>
 
 										{#if criteriaGroup.criteria}
 											<div>
-												<ul data-card="padding-4">
+												<ul
+													data-card="padding-4"
+													data-list="gap-3"
+												>
 													{#each criteriaGroup.criteria as criterion}
-														{@const criterionEvaluation = ladderDefinition ? criterion.evaluate(stageEvaluatableWallet) : null}
-														{@const ratingIcon = criterionEvaluation?.rating === StageCriterionRating.PASS ? '✅' :
-															criterionEvaluation?.rating === StageCriterionRating.FAIL ? '❌' :
-															criterionEvaluation?.rating === StageCriterionRating.EXEMPT ? '⚠️' :
-															'❓'
-														}
-														{@const ratingColor = criterionEvaluation?.rating === StageCriterionRating.PASS ? 'var(--rating-pass)' :
-															criterionEvaluation?.rating === StageCriterionRating.FAIL ? 'var(--rating-fail)' :
-															criterionEvaluation?.rating === StageCriterionRating.EXEMPT ? 'var(--rating-exempt)' :
-															'var(--rating-unrated)'
-														}
+														{@const criterionEvaluation = ladderDefinition ? criterion.evaluate(wallet) : null}
+														{@const criterionRating = criterionEvaluation?.rating}
 														{@const attributeId = getCriterionAttributeId(criterion)}
 														{@const attributeLink = attributeId ? `/${wallet.metadata.id}/#${slugifyCamelCase(attributeId)}` : null}
-														{@const attribute = attributeId ? (() => {
-															for (const attrGroup of Object.values(attributeTree)) {
-																for (const attr of Object.values(attrGroup.attributes)) {
-																	if (attr.id === attributeId) {
-																		return attr
-																	}
-																}
-															}
-
-															return null
-														})() : null}
+														{@const attribute = attributeId ? attributesById.get(attributeId) ?? null : null}
 														{@const attributeName = attribute?.displayName ?? attributeId}
 														{@const attributeTitle = attribute?.displayName ?? attributeId}
 
-														<li data-row="gap-2 start">
-															<span style="color: {ratingColor}">{ratingIcon}</span>
-															<span data-row-item="flexible">
-																{#if attribute}
-																	<span>{@html attribute.icon}</span>
-																{/if}
-																{#if attributeName}
-																	{#if attributeLink}
-																		<a href={attributeLink} title={attributeTitle}>
+														<li
+															data-list-item-marker={attribute?.icon}
+															style:--accent={stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED) as StageCriterionRating].color}
+														>
+															<span data-row>
+																<span data-row-item="flexible">
+																	{#if attributeName}
+																		{#if attributeLink}
+																			<a href={attributeLink} title={attributeTitle}>
+																				<strong>{attributeName}</strong>
+																			</a>
+																		{:else}
 																			<strong>{attributeName}</strong>
-																		</a>
+																		{/if}
+																		<span>
+																			—
+																			{#if isTypographicContent(criterion.description)}
+																				<Typography content={criterion.description} />
+																			{:else}
+																				{criterion.id}
+																			{/if}
+																		</span>
 																	{:else}
-																		<strong>{attributeName}</strong>
-																	{/if}
-																	<span>
-																		—
 																		{#if isTypographicContent(criterion.description)}
 																			<Typography content={criterion.description} />
 																		{:else}
 																			{criterion.id}
 																		{/if}
-																	</span>
-																{:else}
-																	{#if isTypographicContent(criterion.description)}
-																		<Typography content={criterion.description} />
-																	{:else}
-																		{criterion.id}
 																	{/if}
-																{/if}
+																</span>
+
+																<data
+																	value={criterionRating}
+																	title={stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED) as StageCriterionRating].label}
+																>
+																	{stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED) as StageCriterionRating].icon}
+																</data>
 															</span>
 														</li>
 													{/each}
@@ -253,18 +327,17 @@
 
 
 <style>
-	div:has(> div > details) {
-		line-height: 1.6;
-	}
-
 	details {
 		&[data-card] {
 			--card-backgroundColor: var(--stage-background, var(--background-primary));
 		}
 	}
 
+	h3 {
+		font-size: 1.1em;
+	}
+
 	h4 {
 		font-weight: normal;
 	}
 </style>
-

--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -56,7 +56,7 @@
 			color: 'var(--rating-fail)',
 		},
 		[StageCriterionRating.EXEMPT]: {
-			icon: '⚠️',
+			icon: '➖',
 			label: 'Criterion exempt',
 			color: 'var(--rating-exempt)',
 		},
@@ -144,17 +144,18 @@
 				{@const stageIndex = index}
 				{@const isCurrent = stage && typeof stage !== 'string' && stage.id === s.id}
 				{@const allCriteria = s.criteriaGroups.flatMap(group => group.criteria)}
-				{@const passedCriteria = allCriteria.filter(criterion => {
-					const evaluation = criterion.evaluate(wallet)
-
-					return evaluation.rating === StageCriterionRating.PASS
-				})}
-				{@const passedCount = passedCriteria.length}
-				{@const totalCount = allCriteria.length}
-				{@const allPassed = passedCount === totalCount}
+				{@const allEvaluations = allCriteria.map(criterion => criterion.evaluate(wallet))}
+				{@const applicableEvaluations = allEvaluations.filter(e => e.rating !== StageCriterionRating.EXEMPT)}
+				{@const passedCount = applicableEvaluations.filter(e => e.rating === StageCriterionRating.PASS).length}
+				{@const exemptCount = allEvaluations.filter(e => e.rating === StageCriterionRating.EXEMPT).length}
+				{@const totalCount = applicableEvaluations.length}
+				{@const allPassed = totalCount > 0 && passedCount === totalCount}
+				{@const allExempt = allEvaluations.length > 0 && exemptCount === allEvaluations.length}
 				{@const isDefaultOpen = defaultOpenStageIndex === stageIndex}
 				{@const stageRating = (
-					allPassed ?
+					allExempt ?
+						StageStatus.UNRATED
+					: allPassed ?
 						StageStatus.PASS
 					: passedCount > 0 ?
 						StageStatus.PARTIAL
@@ -215,10 +216,16 @@
 							<div data-column>
 								{#each s.criteriaGroups as criteriaGroup}
 									{@const groupEvaluations = ladderDefinition ? criteriaGroup.criteria.map(c => c.evaluate(wallet)) : []}
-									{@const groupPassedCount = groupEvaluations.filter(e => e?.rating === StageCriterionRating.PASS).length}
-									{@const groupTotalCount = groupEvaluations.length}
+									{@const groupApplicableEvaluations = groupEvaluations.filter(e => e?.rating !== StageCriterionRating.EXEMPT)}
+									{@const groupPassedCount = groupApplicableEvaluations.filter(e => e?.rating === StageCriterionRating.PASS).length}
+									{@const groupExemptCount = groupEvaluations.filter(e => e?.rating === StageCriterionRating.EXEMPT).length}
+									{@const groupTotalCount = groupApplicableEvaluations.length}
+									{@const groupAllExempt = groupEvaluations.length > 0 && groupExemptCount === groupEvaluations.length}
+									{@const groupAllUnrated = groupTotalCount > 0 && groupApplicableEvaluations.every(e => e?.rating === StageCriterionRating.UNRATED)}
 									{@const groupRating = (
-										(groupTotalCount > 0 && groupEvaluations.every(e => e?.rating === StageCriterionRating.UNRATED)) ?
+										groupAllExempt ?
+											StageStatus.UNRATED
+										: groupAllUnrated ?
 											StageStatus.UNRATED
 										: groupPassedCount === groupTotalCount ?
 											StageStatus.PASS
@@ -274,6 +281,7 @@
 														<li
 															data-list-item-marker={attribute?.icon}
 															style:--accent={stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED) as StageCriterionRating].color}
+															data-stage-criterion-rating={criterionRating}
 														>
 															<span data-row>
 																<span data-row-item="flexible">
@@ -339,5 +347,12 @@
 
 	h4 {
 		font-weight: normal;
+	}
+
+	[data-stage-criterion-rating] {
+		&[data-stage-criterion-rating="EXEMPT"] {
+			text-decoration: line-through;
+			opacity: 0.6;
+		}
 	}
 </style>

--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -2,7 +2,7 @@
 	// Types/constants
 	import type { RatedWallet } from '@/schema/wallet'
 	import { WalletLadderType, ladders } from '@/schema/ladders'
-	import { StageCriterionRating, type WalletLadderEvaluation, type WalletStage } from '@/schema/stages'
+	import { StageCriterionRating, stageCriterionRatings, type WalletLadderEvaluation, type WalletStage } from '@/schema/stages'
 	import { stageToColor } from '@/utils/colors'
 	import { getCriterionAttributeId, attributesById } from '@/utils/stage-attributes'
 
@@ -37,36 +37,6 @@
 		},
 	} as const satisfies Record<
 		StageStatus,
-		{
-			icon: string
-			label: string
-			color: string
-		}
-	>
-
-	const stageCriterionRatings = {
-		[StageCriterionRating.PASS]: {
-			icon: '✅',
-			label: 'Criterion passed',
-			color: 'var(--rating-pass)',
-		},
-		[StageCriterionRating.FAIL]: {
-			icon: '❌',
-			label: 'Criterion failed',
-			color: 'var(--rating-fail)',
-		},
-		[StageCriterionRating.EXEMPT]: {
-			icon: '➖',
-			label: 'Criterion exempt',
-			color: 'var(--rating-exempt)',
-		},
-		[StageCriterionRating.UNRATED]: {
-			icon: '❔',
-			label: 'Criterion unrated',
-			color: 'var(--rating-unrated)',
-		},
-	} as const satisfies Record<
-		StageCriterionRating,
 		{
 			icon: string
 			label: string

--- a/src/views/WalletStageSummary.svelte
+++ b/src/views/WalletStageSummary.svelte
@@ -2,15 +2,10 @@
 	// Types/constants
 	import { isTypographicContent } from '@/types/content'
 	import type { RatedWallet } from '@/schema/wallet'
-	import { ladders } from '@/schema/ladders'
-	import { StageCriterionRating, type StageEvaluatableWallet, type WalletLadderEvaluation, type WalletStage } from '@/schema/stages'
+	import { WalletLadderType, ladders } from '@/schema/ladders'
+	import { StageCriterionRating, stageCriterionRatings, type StageEvaluatableWallet, type WalletLadderEvaluation, type WalletStage } from '@/schema/stages'
 	import { getCriterionAttributeId, attributesById } from '@/utils/stage-attributes'
 	import { slugifyCamelCase } from '@/types/utils/text'
-
-
-	// Components
-	import Typography from '@/components/Typography.svelte'
-	import WalletStageBadge from './WalletStageBadge.svelte'
 
 
 	// Props
@@ -96,16 +91,6 @@
 		)
 	})
 	
-	// Rating display helpers
-	const getRatingIcon = (rating: StageCriterionRating) => 
-		rating === StageCriterionRating.FAIL ? '❌' :
-		rating === StageCriterionRating.EXEMPT ? '⚠️' :
-		'❔'
-	
-	const getRatingColor = (rating: StageCriterionRating) =>
-		rating === StageCriterionRating.FAIL ? 'var(--rating-fail)' :
-		rating === StageCriterionRating.EXEMPT ? 'var(--rating-exempt)' :
-		'var(--rating-unrated)'
 	
 	// Helper to wrap badge with click handler or link
 	const handleBadgeClick = (clickedStage: WalletStage | null) => (e: MouseEvent) => {
@@ -121,6 +106,10 @@
 		}
 	}
 
+
+	// Components
+	import Typography from '@/components/Typography.svelte'
+	import WalletStageBadge from './WalletStageBadge.svelte'
 </script>
 
 
@@ -198,6 +187,8 @@
 
 					<li
 						data-list-item-marker={attribute?.icon}
+						data-stage-criterion-rating={evaluation.rating}
+						style:--accent={stageCriterionRatings[evaluation.rating as StageCriterionRating].color}
 					>
 						<span data-row="start gap-2">
 							<span data-row-item="flexible">
@@ -227,11 +218,9 @@
 
 							<data
 								value={evaluation.rating}
-								title={evaluation.rating}
+								title={stageCriterionRatings[evaluation.rating as StageCriterionRating].label}
 							>
-								<span>
-									{getRatingIcon(evaluation.rating)}
-								</span>
+								{stageCriterionRatings[evaluation.rating as StageCriterionRating].icon}
 							</data>
 						</span>
 					</li>
@@ -255,5 +244,12 @@
 
 	li > span > span:last-child {
 		color: var(--text-secondary);
+	}
+
+	[data-stage-criterion-rating] {
+		&[data-stage-criterion-rating="EXEMPT"] {
+			text-decoration: line-through;
+			opacity: 0.6;
+		}
 	}
 </style>

--- a/src/views/WalletStageSummary.svelte
+++ b/src/views/WalletStageSummary.svelte
@@ -100,7 +100,7 @@
 	const getRatingIcon = (rating: StageCriterionRating) => 
 		rating === StageCriterionRating.FAIL ? '❌' :
 		rating === StageCriterionRating.EXEMPT ? '⚠️' :
-		'❓'
+		'❔'
 	
 	const getRatingColor = (rating: StageCriterionRating) =>
 		rating === StageCriterionRating.FAIL ? 'var(--rating-fail)' :
@@ -189,41 +189,50 @@
 				</h4>
 			{/if}
 
-			<ul data-column="gap-2">
-				{#each criteria as { criteriaGroup, criterion, evaluation }}
+			<ul>
+				{#each criteria as { criterion, evaluation }}
 					{@const attributeId = getCriterionAttributeId(criterion)}
 					{@const attribute = attributeId ? attributesById.get(attributeId) ?? null : null}
 					{@const attributeName = attribute?.displayName ?? attributeId}
 					{@const attributeLink = attributeId ? `/${wallet.metadata.id}/#${slugifyCamelCase(attributeId)}` : null}
 
-					<li data-row="start gap-2 wrap">
-						<span style="color: {getRatingColor(evaluation.rating)}">{getRatingIcon(evaluation.rating)}</span>
-						<span data-row-item="flexible">
-							{#if attribute}
-								<span>{@html attribute.icon}</span>
-							{/if}
-							{#if attributeName}
-								{#if attributeLink}
-									<a data-link="camouflaged" href={attributeLink} title={attributeName}>
-										<strong>{attributeName}</strong>
-									</a>:
+					<li
+						data-list-item-marker={attribute?.icon}
+					>
+						<span data-row="start gap-2">
+							<span data-row-item="flexible">
+								{#if attributeName}
+									{#if attributeLink}
+										<a href={attributeLink} title={attributeName}>
+											<strong>{attributeName}</strong>
+										</a>:
+									{:else}
+										<strong>{attributeName}</strong>:
+									{/if}
+									<span>
+										{#if isTypographicContent(criterion.description)}
+											<Typography content={criterion.description} />
+										{:else}
+											{criterion.id}
+										{/if}
+									</span>
 								{:else}
-									<strong>{attributeName}</strong>:
-								{/if}
-								<span>
 									{#if isTypographicContent(criterion.description)}
 										<Typography content={criterion.description} />
 									{:else}
 										{criterion.id}
 									{/if}
-								</span>
-							{:else}
-								{#if isTypographicContent(criterion.description)}
-									<Typography content={criterion.description} />
-								{:else}
-									{criterion.id}
 								{/if}
-							{/if}
+							</span>
+
+							<data
+								value={evaluation.rating}
+								title={evaluation.rating}
+							>
+								<span>
+									{getRatingIcon(evaluation.rating)}
+								</span>
+							</data>
 						</span>
 					</li>
 				{/each}

--- a/src/views/attributes/security/ChainVerificationDetails.svelte
+++ b/src/views/attributes/security/ChainVerificationDetails.svelte
@@ -48,7 +48,5 @@
 />
 
 {#if refs && refs.length > 0}
-	<hr>
-
 	<ReferenceLinks references={refs} />
 {/if}

--- a/src/views/attributes/security/ScamAlertDetails.svelte
+++ b/src/views/attributes/security/ScamAlertDetails.svelte
@@ -43,9 +43,9 @@
 						'the domain name of the app',
 				].filter(s => s !== ''))}
 
-	<ul class="features-list">
+	<ul data-list="gap-4">
 		{#if value.sendTransactionWarning?.required}
-			<li>
+			<li data-list-item="gap-2">
 				<Typography
 					content={{
 						contentType: ContentType.MARKDOWN,
@@ -94,14 +94,14 @@
 					].filter(Boolean)
 				: []}
 
-			<li>
+			<li data-list-item="gap-2">
 				<Typography
 					content={{
 						contentType: ContentType.MARKDOWN,
 						markdown: isSupported(value.scamAlerts.contractTransactionWarning)
-							? `**{{WALLET_NAME}}** helps you stay safe when doing onchain transactions by ${
+							? `**{{WALLET_NAME}}** helps you stay safe when doing onchain transactions by${
 									contractFeatures.length > 1
-										? `:${[
+										? `: ${[
 												value.scamAlerts.contractTransactionWarning.contractRegistry &&
 													'Checking the contract or transaction data against a database of known scams',
 												value.scamAlerts.contractTransactionWarning
@@ -110,7 +110,7 @@
 												value.scamAlerts.contractTransactionWarning.recentContractWarning &&
 													'Warning you when interacting with a contract that has only recently been created onchain',
 											]
-												.filter(s => s !== '')
+												.filter(s => s)
 												.map(listItem => `\n* ${listItem}`)
 												.join('')}`
 										: value.scamAlerts.contractTransactionWarning.contractRegistry
@@ -130,7 +130,7 @@
 														'your Ethereum address',
 													value.scamAlerts.contractTransactionWarning.leaksContractAddress &&
 														'the contract address',
-												].filter(s => s !== ''),
+												].filter(s => s),
 											)} to an external provider which can correlate them ahead of the transaction being submitted.`
 										: ''
 								}`
@@ -148,7 +148,7 @@
 		{/if}
 
 		{#if value.scamUrlWarning?.required}
-			<li>
+			<li data-list-item="gap-2">
 				<Typography
 					content={{
 						contentType: ContentType.MARKDOWN,
@@ -174,19 +174,3 @@
 		{/if}
 	</ul>
 {/if}
-
-<style>
-	.features-list {
-		margin: 0.5rem 0 0 0;
-		padding-left: 1.5rem;
-		> li + li {
-			margin-top: 1rem;
-		}
-
-		> li {
-			> :global(* + *) {
-				margin-top: 0.5rem;
-			}
-		}
-	}
-</style>

--- a/src/views/attributes/security/ScamAlertDetails.svelte
+++ b/src/views/attributes/security/ScamAlertDetails.svelte
@@ -78,8 +78,6 @@
 				/>
 
 				{#if isSupported(value.scamAlerts.sendTransactionWarning) && value.scamAlerts.sendTransactionWarning.ref}
-					<hr />
-
 					<ReferenceLinks
 						references={toFullyQualified(value.scamAlerts.sendTransactionWarning.ref)}
 					/>
@@ -142,8 +140,6 @@
 				/>
 
 				{#if isSupported(value.scamAlerts.contractTransactionWarning) && value.scamAlerts.contractTransactionWarning.ref}
-					<hr />
-
 					<ReferenceLinks
 						references={toFullyQualified(value.scamAlerts.contractTransactionWarning.ref)}
 					/>
@@ -170,9 +166,9 @@
 				/>
 
 				{#if isSupported(value.scamAlerts.scamUrlWarning) && value.scamAlerts.scamUrlWarning.ref}
-					<hr />
-
-					<ReferenceLinks references={toFullyQualified(value.scamAlerts.scamUrlWarning.ref)} />
+					<ReferenceLinks
+						references={toFullyQualified(value.scamAlerts.scamUrlWarning.ref)}
+					/>
 				{/if}
 			</li>
 		{/if}

--- a/src/views/attributes/security/SecurityAuditsDetails.svelte
+++ b/src/views/attributes/security/SecurityAuditsDetails.svelte
@@ -26,6 +26,23 @@
 		}
 	>
 
+	const flawStatuses = {
+		FIXED: {
+			label: 'Fixed',
+			color: 'var(--rating-pass)',
+		},
+		NOT_FIXED: {
+			label: 'Not fixed',
+			color: 'var(--rating-fail)',
+		},
+	} as const satisfies Record<
+		'FIXED' | 'NOT_FIXED',
+		{
+			label: string
+			color: string
+		}
+	>
+
 
 	// Props
 	const {
@@ -138,15 +155,19 @@
 									{#each [SecurityFlawSeverity.CRITICAL, SecurityFlawSeverity.HIGH, SecurityFlawSeverity.MEDIUM] as severity}
 										{#if flawGroups.has(severity)}
 											{@const flaws = flawGroups.get(severity)!}
+											{@const unfixedCount = flaws.filter((flaw: UnpatchedSecurityFlaw) => flaw.presentStatus === 'NOT_FIXED').length}
+											{@const allFixed = unfixedCount === 0}
 
 											<data	
 												data-badge="small"
+												data-row="gap-1"
 												value={severity}
-												title="{securityFlawSeverities[severity].label} severity flaws"
+												title="{securityFlawSeverities[severity].label} severity flaws{allFixed ? ' (all fixed)' : ''}"
+												style:--accent={allFixed ? 'var(--rating-pass)' : undefined}
 											>
-												{securityFlawSeverities[severity].icon}
-												{securityFlawSeverities[severity].label} Severity
-												({flaws.length})
+												<span>{securityFlawSeverities[severity].icon}</span>
+												<span>{securityFlawSeverities[severity].label} Severity</span>
+												<span>{allFixed ? '✅' : `(${unfixedCount})`}</span>
 											</data>
 										{/if}
 									{/each}
@@ -181,19 +202,20 @@
 								>
 									<span data-row="wrap wrap-first-last">
 										<span data-row-item="flexible basis-2">
-											<strong>{securityFlawSeverities[flaw.severityAtAuditPublication].label}</strong>:
 											{#if flaw.presentStatus === 'FIXED'}
-												<s class="fixed-flaw">{flaw.name}</s>
+												<s class="fixed-flaw">
+													<strong>{securityFlawSeverities[flaw.severityAtAuditPublication].label}</strong>: {flaw.name}
+												</s>
 											{:else}
-												<span>{flaw.name}</span>
+												<strong>{securityFlawSeverities[flaw.severityAtAuditPublication].label}</strong>: <span>{flaw.name}</span>
 											{/if}
 										</span>
 										<data
 											data-badge="small"
 											value={flaw.presentStatus}
-											style:--accent={flaw.presentStatus === 'FIXED' ? 'var(--rating-pass)' : 'var(--rating-fail)'}
+											style:--accent={flawStatuses[flaw.presentStatus].color}
 										>
-											{flaw.presentStatus === 'FIXED' ? 'Fixed' : 'Not fixed'}
+											{flawStatuses[flaw.presentStatus].label}
 										</data>
 									</span>
 								</li>

--- a/src/views/attributes/security/SecurityAuditsDetails.svelte
+++ b/src/views/attributes/security/SecurityAuditsDetails.svelte
@@ -3,6 +3,28 @@
 	import type { SecurityAuditsValue } from '@/schema/attributes/security/security-audits'
 	import type { RatedWallet } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
+	import { SecurityFlawSeverity } from '@/schema/features/security/security-audits'
+
+	const securityFlawSeverities = {
+		[SecurityFlawSeverity.CRITICAL]: {
+			icon: '🚨',
+			label: 'Critical',
+		},
+		[SecurityFlawSeverity.HIGH]: {
+			icon: '‼️',
+			label: 'High',
+		},
+		[SecurityFlawSeverity.MEDIUM]: {
+			icon: '⚠️',
+			label: 'Medium',
+		},
+	} as const satisfies Record<
+		SecurityFlawSeverity,
+		{
+			icon: string
+			label: string
+		}
+	>
 
 
 	// Props
@@ -20,7 +42,7 @@
 
 
 	// Functions
-	import { securityAuditId, securityFlawSeverityName, type UnpatchedSecurityFlaw } from '@/schema/features/security/security-audits'
+	import { securityAuditId, type UnpatchedSecurityFlaw } from '@/schema/features/security/security-audits'
 	import { toFullyQualified } from '@/schema/reference'
 	import { isUrl } from '@/schema/url'
 
@@ -39,11 +61,28 @@
 		strings={{ WALLET_NAME: wallet.metadata.displayName }}
 	/>
 {:else}
-	{@const securityAuditsSorted = value.securityAudits.toSorted(
-		(a, b) => new Date(b.auditDate).getTime() - new Date(a.auditDate).getTime(),
+	{@const securityAudits = (
+		value
+			.securityAudits
+			.toSorted((a, b) => (
+				new Date(b.auditDate).getTime() - new Date(a.auditDate).getTime()
+			))
 	)}
 
-	{@const mostRecentAudit = securityAuditsSorted[0]}
+	{@const mostRecentAudit = securityAudits[0]}
+
+	{@const anyAuditHasUnfixedFlaws = (
+		securityAudits
+			.some((audit) => (
+				Array.isArray(audit.unpatchedFlaws)
+				&& (
+					audit.unpatchedFlaws
+						.some((flaw: UnpatchedSecurityFlaw) => (
+							flaw.presentStatus === 'NOT_FIXED'
+						))
+				)
+			))
+	)}
 
 	<Typography
 		content={{
@@ -53,128 +92,128 @@
 		strings={{ WALLET_NAME: wallet.metadata.displayName }}
 	/>
 
-	{#if mostRecentAudit?.ref}
-		<ReferenceLinks references={toFullyQualified(mostRecentAudit.ref)} />
-	{/if}
+	<section data-column="gap-2">
+		{#each securityAudits as audit, index (securityAuditId(audit))}
+			{@const isMostRecent = index === 0}
+			{@const hasUnfixedFlaws = Array.isArray(audit.unpatchedFlaws) && audit.unpatchedFlaws.some((flaw: UnpatchedSecurityFlaw) => flaw.presentStatus === 'NOT_FIXED')}
+			{@const flawGroups = Array.isArray(audit.unpatchedFlaws) ? Map.groupBy(audit.unpatchedFlaws, (flaw: UnpatchedSecurityFlaw) => flaw.severityAtAuditPublication) : null}
+			{@const hasFlaws = flawGroups && flawGroups.size > 0}
 
-	<div class="audits-container" data-card="secondary padding-6">
-		<h4>Audits</h4>
-
-		<ul class="audits-list">
-			{#each securityAuditsSorted as audit (securityAuditId(audit))}
-				<li>
-					<article data-column>
-						<header data-row="wrap">
-							{#if isUrl(audit.auditor.url)}
-								<cite
-									><a
-										href={typeof audit.auditor.url === 'string'
-											? audit.auditor.url
-											: audit.auditor.url.url}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
+			<details
+				data-card="secondary"
+				open={
+					anyAuditHasUnfixedFlaws ?
+						hasUnfixedFlaws
+					:
+						isMostRecent
+				}
+			>
+				<summary>
+					<header data-row="wrap wrap-first-last">
+						<div 
+							data-row-item="flexible basis-1"
+							data-row="start wrap gap-2"
+						>
+							<h4>
+								Audit by 
+								<cite>
+									{#if isUrl(audit.auditor.url)}
+										<a
+											href={typeof audit.auditor.url === 'string'
+												? audit.auditor.url
+												: audit.auditor.url.url}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{audit.auditor.name}
+										</a>
+									{:else}
 										{audit.auditor.name}
-									</a></cite
-								>
-							{:else}
-								<cite>{audit.auditor.name}</cite>
-							{/if}
+									{/if}
+								</cite>
+							</h4>
 
-							<strong
-								><time datetime={audit.auditDate}
-									>{Intl.DateTimeFormat(undefined, { dateStyle: 'long' }).format(
-										new Date(audit.auditDate),
-									)}</time
-								></strong
-							>
-						</header>
+							{#if hasFlaws && flawGroups}
+								<div data-row="gap-1 wrap">
+									{#each [SecurityFlawSeverity.CRITICAL, SecurityFlawSeverity.HIGH, SecurityFlawSeverity.MEDIUM] as severity}
+										{#if flawGroups.has(severity)}
+											{@const flaws = flawGroups.get(severity)!}
 
-						{#if audit.ref}
-							<ReferenceLinks references={toFullyQualified(audit.ref)} />
-						{/if}
-
-						{#if audit.unpatchedFlaws === 'NONE_FOUND'}
-							<p>No security flaws of severity level medium or higher were found.</p>
-						{:else if audit.unpatchedFlaws === 'ALL_FIXED'}
-							<p>All security flaws of severity level medium or higher were addressed.</p>
-						{:else if Array.isArray(audit.unpatchedFlaws) && audit.unpatchedFlaws.length > 0}
-							<p>
-								The following security flaws were identified
-								{!audit.unpatchedFlaws.some((flaw: UnpatchedSecurityFlaw) => flaw.presentStatus === 'NOT_FIXED')
-									? ' and have all been addressed since'
-									: ''}:
-							</p>
-							<ul class="flaws-list">
-								{#each audit.unpatchedFlaws as flaw (flaw.name)}
-									<li>
-										<strong>{securityFlawSeverityName(flaw.severityAtAuditPublication)}</strong>:
-										{#if flaw.presentStatus === 'FIXED'}
-											<span class="fixed-flaw">{flaw.name}</span>
-											<strong class="fixed-label">(Fixed)</strong>
-										{:else}
-											<span>{flaw.name}</span>
-											<strong class="not-fixed-label">(Not fixed)</strong>
+											<data	
+												data-badge="small"
+												value={severity}
+												title="{securityFlawSeverities[severity].label} severity flaws"
+											>
+												{securityFlawSeverities[severity].icon}
+												{securityFlawSeverities[severity].label} Severity
+												({flaws.length})
+											</data>
 										{/if}
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</article>
-				</li>
-			{/each}
-		</ul>
-	</div>
+									{/each}
+								</div>
+							{/if}
+						</div>
+
+						<time datetime={audit.auditDate}>
+							{
+								Intl.DateTimeFormat(undefined, { dateStyle: 'long' })
+									.format(
+										new Date(audit.auditDate),
+									)
+							}
+						</time>
+					</header>
+				</summary>
+
+				<section data-column="gap-4">
+					{#if audit.unpatchedFlaws === 'NONE_FOUND'}
+						<p>No security flaws of severity level medium or higher were found.</p>
+					{:else if audit.unpatchedFlaws === 'ALL_FIXED'}
+						<p>All security flaws of severity level medium or higher were addressed.</p>
+					{:else if Array.isArray(audit.unpatchedFlaws) && audit.unpatchedFlaws.length > 0}
+						<p>
+							The following security flaws were identified{!hasUnfixedFlaws ? ' and have all been addressed since' : ''}:
+						</p>
+						<ul class="flaws-list" data-list>
+							{#each audit.unpatchedFlaws as flaw (flaw.name)}
+								<li
+									data-list-item-marker={securityFlawSeverities[flaw.severityAtAuditPublication].icon}
+								>
+									<span data-row="wrap wrap-first-last">
+										<span data-row-item="flexible basis-2">
+											<strong>{securityFlawSeverities[flaw.severityAtAuditPublication].label}</strong>:
+											{#if flaw.presentStatus === 'FIXED'}
+												<s class="fixed-flaw">{flaw.name}</s>
+											{:else}
+												<span>{flaw.name}</span>
+											{/if}
+										</span>
+										<data
+											data-badge="small"
+											value={flaw.presentStatus}
+											style:--accent={flaw.presentStatus === 'FIXED' ? 'var(--rating-pass)' : 'var(--rating-fail)'}
+										>
+											{flaw.presentStatus === 'FIXED' ? 'Fixed' : 'Not fixed'}
+										</data>
+									</span>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+
+					{#if audit.ref}
+						<ReferenceLinks references={toFullyQualified(audit.ref)} />
+					{/if}
+				</section>
+			</details>
+		{/each}
+	</section>
 {/if}
 
+
 <style>
-	.audits-container {
-		max-height: 300px;
-		overflow-y: auto;
-	}
-
-	.audits-list {
-		list-style-type: revert;
-		margin: 0;
-		padding-left: 1.5rem;
-
-		> li + li {
-			margin-top: 2em;
-		}
-
-		> li {
-			line-height: 1.5;
-
-			&:last-child {
-				margin-bottom: 0;
-			}
-
-			> :global(* + *) {
-				margin-top: 0.5em;
-			}
-		}
-	}
-
-	.flaws-list {
-		margin: 0.25rem 0 0.5rem 0;
-		padding-left: 1.5rem;
-
-		li {
-			margin-bottom: 0.25rem;
-		}
-	}
-
 	.fixed-flaw {
-		text-decoration: line-through;
 		opacity: 0.75;
-	}
-
-	.fixed-label {
-		color: var(--success);
-	}
-
-	.not-fixed-label {
-		color: var(--error);
 	}
 
 	cite {

--- a/src/views/attributes/transparency/FundingDetails.svelte
+++ b/src/views/attributes/transparency/FundingDetails.svelte
@@ -52,8 +52,6 @@
 {#if monetization}
 	{@const references = refs(monetization)}
 	{#if references.length > 0}
-		<hr>
-
 		<ReferenceLinks references={references} />
 	{/if}
 {/if}


### PR DESCRIPTION
* Unify styling for all lists and list items (`<ul>` elements and left-aligned icons) across the site
* Improve/rewrite layouts involving lists: stage overview, stage summaries, attribute rating details, attribute rating methodology, reference links, security audits, scam alerts

---

## Layout primitives

* `[data-list]`
  * introduce unified list styling utility with standardized spacing, indentation, and marker styling
  * `[data-list-item-marker]`: support custom list markers (emojis/icons)

## Components

* `<Typography>`
  * remove wrapper element; adjust spacing in parent elements instead

## Views

* `<ReferenceLinks>`
  * overhaul layout / display logic (fixes https://github.com/walletbeat/walletbeat/issues/320)
  * wrap in `[data-card]` for consistent visual treatment

* `<WalletPage>`
  * overhaul attribute rating methodology to use `[data-list]`
  * overhaul attribute rating details to use `[data-list]`
  * only render `<ReferenceLinks>` if attribute rating details don't
  * remove de-emphasis styling on "Impact" section (fixes https://github.com/walletbeat/walletbeat/issues/321)

* `<WalletStageOverview>`
  * overhaul layout / data derivation logic
  * exclude exempt criteria from counts
  * add constant mappings for stage statuses and criterion ratings with icons, labels, and colors
  * apply accent colors at list item / details level
  * fade exempt items with strikethrough styling

* `<WalletStageSummary>`
  * update layout to use `[data-list]`

* `<SecurityAuditsDetails>`
  * overhaul layout; account for flaw severities and fix statuses
  * add constant mappings for security flaw severities and fix statuses
  * exclude fixed flaws from counts; show checkmark when all fixed
  * wrap fixed flaw labels and names in `<s>` tag

* `<ScamAlertDetails>`
  * update to use `[data-list]`

* `<ChainVerificationDetails>`
  * remove redundant `<hr>` before `<ReferenceLinks>`

* `<FundingDetails>`
  * remove redundant `<hr>` before `<ReferenceLinks>`

---

<img width="1571" height="1293" alt="Screenshot 2026-01-12 at 02 32 46" src="https://github.com/user-attachments/assets/1893e7e5-9216-442c-88a1-c0747225409a" />

<img width="1569" height="1293" alt="Screenshot 2026-01-12 at 02 34 51" src="https://github.com/user-attachments/assets/e6235246-5495-439b-b29d-c716ce379584" />

<img width="1571" height="1293" alt="Screenshot 2026-01-12 at 02 37 19" src="https://github.com/user-attachments/assets/f6b641e8-632c-43cf-856c-1d3459f6578c" />

<img width="1571" height="1292" alt="Screenshot 2026-01-12 at 02 38 38" src="https://github.com/user-attachments/assets/013301bf-12bf-4b57-ab49-776c07d22508" />

<img width="1374" height="1518" alt="Screenshot 2026-01-12 at 03 44 02" src="https://github.com/user-attachments/assets/c5855d71-4b7a-437a-816d-bbd7619b1d29" />