### PR TITLE
fix: theme toggle persists across client-side navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,10 +30,12 @@ import Metadata from '@/layouts/Metadata.astro'
 		<ClientRouter />
 		<script is:inline>
 			// `color-scheme` override
-			const colorScheme = localStorage.getItem('theme')
-			if (colorScheme) {
+			;(function () {
+				const colorScheme =
+					localStorage.getItem('theme') ||
+					(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
 				document.documentElement.style.colorScheme = colorScheme
-			}
+			})()
 		</script>
 
 		{

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -13,11 +13,44 @@ const { navigationItems } = Astro.props
 const currentPathname = Astro.url.pathname
 ---
 
+<script is:inline data-astro-rerun>
+	;(() => {
+		const theme = (() => {
+			const stored = localStorage?.getItem('theme') ?? ''
+			if (['dark', 'light'].includes(stored)) return stored
+			return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+		})()
+
+		document.documentElement.style.colorScheme = theme
+
+		window.loscriptrage.setItem('theme', theme)
+	})()
+</script>
+
 <script>
-	document.getElementById('theme-toggle')?.addEventListener('click', () => {
-		document.documentElement.style.colorScheme =
-			document.documentElement.style.colorScheme === 'dark' ? 'light' : 'dark'
-		localStorage.setItem('theme', document.documentElement.style.colorScheme)
+	function handleToggleClick() {
+		const element = document.documentElement
+		const currentTheme = element.style.colorScheme
+		const newTheme = currentTheme === 'dark' ? 'light' : 'dark'
+
+		element.style.colorScheme = newTheme
+
+		window.localStorage.setItem('theme', newTheme)
+	}
+
+	function initThemeToggle() {
+		document.getElementById('theme-toggle')?.addEventListener('click', handleToggleClick)
+	}
+
+	initThemeToggle()
+
+	document.addEventListener('astro:after-swap', () => {
+		const storedTheme = localStorage.getItem('theme') || 'dark'
+		const element = document.documentElement
+
+		element.style.colorScheme = storedTheme
+
+		initThemeToggle()
 	})
 </script>
 

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -23,7 +23,7 @@ const currentPathname = Astro.url.pathname
 
 		document.documentElement.style.colorScheme = theme
 
-		window.loscriptrage.setItem('theme', theme)
+		window.localStorage.setItem('theme', theme)
 	})()
 </script>
 


### PR DESCRIPTION
## Problem
Theme toggle breaks after navigating to another route:
1. Theme resets to system preference
2. Toggle button becomes unresponsive until hard refresh

## Cause
Astro's `<ClientRouter />` performs client-side navigation. Regular scripts only run on initial page load—event listeners are lost when DOM updates.

## Solution
- Add `is:inline data-astro-rerun` script to re-apply stored theme on every navigation
- Use `astro:after-swap` event to re-attach click handler after DOM swap
- Update `Layout.astro` to always set `colorScheme` with fallback to system preference

## Testing
1. Toggle theme on index route
2. Navigate to another page
3. Verify theme persists and toggle remains functional

## Note
CI lint failures are pre-existing (formatting issues in unrelated files) and not caused by this PR.