### PR TITLE
Wallet attribute / stage display improvements: `<Tooltip>`, `<Pie>`, `title` text, exempt attribute pie slices, stage anchor links

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -7,6 +7,7 @@
 		arcLabel: string
 		titleText: string
 		href?: string
+		opacity?: number
 		children?: Slice[]
 	}
 
@@ -333,6 +334,7 @@
 		style:--slice-totalAngle={slice.computed.totalAngle}
 		style:--slice-path={`path("${slice.computed.path}")`}
 		style:--slice-fill={slice.color}
+		style:--slice-opacity={slice.opacity ?? 1}
 		class:highlighted={highlightedSliceId === slice.id}
 		data-slice-id={slice.id}
 		role={slice.href ? 'link' : 'button'}
@@ -506,25 +508,26 @@
 					scale(var(--slice-scale))
 					translateY(calc(var(--slice-offset) * -1px))
 				;
-				transition-property: transform;
+				opacity: var(--slice-opacity);
+				transition-property: transform, opacity;
 
 				&:hover,
 				&:focus {
 					filter: brightness(var(--hover-brightness));
 					--slice-scale: var(--hover-scale);
+					opacity: 1;
 				}
 
-				&:focus {
-					stroke: var(--highlight-color);
-					stroke-width: calc(var(--highlight-stroke-width) * 1px);
-					z-index: 2;
-					outline: none;
-				}
-
+				&:focus,
 				&.highlighted {
 					stroke: var(--highlight-color);
 					stroke-width: calc(var(--highlight-stroke-width) * 1px);
 					z-index: 2;
+					opacity: 1;
+				}
+
+				&:focus {
+					outline: none;
 				}
 
 				> .label-line {

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -5,8 +5,7 @@
 		color: string
 		weight: number
 		arcLabel: string
-		tooltip: string
-		tooltipValue: string
+		titleText: string
 		href?: string
 		children?: Slice[]
 	}
@@ -360,7 +359,7 @@
 				d={slice.computed.path}
 				class="slice-path"
 			>
-				<title>{[slice.tooltipValue, slice.tooltip].join('\n')}</title>
+				<title>{slice.titleText}</title>
 			</path>
 		{/snippet}
 

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -28,9 +28,10 @@
 	type ComputedSlice = Slice & {
 		computed: {
 			path: string
+			totalAngle: number
 			midAngle: number
-			outerRadius: number
-			innerRadius: number
+			outerR: number
+			innerR: number
 			gap: number
 			level: number
 			offset: number
@@ -57,6 +58,7 @@
 		layout = PieLayout.HalfTop,
 		padding = 0,
 		radius = 47,
+		labelSize = radius / 4,
 		levels = [
 			{
 				outerRadiusFraction: 0.6,
@@ -95,6 +97,7 @@
 		layout?: (typeof PieLayout)[keyof typeof PieLayout]
 		radius?: number
 		padding?: number
+		labelSize?: number
 		levels?: LevelConfig[]
 
 		// State
@@ -133,16 +136,16 @@
 		cx = 0,
 		cy = 0,
 		gap,
-		outerRadius,
-		innerRadius,
+		outerR,
+		innerR,
 		startAngle,
 		endAngle,
 	}: {
 		cx: number
 		cy: number
 		gap: number
-		outerRadius: number
-		innerRadius: number
+		outerR: number
+		innerR: number
 		startAngle: number
 		endAngle: number
 	}) => {
@@ -152,26 +155,26 @@
 		// Handle full circles (or nearly full circles)
 		if (angleDiff >= 359.99) {
 			return [
-				`M ${cx + outerRadius} ${cy}`,
-				`A ${outerRadius} ${outerRadius} 0 1 0 ${cx - outerRadius} ${cy}`,
-				`A ${outerRadius} ${outerRadius} 0 1 0 ${cx + outerRadius} ${cy}`,
-				`M ${cx + innerRadius} ${cy}`,
-				`A ${innerRadius} ${innerRadius} 0 1 1 ${cx - innerRadius} ${cy}`,
-				`A ${innerRadius} ${innerRadius} 0 1 1 ${cx + innerRadius} ${cy}`,
+				`M ${cx + outerR} ${cy}`,
+				`A ${outerR} ${outerR} 0 1 0 ${cx - outerR} ${cy}`,
+				`A ${outerR} ${outerR} 0 1 0 ${cx + outerR} ${cy}`,
+				`M ${cx + innerR} ${cy}`,
+				`A ${innerR} ${innerR} 0 1 1 ${cx - innerR} ${cy}`,
+				`A ${innerR} ${innerR} 0 1 1 ${cx + innerR} ${cy}`,
 			].join(' ')
 		}
 
-		const outerAngleStart = startAngle + Math.asin((gap / 2) / outerRadius) * 180 / Math.PI * orientation
-		const outerStart = polarToCartesian(cx, cy, outerRadius, outerAngleStart)
+		const outerAngleStart = startAngle + Math.asin((gap / 2) / outerR) * 180 / Math.PI * orientation
+		const outerStart = polarToCartesian(cx, cy, outerR, outerAngleStart)
 
-		const outerAngleEnd = endAngle - Math.asin((gap / 2) / outerRadius) * 180 / Math.PI * orientation
-		const outerEnd = polarToCartesian(cx, cy, outerRadius, outerAngleEnd)
+		const outerAngleEnd = endAngle - Math.asin((gap / 2) / outerR) * 180 / Math.PI * orientation
+		const outerEnd = polarToCartesian(cx, cy, outerR, outerAngleEnd)
 
-		const innerAngleEnd = endAngle - Math.asin((gap / 2) / innerRadius) * 180 / Math.PI * orientation
-		const innerEnd = polarToCartesian(cx, cy, innerRadius, innerAngleEnd)
+		const innerAngleEnd = endAngle - Math.asin((gap / 2) / innerR) * 180 / Math.PI * orientation
+		const innerEnd = polarToCartesian(cx, cy, innerR, innerAngleEnd)
 
-		const innerAngleStart = startAngle + Math.asin((gap / 2) / innerRadius) * 180 / Math.PI * orientation
-		const innerStart = polarToCartesian(cx, cy, innerRadius, innerAngleStart)
+		const innerAngleStart = startAngle + Math.asin((gap / 2) / innerR) * 180 / Math.PI * orientation
+		const innerStart = polarToCartesian(cx, cy, innerR, innerAngleStart)
 
 		const largeArcFlag = angleDiff > 180 ? 1 : 0
 		const sweepFlag = orientation === 1 ? 1 : 0
@@ -184,9 +187,9 @@
 		return (
 			[
 				`M ${outerStart.x} ${outerStart.y}`,
-				`A ${outerRadius} ${outerRadius} 0 ${largeArcFlag} ${sweepFlag} ${outerEnd.x} ${outerEnd.y}`,
+				`A ${outerR} ${outerR} 0 ${largeArcFlag} ${sweepFlag} ${outerEnd.x} ${outerEnd.y}`,
 				`L ${innerEnd.x} ${innerEnd.y}`,
-				`A ${innerRadius} ${innerRadius} 0 ${largeArcFlag} ${1 - sweepFlag} ${innerStart.x} ${innerStart.y}`,
+				`A ${innerR} ${innerR} 0 ${largeArcFlag} ${1 - sweepFlag} ${innerStart.x} ${innerStart.y}`,
 				`L ${outerStart.x} ${outerStart.y}`,
 			]
 				.join(' ')
@@ -209,8 +212,8 @@
 		const levelConfig = getLevelConfig(level)
 		const parentLevelConfig = getLevelConfig(level - 1)
 
-		const outerRadius = radius * levelConfig.outerRadiusFraction
-		const innerRadius = radius * levelConfig.innerRadiusFraction
+		const outerR = radius * levelConfig.outerRadiusFraction
+		const innerR = radius * levelConfig.innerRadiusFraction
 
 		const orientation = Math.sign(endAngle - startAngle)
 
@@ -218,7 +221,7 @@
 		const totalGapAngle = angleGap * (slices.length - 1)
 
 		const angleInsetFromGap = angleGap / 2
-		const angleInsetFromParentGap = parentLevelConfig ? (Math.asin((levelConfig.gap / 2) / outerRadius) - Math.asin((parentLevelConfig.gap / 2) / outerRadius)) * 180 / Math.PI * orientation : 0
+		const angleInsetFromParentGap = parentLevelConfig ? (Math.asin((levelConfig.gap / 2) / outerR) - Math.asin((parentLevelConfig.gap / 2) / outerR)) * 180 / Math.PI * orientation : 0
 
 		const effectiveStartAngle = startAngle + (angleInsetFromGap + angleInsetFromParentGap) * orientation
 		const effectiveEndAngle = endAngle - (angleInsetFromGap + angleInsetFromParentGap) * orientation
@@ -243,15 +246,15 @@
 						cx: 0,
 						cy,
 						gap: levelConfig.gap,
-						outerRadius,
-						innerRadius,
+						outerR,
+						innerR,
 						startAngle: -totalAngle / 2,
 						endAngle: totalAngle / 2,
 					}),
 					totalAngle,
 					midAngle,
-					outerRadius,
-					innerRadius,
+					outerR,
+					innerR,
 					level,
 					offset: levelConfig.offset ?? 0,
 					gap: levelConfig.gap,
@@ -325,8 +328,9 @@
 		style:--slice-midAngle={slice.computed.midAngle}
 		style:--slice-offset={slice.computed.offset}
 		style:--slice-gap={slice.computed.gap}
-		style:--slice-outerRadius={slice.computed.outerRadius}
-		style:--slice-innerRadius={slice.computed.innerRadius}
+		style:--slice-outerR={slice.computed.outerR}
+		style:--slice-innerR={slice.computed.innerR}
+		style:--slice-totalAngle={slice.computed.totalAngle}
 		style:--slice-path={`path("${slice.computed.path}")`}
 		style:--slice-fill={slice.color}
 		class:highlighted={highlightedSliceId === slice.id}
@@ -351,7 +355,7 @@
 			x1="0"
 			y1={slice.computed.gap}
 			x2="0"
-			y2={-slice.computed.innerRadius}
+			y2={-slice.computed.innerR}
 		/>
 
 		{#snippet slicePathSnippet(slice: ComputedSlice)}
@@ -390,6 +394,8 @@
 	{...restProps}
 	class="container {'class' in restProps ? restProps.class : ''}"
 	data-layout={layout}
+	style:--pie-radius={radius}
+	style:--pie-labelSize={labelSize}
 >
 	<svg {...svgAttributes}>
 		{#if title}
@@ -457,14 +463,38 @@
 				--slice-scale: 1;
 				--slice-offset: 0;
 
-				/* Weighted average: 1/3 centroid distance + 2/3 midpoint radius for better visual balance */
-				--slice-labelRadius: calc(
-					1/3 * (
-						2/3 * (pow(var(--slice-outerRadius), 3) - pow(var(--slice-innerRadius), 3)) / (pow(var(--slice-outerRadius), 2) - pow(var(--slice-innerRadius), 2))
-					)
-					+ 2/3 * (
-						(var(--slice-outerRadius) + var(--slice-innerRadius)) / 2
-					)
+				--slice-labelRadius: calc(var(--pie-labelSize) / 2);
+				--slice-labelR: clamp(
+					/* Geometric mean of the inner and outer radii (with label radius carved out) */
+					pow(
+						(
+							(var(--slice-outerR) - var(--slice-labelRadius))
+							* (var(--slice-innerR) + var(--slice-labelRadius))
+						),
+						0.5
+					),
+
+					/* Centroid of the trimmed annular sector (with inner radius adjusted by label radius) */
+					(
+						2 / 3
+						* (
+							(
+								pow(var(--slice-outerR), 3)
+								- pow(var(--slice-innerR), 3)
+							)
+							/ (
+								pow(var(--slice-outerR), 2)
+								- pow(var(--slice-innerR), 2)
+							)
+						)
+						* (
+							sin(var(--slice-totalAngle) * 1deg / 2)
+							/ (var(--slice-totalAngle) * pi/180 / 2)
+						)
+					),
+
+					/* Outer radius minus label radius */
+					var(--slice-outerR) - var(--slice-labelRadius)
 				);
 
 				transform-origin: 0 0;
@@ -516,9 +546,9 @@
 					dominant-baseline: central;
 					fill: currentColor;
 					stroke: none;
-					font-size: 0.725em;
+					font-size: calc(var(--pie-labelSize) * 1px);
 					pointer-events: none;
-					translate: 0 calc(var(--slice-labelRadius) * -1px);
+					translate: 0 calc(var(--slice-labelR) * -1px);
 					rotate: calc(-1 * (var(--pie-rotate) + var(--slice-midAngle) * 1deg));
 					transition-property: translate, rotate, filter;
 				}

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -49,6 +49,7 @@
 	// Props
 	const {
 		// Content
+		title,
 		slices = [],
 		centerLabel,
 
@@ -391,6 +392,10 @@
 	data-layout={layout}
 >
 	<svg {...svgAttributes}>
+		{#if title}
+			<title>{title}</title>
+		{/if}
+
 		<g class="slices">
 			{#each computedSlices as slice (slice.id)}
 				{@render sliceSnippet(slice)}

--- a/src/components/Table.svelte
+++ b/src/components/Table.svelte
@@ -40,8 +40,16 @@
 			]
 		>
 
+		align?: ColumnAlignment
+
 		subcolumns?: Column<_RowValue, _CellValue, _ColumnId>[]
 		isDefaultExpanded?: boolean
+	}
+
+	export enum ColumnAlignment {
+		Start = 'Start',
+		Center = 'Center',
+		End = 'End',
 	}
 
 	export enum SortDirection {
@@ -442,6 +450,7 @@
 					span={columnSpan}
 					data-sortable={isSortable ? '' : undefined}
 					data-sort={table.sortState?.columnId === column.id ? table.sortState?.direction : undefined}
+					data-column-align={column.align ? column.align.toLowerCase() : undefined}
 				/>
 			{/each}
 		</colgroup>
@@ -495,6 +504,7 @@
 					data-sortable={isSortable ? '' : undefined}
 					data-sort={table.sortState?.columnId === column.id ? table.sortState?.direction : undefined}
 					data-sticky={column.isSticky ? 'inline' : undefined}
+					data-column-align={column.align ? column.align.toLowerCase() : undefined}
 					data-expandable={isExpandable ? '' : undefined}
 					data-expanded={isExpandable && isExpanded ? '' : undefined}
 				>
@@ -601,6 +611,7 @@
 							data-sortable={isSortable ? '' : undefined}
 							data-sort={table.sortState?.columnId === column.id ? table.sortState?.direction : undefined}
 							data-sticky={column.isSticky ? 'inline' : undefined}
+							data-column-align={column.align ? column.align.toLowerCase() : undefined}
 							style:--table-cell-verticalAlign={
 								cellVerticalAlign?.({
 									row,
@@ -965,14 +976,16 @@
 			th,
 			td
 		) {
-			&[data-align='start'] {
+			&[data-column-align='start'] {
 				text-align: start;
-				align-items: start;
 				transform-origin: left;
 			}
-			&[data-align='end'] {
+			&[data-column-align='center'] {
+				text-align: center;
+				transform-origin: center;
+			}
+			&[data-column-align='end'] {
 				text-align: end;
-				align-items: end;
 				transform-origin: right;
 			}
 

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -12,6 +12,11 @@
 			hidePopover(): void
 		}
 	}
+
+	export enum TooltipLayoutMode {
+		FloatingUI = 'FloatingUI',
+		AnchorPositioning = 'AnchorPositioning',
+	}
 </script>
 
 
@@ -33,6 +38,7 @@
 		placement = 'block-end',
 		buttonTriggerPlacement = 'around',
 		hoverTriggerPlacement = 'around',
+		layoutMode = TooltipLayoutMode.FloatingUI,
 		offset = 8,
 		TooltipContent,
 		hideDelay = 200,
@@ -44,6 +50,7 @@
 		placement?: 'block-start' | 'block-end' | 'inline-start' | 'inline-end'
 		buttonTriggerPlacement?: 'around' | 'behind'
 		hoverTriggerPlacement?: 'around' | 'button'
+		layoutMode?: TooltipLayoutMode
 		offset?: number
 		hideDelay?: number
 		TooltipContent?: Snippet
@@ -83,7 +90,8 @@
 				node.style.removeProperty('position')
 		})
 
-		if (supportsAnchorPositioning) return
+		if (layoutMode === TooltipLayoutMode.AnchorPositioning && supportsAnchorPositioning)
+			return
 
 		const {
 			computePosition,
@@ -92,6 +100,11 @@
 			shift,
 			autoUpdate,
 		} = await import('@floating-ui/dom')
+
+		// Disable native anchor positioning
+		node.popoverTargetElement.style.position = 'absolute'
+		node.popoverTargetElement.style.setProperty('position-area', 'none')
+		node.popoverTargetElement.style.setProperty('position-anchor', anchorName)
 
 		const updatePosition = () => {
 			void computePosition(
@@ -107,7 +120,11 @@
 					middleware: [
 						offsetMiddleware(offset),
 						flip(),
-						shift(),
+						shift({
+							padding: offset * 2,
+							crossAxis: true,
+							mainAxis: true,
+						}),
 					],
 				}
 			)
@@ -236,6 +253,7 @@
 		position-visibility: anchors-visible;
 
 		margin: var(--offset);
+		width: max-content;
 
 		background-color: var(--popover-backgroundColor);
 		border-radius: 0.5rem;

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -232,7 +232,7 @@
 
 <style>
 	[data-tooltip-trigger] {
-		display: grid;
+		display: inline grid;
 		font: inherit;
 		padding: 0;
 		background-color: transparent;

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -229,7 +229,7 @@
 		--popover-borderWidth: 1px;
 		--popover-boxShadow: 0 4px 12px light-dark(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.4));
 
-		position: absolute;
+		position: fixed;
 		position-area: block-end;
 		position-try-fallbacks: flip-block;
 		position-try-order: most-block-size;

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -46,7 +46,7 @@
 		hoverTriggerPlacement?: 'around' | 'button'
 		offset?: number
 		hideDelay?: number
-		TooltipContent: Snippet
+		TooltipContent?: Snippet
 		isEnabled?: boolean
 		children?: Snippet
 	} = $props()
@@ -160,7 +160,9 @@
 
 			{...restProps}
 		>
-			{@render TooltipContent()}
+			{#if TooltipContent}
+				{@render TooltipContent()}
+			{/if}
 		</div>
 	{/snippet}
 

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -48,7 +48,7 @@
 		hideDelay?: number
 		TooltipContent: Snippet
 		isEnabled?: boolean
-		children: Snippet
+		children?: Snippet
 	} = $props()
 
 
@@ -180,7 +180,9 @@
 				{@attach useButtonTrigger}
 			></button>
 
-			{@render children()}
+			{#if children}
+				{@render children()}
+			{/if}
 		</div>
 
 		{@render Popover()}
@@ -195,13 +197,17 @@
 			{...hoverTriggerEvents}
 			{@attach useButtonTrigger}
 		>
-			{@render children()}
+			{#if children}
+				{@render children()}
+			{/if}
 
 			{@render Popover()}
 		</button>
 	{/if}
 {:else}
-	{@render children()}
+	{#if children}
+		{@render children()}
+	{/if}
 {/if}
 
 

--- a/src/global.css
+++ b/src/global.css
@@ -480,7 +480,7 @@ span svg {
 [data-row],
 [data-badge],
 summary {
-	display: inline flex;
+	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	gap: 1em;
@@ -647,6 +647,7 @@ summary {
 	--badge-borderColor: color-mix(in srgb, var(--accent) 40%, transparent);
 	--badge-textColor: currentColor;
 
+	display: inline-flex;
 	flex-shrink: 0;
 	flex-basis: auto;
 

--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -765,19 +765,16 @@ export const formatAttributeGroupTitleText = <Vs extends ValueSet>(
 	attrGroup: AttributeGroup<Vs>,
 	groupScore: MaybeUnratedScore,
 	showScores: boolean,
-) => (
+) =>
 	`${attrGroup.icon} ${attrGroup.displayName}${
-		showScores ?
-			`\n\n${
-				groupScore !== null && groupScore.score !== null ?
-					`${(groupScore.score * 100).toFixed(0)}%${groupScore.hasUnratedComponent ? ' (has unrated components)' : ''}`
-				:
-					'N/A'
-			}`
-		:
-			''
+		showScores
+			? `\n\n${
+					groupScore !== null && groupScore.score !== null
+						? `${(groupScore.score * 100).toFixed(0)}%${groupScore.hasUnratedComponent ? ' (has unrated components)' : ''}`
+						: 'N/A'
+				}`
+			: ''
 	}`
-)
 
 /**
  * Look up an attribute group by ID, verifying that it exists and is not

--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -755,6 +755,31 @@ export const calculateOverallScore = (
 }
 
 /**
+ * Format title text for an attribute group.
+ * @param attrGroup The attribute group to format.
+ * @param groupScore The score for the group, or null if not available.
+ * @param showScores Whether to show scores in the title.
+ * @returns Formatted title text showing icon and score (if enabled) or just display name.
+ */
+export const formatAttributeGroupTitleText = <Vs extends ValueSet>(
+	attrGroup: AttributeGroup<Vs>,
+	groupScore: MaybeUnratedScore,
+	showScores: boolean,
+) => (
+	`${attrGroup.icon} ${attrGroup.displayName}${
+		showScores ?
+			`\n\n${
+				groupScore !== null && groupScore.score !== null ?
+					`${(groupScore.score * 100).toFixed(0)}%${groupScore.hasUnratedComponent ? ' (has unrated components)' : ''}`
+				:
+					'N/A'
+			}`
+		:
+			''
+	}`
+)
+
+/**
  * Look up an attribute group by ID, verifying that it exists and is not
  * entirely exempt from the given EvaluationTree.
  */

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -623,4 +623,19 @@ export function exampleRating<V extends Value>(
  * @returns Formatted title text in the format: "(icon) title [(eval icon) EVAL VALUE]\n\n(displayName)"
  */
 export const formatAttributeTitleText = (attribute: EvaluatedAttribute<Value>, suffix?: string) =>
-	`${attribute.evaluation.value.icon ?? attribute.attribute.icon} ${attribute.attribute.displayName}${suffix ?? ''} [${ratingIcons[attribute.evaluation.value.rating]} ${attribute.evaluation.value.rating}]\n\n${attribute.evaluation.value.displayName}`
+	`${
+		attribute.evaluation.value.icon ?? attribute.attribute.icon
+	} ${
+		attribute.attribute.displayName
+	}${
+		suffix ?? ''
+	} [${
+		ratingIcons[attribute.evaluation.value.rating]
+	} ${
+		attribute.evaluation.value.rating
+	}]${
+		![Rating.EXEMPT, Rating.UNRATED].includes(attribute.evaluation.value.rating) ?
+			`\n\n${attribute.evaluation.value.displayName}`
+		:
+			''
+	}`

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -622,9 +622,5 @@ export function exampleRating<V extends Value>(
  * @param suffix Optional suffix to append to the title.
  * @returns Formatted title text in the format: "(icon) title [(eval icon) EVAL VALUE]\n\n(displayName)"
  */
-export const formatAttributeTitleText = (
-	attribute: EvaluatedAttribute<Value>,
-	suffix?: string,
-) => (
+export const formatAttributeTitleText = (attribute: EvaluatedAttribute<Value>, suffix?: string) =>
 	`${attribute.evaluation.value.icon ?? attribute.attribute.icon} ${attribute.attribute.displayName}${suffix ?? ''} [${ratingIcons[attribute.evaluation.value.rating]} ${attribute.evaluation.value.rating}]\n\n${attribute.evaluation.value.displayName}`
-)

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -623,19 +623,12 @@ export function exampleRating<V extends Value>(
  * @returns Formatted title text in the format: "(icon) title [(eval icon) EVAL VALUE]\n\n(displayName)"
  */
 export const formatAttributeTitleText = (attribute: EvaluatedAttribute<Value>, suffix?: string) =>
-	`${
-		attribute.evaluation.value.icon ?? attribute.attribute.icon
-	} ${
+	`${attribute.evaluation.value.icon ?? attribute.attribute.icon} ${
 		attribute.attribute.displayName
-	}${
-		suffix ?? ''
-	} [${
-		ratingIcons[attribute.evaluation.value.rating]
-	} ${
+	}${suffix ?? ''} [${ratingIcons[attribute.evaluation.value.rating]} ${
 		attribute.evaluation.value.rating
 	}]${
-		![Rating.EXEMPT, Rating.UNRATED].includes(attribute.evaluation.value.rating) ?
-			`\n\n${attribute.evaluation.value.displayName}`
-		:
-			''
+		![Rating.EXEMPT, Rating.UNRATED].includes(attribute.evaluation.value.rating)
+			? `\n\n${attribute.evaluation.value.displayName}`
+			: ''
 	}`

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -615,3 +615,16 @@ export function exampleRating<V extends Value>(
 		sampleEvaluations,
 	}
 }
+
+/**
+ * Format title text for an attribute pie slice.
+ * @param attribute The evaluated attribute to format.
+ * @param suffix Optional suffix to append to the title.
+ * @returns Formatted title text in the format: "(icon) title [(eval icon) EVAL VALUE]\n\n(displayName)"
+ */
+export const formatAttributeTitleText = (
+	attribute: EvaluatedAttribute<Value>,
+	suffix?: string,
+) => (
+	`${attribute.evaluation.value.icon ?? attribute.attribute.icon} ${attribute.attribute.displayName}${suffix ?? ''} [${ratingIcons[attribute.evaluation.value.rating]} ${attribute.evaluation.value.rating}]\n\n${attribute.evaluation.value.displayName}`
+)

--- a/src/schema/score.ts
+++ b/src/schema/score.ts
@@ -40,16 +40,9 @@ export const weightedScore = (scores: NonEmptyArray<WeightedScore>): Score => {
  * @param score The score to format, or null if not available.
  * @returns Formatted string: '❔' for null, '💀' for 0, '💯' for 1, percentage otherwise, with '*' suffix if hasUnratedComponent.
  */
-export const formatScore = (score: MaybeUnratedScore): string => (
-	score !== null && score.score !== null ?
-		`${
-			score.score === 0 ?
-				'💀'
-			: score.score === 1 ?
-				'💯'
-			:
-				(score.score * 100).toFixed(0)
-		}${score.hasUnratedComponent ? '*' : ''}`
-	:
-		'❔'
-)
+export const formatScore = (score: MaybeUnratedScore): string =>
+	score !== null && score.score !== null
+		? `${
+				score.score === 0 ? '💀' : score.score === 1 ? '💯' : (score.score * 100).toFixed(0)
+			}${score.hasUnratedComponent ? '*' : ''}`
+		: '❔'

--- a/src/schema/score.ts
+++ b/src/schema/score.ts
@@ -34,3 +34,22 @@ export const weightedScore = (scores: NonEmptyArray<WeightedScore>): Score => {
 
 	return totalScore / totalWeight
 }
+
+/**
+ * Format a score for display in the UI.
+ * @param score The score to format, or null if not available.
+ * @returns Formatted string: '❔' for null, '💀' for 0, '💯' for 1, percentage otherwise, with '*' suffix if hasUnratedComponent.
+ */
+export const formatScore = (score: MaybeUnratedScore): string => (
+	score !== null && score.score !== null ?
+		`${
+			score.score === 0 ?
+				'💀'
+			: score.score === 1 ?
+				'💯'
+			:
+				(score.score * 100).toFixed(0)
+		}${score.hasUnratedComponent ? '*' : ''}`
+	:
+		'❔'
+)

--- a/src/schema/stages.ts
+++ b/src/schema/stages.ts
@@ -147,7 +147,7 @@ export interface WalletStageGroup {
  */
 export interface WalletStage {
 	/** An ID for this stage. */
-	id: string
+	id: `stage:${string}`
 
 	/** A human-readable label for this stage (e.g., "Stage 0", "Stage 1"). */
 	label: string

--- a/src/schema/stages/software-wallet-stages.ts
+++ b/src/schema/stages/software-wallet-stages.ts
@@ -34,7 +34,7 @@ import { WalletType, walletTypeToVariants } from '../wallet-types'
 export const softwareWalletVariants = walletTypeToVariants(WalletType.SOFTWARE)
 
 export const softwareWalletStageZero: WalletStage = {
-	id: 'software_stage_0',
+	id: 'stage:software-0',
 	label: 'Stage 0',
 	description: sentence('The wallet meets the minimum criteria for evaluation.'),
 	criteriaGroups: [
@@ -56,7 +56,7 @@ export const softwareWalletStageZero: WalletStage = {
 }
 
 export const softwareWalletStageOne: WalletStage = {
-	id: 'software_stage_1',
+	id: 'stage:software-1',
 	label: 'Stage 1',
 	description: sentence('The wallet has made a minimal commitment to Ethereum values.'),
 	criteriaGroups: [
@@ -271,7 +271,7 @@ export const softwareWalletStageOne: WalletStage = {
 }
 
 const softwareWalletStageTwo: WalletStage = {
-	id: 'software_stage_2',
+	id: 'stage:software-2',
 	label: 'Stage 2',
 	description: sentence('The wallet has made a significant commitment to Ethereum values.'),
 	criteriaGroups: [

--- a/src/utils/stage-attributes.ts
+++ b/src/utils/stage-attributes.ts
@@ -84,7 +84,10 @@ const isAttributeUsedInStageObject = (attribute: Attribute, stage: WalletStage):
  * @param stageId The stage ID to check
  * @returns true if the attribute is used in the stage
  */
-export const isAttributeUsedInStage = (attribute: Attribute, stageId: string): boolean => {
+export const isAttributeUsedInStage = (
+	attribute: Attribute,
+	stageId: WalletStage['id'],
+): boolean => {
 	const stage = stagesById.get(stageId)
 
 	return stage !== undefined && isAttributeUsedInStageObject(attribute, stage)

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -94,10 +94,7 @@
 
 		<div data-row="gap-2">
 			{#if relevantStages.length > 0 && firstStage && ladderEvaluation}
-				<Tooltip
-					buttonTriggerPlacement="behind"
-					hoverTriggerPlacement="around"
-				>
+				<Tooltip>
 					<a
 						href={`/${wallet.metadata.id}/${variant ? `?variant=${variant}` : ''}#${firstStage.id}`}
 						data-link="camouflaged"

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -94,13 +94,12 @@
 
 		<div data-row="gap-2">
 			{#if relevantStages.length > 0 && firstStage && ladderEvaluation}
-				{@const stageNumber = relevantStages[0]}
 				<Tooltip
 					buttonTriggerPlacement="behind"
 					hoverTriggerPlacement="around"
 				>
 					<a
-						href={`/${wallet.metadata.id}/${variant ? `?variant=${variant}` : ''}#stage-${stageNumber}`}
+						href={`/${wallet.metadata.id}/${variant ? `?variant=${variant}` : ''}#${firstStage.id}`}
 						data-link="camouflaged"
 						title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
 					>

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -329,14 +329,15 @@
 				>
 					{#if showStage}
 						{@const { stage, ladderEvaluation } = getWalletStageAndLadder(wallet)}
+
 						{#if stage !== null && ladderEvaluation !== null}
-							<Tooltip
-								buttonTriggerPlacement="behind"
-								hoverTriggerPlacement="around"
-							>
-								{#snippet children()}
-									<WalletStageBadge {stage} {ladderEvaluation} size="large" />
-								{/snippet}
+							<Tooltip>
+								<WalletStageBadge
+									{stage}
+									{ladderEvaluation}
+									size="large"
+								/>
+
 								{#snippet TooltipContent()}
 									<WalletStageSummary {wallet} {stage} {ladderEvaluation} />
 								{/snippet}
@@ -714,10 +715,7 @@
 									{@const stageNumber = relevantStages[0]}
 									{@const stage = ladderEvaluation?.ladder.stages[stageNumber]}
 									{#if stage && ladderEvaluation}
-										<Tooltip
-											buttonTriggerPlacement="behind"
-											hoverTriggerPlacement="around"
-										>
+										<Tooltip>
 											{#snippet children()}
 												<a
 													href={`#${stage.id}`}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -691,28 +691,30 @@
 							</a>
 
 							{#if true}
-								{@const attributeStages = getAttributeStages(attribute)}
 								{@const { ladderEvaluation } = getWalletStageAndLadder(wallet)}
-								{@const relevantStages = (() => {
-									if (!ladderEvaluation) {
-										return []
-									}
-									const ladderType = (() => {
-										for (const [type, evaluation] of Object.entries(wallet.ladders)) {
-											if (evaluation === ladderEvaluation) {
-												return type as WalletLadderType
-											}
-										}
-										return null
-									})()
-									if (!ladderType) {
-										return []
-									}
-									const stagesForLadder = attributeStages.find(s => s.ladderType === ladderType)
-									return stagesForLadder?.stageNumbers ?? []
-								})()}
-								{#if relevantStages.length > 0}
-									{@const stageNumber = relevantStages[0]}
+
+								{@const ladderType = (
+									ladderEvaluation ?
+										Object.entries(wallet.ladders)
+											.find(([_, evaluation]) => evaluation === ladderEvaluation)
+											?.[0] as WalletLadderType | undefined
+									:
+										undefined
+								)}
+
+								{@const attributeStages = getAttributeStages(attribute)}
+
+								{@const stageNumbers = (
+									ladderType &&
+										attributeStages
+											.find(stage => stage.ladderType === ladderType)
+											?.stageNumbers
+									||
+										[]
+								)}
+
+								{#if stageNumbers.length > 0}
+									{@const stageNumber = stageNumbers[0]}
 									{@const stage = ladderEvaluation?.ladder.stages[stageNumber]}
 
 									{#if stage && ladderEvaluation}
@@ -720,13 +722,13 @@
 											<a
 												href={`#${stage.id}`}
 												data-link="camouflaged"
-												title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
+												title={`This attribute is required for stage${stageNumbers.length > 1 ? 's' : ''} ${stageNumbers.join(', ')}`}
 											>
 												<div
 													data-badge="small"
 													style:--accent="var(--accent-color)"
 												>
-													<small>Stage {relevantStages.join(', ')}</small>
+													<small>Stage {stageNumbers.join(', ')}</small>
 												</div>
 											</a>
 
@@ -743,13 +745,13 @@
 										<a
 											href={`#${stage.id}`}
 											data-link="camouflaged"
-											title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
+											title={`This attribute is required for stage${stageNumbers.length > 1 ? 's' : ''} ${stageNumbers.join(', ')}`}
 										>
 											<div
 												data-badge="small"
 												style:--accent="var(--accent-color)"
 											>
-												<small>Stage {relevantStages.join(', ')}</small>
+												<small>Stage {stageNumbers.join(', ')}</small>
 											</div>
 										</a>
 									{/if}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -714,22 +714,22 @@
 								{#if relevantStages.length > 0}
 									{@const stageNumber = relevantStages[0]}
 									{@const stage = ladderEvaluation?.ladder.stages[stageNumber]}
+
 									{#if stage && ladderEvaluation}
 										<Tooltip>
-											{#snippet children()}
-												<a
-													href={`#${stage.id}`}
-													data-link="camouflaged"
-													title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
+											<a
+												href={`#${stage.id}`}
+												data-link="camouflaged"
+												title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
+											>
+												<div
+													data-badge="small"
+													style:--accent="var(--accent-color)"
 												>
-													<div
-														data-badge="small"
-														style:--accent="var(--accent-color)"
-													>
-														<small>Stage {relevantStages.join(', ')}</small>
-													</div>
-												</a>
-											{/snippet}
+													<small>Stage {relevantStages.join(', ')}</small>
+												</div>
+											</a>
+
 											{#snippet TooltipContent()}
 												<WalletStageSummary 
 													{wallet} 

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -28,6 +28,7 @@
 		attributeTree,
 		calculateAttributeGroupScore,
 		calculateOverallScore,
+		formatAttributeGroupTitleText,
 	} from '@/schema/attribute-groups'
 	import { toFullyQualified } from '@/schema/reference'
 	import { getAttributeOverride } from '@/schema/wallet'
@@ -131,6 +132,10 @@
 	const overallScore = $derived(
 		calculateOverallScore(wallet.overall, () => true),
 	)
+
+
+	// Functions
+	import { formatAttributeTitleText } from '@/schema/attributes'
 
 
 	// Components
@@ -497,7 +502,7 @@
 				data-scroll-item="inline-detached"
 			>
 				<a data-link="camouflaged" href={`#${slugifyCamelCase(attrGroup.id)}`}>
-					<h2>
+					<h2 title={formatAttributeGroupTitleText(attrGroup, score, showScores)}>
 						{attrGroup.displayName}
 					</h2>
 				</a>
@@ -531,6 +536,8 @@
 							data-row-item="wrap-center"
 						>
 							<Pie
+								title={formatAttributeGroupTitleText(attrGroup, score, showScores)}
+
 								layout={PieLayout.FullTop}
 								radius={120}
 								padding={20}
@@ -540,6 +547,7 @@
 									gap: 8,
 									angleGap: 0,
 								}]}
+
 								slices={
 									attributes
 										.map(({ attribute, evalAttr }) => ({
@@ -547,8 +555,7 @@
 											color: ratingToColor(evalAttr.evaluation.value.rating),
 											weight: attrGroup.attributeWeights[attribute.id],
 											arcLabel: evalAttr.evaluation.value.icon ?? evalAttr.attribute.icon,
-											tooltip: attribute.displayName,
-											tooltipValue: evalAttr.evaluation.value.rating,
+											titleText: formatAttributeTitleText(evalAttr),
 											href: `#${slugifyCamelCase(attribute.id)}`,
 										}))
 								}
@@ -565,7 +572,7 @@
 										r="8"
 										fill={scoreColor}
 									>
-										{#if score?.hasUnratedComponent}
+										{#if showScores && score?.hasUnratedComponent}
 											<title>
 												*contains unrated components
 											</title>
@@ -674,7 +681,10 @@
 					<div data-row-item="flexible basis-2">
 						<div data-row="start gap-2 wrap">
 							<a data-link="camouflaged" href={`#${slugifyCamelCase(attribute.id)}`}>
-								<h3 data-icon={attribute.icon}>
+								<h3
+									data-icon={attribute.icon}
+									title={formatAttributeTitleText(evalAttr)}
+								>
 									{attribute.displayName}
 								</h3>
 							</a>

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -437,8 +437,8 @@
 					data-row
 					data-scroll-item="inline-detached"
 				>
-					<a data-link="camouflaged" href="#stage-requirements">
-						<h2>Stage Progress</h2>
+					<a data-link="camouflaged" href="#stages">
+						<h2 id="stages">Stage Progress</h2>
 					</a>
 				</header>
 
@@ -720,7 +720,7 @@
 										>
 											{#snippet children()}
 												<a
-													href={`#stage-${stageNumber}`}
+													href={`#${stage.id}`}
 													data-link="camouflaged"
 													title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
 												>
@@ -741,9 +741,9 @@
 												/>
 											{/snippet}
 										</Tooltip>
-									{:else}
+									{:else if stage}
 										<a
-											href={`#stage-${stageNumber}`}
+											href={`#${stage.id}`}
 											data-link="camouflaged"
 											title={`This attribute is required for stage${relevantStages.length > 1 ? 's' : ''} ${relevantStages.join(', ')}`}
 										>

--- a/src/views/WalletStageBadge.svelte
+++ b/src/views/WalletStageBadge.svelte
@@ -54,13 +54,11 @@
 	style:--accent={stageColor}
 >
 	{#if stageValue === 'NOT_APPLICABLE'}
-		<small>N/A</small>
+		N/A
 	{:else if stageValue === 'QUALIFIED_FOR_NO_STAGES'}
-		<small>No Stage</small>
+		No Stage
 	{:else if stage && typeof stage === 'object'}
-		<strong>
-			{stage.label}
-		</strong>
+		{stage.label}
 	{/if}
 </data>
 
@@ -70,6 +68,12 @@
 		&[value='NO_STAGES'],
 		&[value='NOT_APPLICABLE'] {
 			--accent: var(--rating-unrated);
+		}
+
+		&[value='NO_STAGES'] {
+			border-style: dashed;
+			background-color: color-mix(in oklch, var(--background-tertiary) 75%, transparent);
+			color: color-mix(in oklch, var(--text-primary) 85%, transparent);
 		}
 	}
 </style>

--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -134,7 +134,7 @@
 				)}
 
 				<details
-					id={`stage-${stageIndex}`}
+					id={s.id}
 					open={isDefaultOpen}
 					data-card="radius-8 padding-6 {isCurrent ? 'border-accent' : ''}"
 					data-column="gap-0"
@@ -145,7 +145,7 @@
 						<div data-row="wrap wrap-first-last">
 							<a
 								data-link="camouflaged"
-								href={`#stage-${stageIndex}`}
+								href={`#${s.id}`}
 							>
 								<data
 									data-badge="medium"

--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -83,7 +83,7 @@
 		!ladderDefinition ?
 			null
 		: currentStageIndex === null ?
-			ladderDefinition.stages.length - 1
+			0
 		:
 			(currentStageIndex + 1 < ladderDefinition.stages.length ? currentStageIndex + 1 : ladderDefinition.stages.length - 1)
 	)

--- a/src/views/WalletStageSummary.svelte
+++ b/src/views/WalletStageSummary.svelte
@@ -261,6 +261,10 @@
 
 
 <style>
+	section {
+		text-align: start;
+	}
+
 	button {
 		background: none;
 		border: none;

--- a/src/views/WalletStageSummary.svelte
+++ b/src/views/WalletStageSummary.svelte
@@ -21,13 +21,11 @@
 		stage,
 		ladderEvaluation,
 		showNextStageCriteria = true,
-		onStageClick,
 	}: {
 		wallet: RatedWallet
 		stage: WalletStage | 'NOT_APPLICABLE' | 'QUALIFIED_FOR_NO_STAGES' | null
 		ladderEvaluation: WalletLadderEvaluation | null
 		showNextStageCriteria?: boolean
-		onStageClick?: (stageIndex: number) => void
 	} = $props()
 
 
@@ -117,21 +115,6 @@
 	)
 
 
-	// Actions
-	const handleBadgeClick = (clickedStage: WalletStage | null) => (e: MouseEvent) => {
-		e.preventDefault()
-		e.stopPropagation()
-
-		if (clickedStage && ladderDefinition) {
-			const stageIndex = ladderDefinition.stages.findIndex(stage => stage.id === clickedStage.id)
-
-			if (stageIndex >= 0) {
-				onStageClick?.(stageIndex)
-			}
-		}
-	}
-
-
 	// Components
 	import Typography from '@/components/Typography.svelte'
 	import WalletStageBadge from './WalletStageBadge.svelte'
@@ -151,27 +134,28 @@
 	{:else if stage === 'QUALIFIED_FOR_NO_STAGES'}
 		<header data-column="gap-2">
 			<h3 data-row="gap-2">
-				{#if onStageClick}
-					<button type="button" onclick={handleBadgeClick(stage0)}>
-						<WalletStageBadge stage={stage} ladderEvaluation={ladderEvaluation} size="large" />
-					</button>
-				{:else}
-					<WalletStageBadge stage={stage} ladderEvaluation={ladderEvaluation} size="large" />
-				{/if}
+				<a data-link="camouflaged" href={`/${wallet.metadata.id}/#stages`}>
+					<WalletStageBadge
+						stage={stage}
+						ladderEvaluation={ladderEvaluation}
+						size="large"
+					/>
+				</a>
 			</h3>
 		</header>
 	{:else if displayStage}
 		<header data-column="gap-2">
 			<h3 data-row="gap-2 start">
-				{#if onStageClick}
-					<button type="button" onclick={handleBadgeClick(displayStage)}>
-						<WalletStageBadge stage={displayStage} ladderEvaluation={ladderEvaluation} size="large" />
-					</button>
-				{:else}
-					<a data-link="camouflaged" href={`/${wallet.metadata.id}/#stage-${displayStage.id}`}>
-						<WalletStageBadge stage={displayStage} ladderEvaluation={ladderEvaluation} size="large" />
-					</a>
-				{/if}
+				<a
+					data-link="camouflaged"
+					href={`/${wallet.metadata.id}/#${displayStage.id}`}
+				>
+					<WalletStageBadge
+						stage={displayStage}
+						ladderEvaluation={ladderEvaluation}
+						size="large"
+					/>
+				</a>
 				{#if isTypographicContent(displayStage.description)}
 					<Typography content={displayStage.description} />
 				{:else}
@@ -190,16 +174,16 @@
 			{#if showNextStageCriteria && targetStage && typeof targetStage === 'object'}
 				<h4>
 					Criteria needed to advance to
-					{#if onStageClick}
-						<button type="button" onclick={handleBadgeClick(targetStage)}>
-							<WalletStageBadge stage={targetStage} ladderEvaluation={ladderEvaluation} size="medium" />
-						</button>
-					{:else}
-						<a data-link="camouflaged" href={`/${wallet.metadata.id}/#stage-${targetStage.id}`}>
-							<WalletStageBadge stage={targetStage} ladderEvaluation={ladderEvaluation} size="large" />
-						</a>
-					{/if}
-					:
+					<a
+						data-link="camouflaged"
+						href={`/${wallet.metadata.id}/#${targetStage.id}`}
+					>
+						<WalletStageBadge
+							stage={targetStage}
+							ladderEvaluation={ladderEvaluation}
+							size="medium"
+						/>
+					</a>:
 				</h4>
 			{/if}
 
@@ -263,12 +247,6 @@
 <style>
 	section {
 		text-align: start;
-	}
-
-	button {
-		background: none;
-		border: none;
-		padding: 0;
 	}
 
 	li > span > span:last-child {

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -594,31 +594,32 @@
 					{:else}
 						{@const stageValue = typeof stage === 'string' ? stage : stage.id}
 						{@const stageFilterId = `stage-${stageValue}`}
-						<Tooltip
-							buttonTriggerPlacement="behind"
-							hoverTriggerPlacement="around"
-						>
-							{#snippet children()}
-								<div
-									role="button"
-									tabindex="0"
-									aria-label={stage === 'QUALIFIED_FOR_NO_STAGES' ? 'Filter by No Stage' : stage && typeof stage === 'object' ? `Filter by ${stage.label}` : 'Filter by stage'}
-									onclick={(e) => {
-										e.preventDefault()
-										e.stopPropagation()
-										toggleAttributeFilterById?.(stageFilterId)
-									}}
-									onkeydown={(e) => {
-										if (e.key !== 'Enter' && e.key !== ' ') return
 
-										e.preventDefault()
-										e.stopPropagation()
-										toggleAttributeFilterById?.(stageFilterId)
-									}}
-								>
-									<WalletStageBadge {stage} {ladderEvaluation} size="medium" />
-								</div>
-							{/snippet}
+						<Tooltip>
+							<div
+								role="button"
+								tabindex="0"
+								aria-label={stage === 'QUALIFIED_FOR_NO_STAGES' ? 'Filter by No Stage' : stage && typeof stage === 'object' ? `Filter by ${stage.label}` : 'Filter by stage'}
+								onclick={(e) => {
+									e.preventDefault()
+									e.stopPropagation()
+									toggleAttributeFilterById?.(stageFilterId)
+								}}
+								onkeydown={(e) => {
+									if (e.key !== 'Enter' && e.key !== ' ') return
+
+									e.preventDefault()
+									e.stopPropagation()
+									toggleAttributeFilterById?.(stageFilterId)
+								}}
+							>
+								<WalletStageBadge
+									{stage}
+									{ladderEvaluation}
+									size="medium"
+								/>
+							</div>
+
 							{#snippet TooltipContent()}
 								<WalletStageSummary
 									{wallet}

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1401,6 +1401,10 @@
 
 						transition-property: opacity, scale, min-block-size, padding-block-end;
 						min-block-size: var(--walletTable-rowClosed-blockSize);
+
+						> :global(:first-child) {
+							flex: 1;
+						}
 					}
 
 					&:open summary {

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -624,11 +624,6 @@
 									{wallet}
 									{stage}
 									{ladderEvaluation}
-									onStageClick={n => {
-										if (ladderEvaluation && n !== null && n < ladderEvaluation.ladder.stages.length) {
-											toggleAttributeFilterById?.(stageFilterId)
-										}
-									}}
 								/>
 							{/snippet}
 						</Tooltip>

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1367,6 +1367,12 @@
 		}
 	}
 
+	@media (scripting: none) {
+		.filters {
+			display: none;
+		}
+	}
+
 	:global {
 		.wallet-table {
 			tr {

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -247,7 +247,7 @@
 	import Filters from '@/components/Filters.svelte'
 	import Pie, { PieLayout } from '@/components/Pie.svelte'
 	import Select from '@/components/Select.svelte'
-	import Table, { SortDirection } from '@/components/Table.svelte'
+	import Table, { ColumnAlignment, SortDirection } from '@/components/Table.svelte'
 	import Tooltip from '@/components/Tooltip.svelte'
 	import TooltipOrAccordion from '@/components/TooltipOrAccordion.svelte'
 	import WalletStageSummary from './WalletStageSummary.svelte'
@@ -482,9 +482,12 @@
 									const attrGroupScore = calculateAttributeGroupScore(attrGroup.attributeWeights, wallet.overall[attrGroup.id])
 									return attrGroupScore === null ? null : attrGroupScore.score
 								},
+
 								sort: {
 									defaultDirection: SortDirection.Descending,
 								},
+
+								align: ColumnAlignment.Center,
 
 								subcolumns: (
 									Object.entries(attrGroup.attributes)
@@ -531,6 +534,8 @@
 							sort: {
 								defaultDirection: SortDirection.Descending,
 							},
+
+							align: ColumnAlignment.Center,
 						} satisfies Column<RatedWallet>]),
 
 						(
@@ -550,6 +555,8 @@
 										isDefault: true,
 										defaultDirection: SortDirection.Descending,
 									},
+
+									align: ColumnAlignment.Center,
 
 									subcolumns: attrGroupColumns,
 									isDefaultExpanded: true,

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -199,6 +199,26 @@
 		})
 	)
 
+	const attributesExemptForAllWallets = $derived(
+		new Set(
+			attributeGroups.flatMap(attrGroup =>
+				Object.keys(attrGroup.attributes)
+					.filter(attributeId => {
+						const walletsWithAttribute = filteredWallets.filter(wallet =>
+							wallet.overall[attrGroup.id]?.[attributeId] !== undefined
+						)
+						return (
+							walletsWithAttribute.length > 0 &&
+							walletsWithAttribute.every(wallet =>
+								wallet.overall[attrGroup.id]?.[attributeId]?.evaluation?.value?.rating === Rating.EXEMPT
+							)
+						)
+					})
+					.map(attributeId => `${attrGroup.id}.${attributeId}`)
+			)
+		)
+	)
+
 
 	// Functions
 	import { variantToName } from '@/constants/variants'
@@ -966,8 +986,14 @@
 												children: (
 													evaluatedAttributesEntries(evalGroup)
 														.filter(([attributeId, attribute]) => (
-															attribute?.evaluation?.value?.rating !== Rating.EXEMPT &&
-															(overallFilteredAttributeIds === null || overallFilteredAttributeIds.has(`${attrGroup.id}.${attributeId}`))
+															(
+																attribute?.evaluation?.value?.rating !== Rating.EXEMPT
+																|| !attributesExemptForAllWallets.has(`${attrGroup.id}.${attributeId}`)
+															)
+															&& (
+																overallFilteredAttributeIds === null
+																|| overallFilteredAttributeIds.has(`${attrGroup.id}.${attributeId}`)
+															)
 														))
 														.map(([attributeId, attribute]) => ({
 															id: `attrGroup_${attrGroup.id}__attr_${attributeId}`,
@@ -975,6 +1001,9 @@
 															weight: attrGroup.attributeWeights[attributeId],
 															arcLabel: attribute.evaluation.value.icon ?? attribute.attribute.icon,
 															titleText: formatAttributeTitleText(attribute),
+															...attribute.evaluation.value.rating === Rating.EXEMPT && {
+																opacity: 0.33,
+															},
 														}))
 												),
 											},
@@ -1104,11 +1133,19 @@
 						{@const filteredAttributeIds = attributeActiveFilters.size > 0 ? new Set(
 							filteredAttributes.map(a => `${a.attributeGroupId}.${a.attributeId}`)
 						) : null}
-						{@const evalEntries = evaluatedAttributesEntries(evalGroup)
-							.filter(([attributeId, attribute]) => (
-								attribute?.evaluation?.value?.rating !== Rating.EXEMPT &&
-								(filteredAttributeIds === null || filteredAttributeIds.has(`${attrGroup.id}.${attributeId}`))
-							))}
+						{@const evalEntries = (
+							evaluatedAttributesEntries(evalGroup)
+								.filter(([attributeId, attribute]) => (
+									(
+										attribute?.evaluation?.value?.rating !== Rating.EXEMPT
+										|| !attributesExemptForAllWallets.has(`${attrGroup.id}.${attributeId}`)
+									)
+									&& (
+										filteredAttributeIds === null
+										|| filteredAttributeIds.has(`${attrGroup.id}.${attributeId}`)
+									)
+								))
+						)}
 
 						{@const hasActiveAttribute = activeEntityId?.walletId === wallet.metadata.id && activeEntityId?.attributeGroupId === attrGroup.id}
 
@@ -1181,6 +1218,9 @@
 												weight: attrGroup.attributeWeights[attributeId],
 												arcLabel: icon,
 												titleText: formatAttributeTitleText(attribute, tooltipSuffix),
+												...attribute.evaluation.value.rating === Rating.EXEMPT && {
+													opacity: 0.33,
+												},
 											}
 										}
 									)
@@ -1364,12 +1404,6 @@
 			--scrollItem-inlineDetached-maxSize: 60.5rem;
 			--scrollItem-inlineDetached-paddingStart: clamp(1.5rem, 0.04 * var(--scrollContainer-sizeInline), 3rem);
 			--scrollItem-inlineDetached-paddingEnd: clamp(1.5rem, 0.04 * var(--scrollContainer-sizeInline), 3rem);
-		}
-	}
-
-	@media (scripting: none) {
-		.filters {
-			display: none;
 		}
 	}
 

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -204,6 +204,7 @@
 	import { variantToName } from '@/constants/variants'
 	import { calculateAttributeGroupScore, calculateOverallScore, formatAttributeGroupTitleText } from '@/schema/attribute-groups'
 	import { evaluatedAttributesEntries, ratingToColor, formatAttributeTitleText } from '@/schema/attributes'
+	import { formatScore } from '@/schema/score'
 	import { isLabeledUrl } from '@/schema/url'
 	import { hasVariant } from '@/schema/variants'
 	import { attributeVariantSpecificity, VariantSpecificity,walletSupportedAccountTypes } from '@/schema/wallet'
@@ -1029,24 +1030,7 @@
 										{/if}
 									{:else if summaryVisualization === SummaryVisualization.Score}
 										<text>
-											{
-												score !== null && score.score !== null ?
-													`${
-														score.score === 0 ?
-															'\u{1f480}'
-														: score.score === 1 ?
-															'\u{1f4af}'
-														:
-															(score.score * 100).toFixed(0)
-													}${
-														score !== null && score.hasUnratedComponent ?
-															'*'
-														:
-															''
-													}`
-												:
-													'❔'
-											}
+											{formatScore(score)}
 										</text>
 									{:else if summaryVisualization === SummaryVisualization.ScoreDot}
 										<circle
@@ -1253,19 +1237,7 @@
 										</text>
 									{:else if summaryVisualization === SummaryVisualization.Score}
 										<text>
-											{
-												groupScore !== null && groupScore.score !== null ?
-													`${
-														groupScore.score === 0 ?
-															'\u{1f480}'
-														: groupScore.score === 1 ?
-															'\u{1f4af}'
-														:
-															(groupScore.score * 100).toFixed(0)
-													}${groupScore.hasUnratedComponent ? '*' : ''}`
-												:
-													'❔'
-											}
+											{formatScore(groupScore)}
 										</text>
 									{:else if summaryVisualization === SummaryVisualization.ScoreDot}
 										<circle

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -202,8 +202,8 @@
 
 	// Functions
 	import { variantToName } from '@/constants/variants'
-	import { calculateAttributeGroupScore, calculateOverallScore } from '@/schema/attribute-groups'
-	import { evaluatedAttributesEntries, ratingToColor } from '@/schema/attributes'
+	import { calculateAttributeGroupScore, calculateOverallScore, formatAttributeGroupTitleText } from '@/schema/attribute-groups'
+	import { evaluatedAttributesEntries, ratingToColor, formatAttributeTitleText } from '@/schema/attributes'
 	import { isLabeledUrl } from '@/schema/url'
 	import { hasVariant } from '@/schema/variants'
 	import { attributeVariantSpecificity, VariantSpecificity,walletSupportedAccountTypes } from '@/schema/wallet'
@@ -959,16 +959,10 @@
 												:
 													'var(--rating-unrated)'
 											),
-											tooltip: attrGroup.displayName,
-											tooltipValue: (
-												groupScore !== null && groupScore.score !== null ?
-													`${
-														(groupScore.score * 100).toFixed(0)
-													}%${
-														groupScore.hasUnratedComponent ? ' (has unrated components)' : ''
-													}`
-												:
-													'N/A'
+											titleText: formatAttributeGroupTitleText(
+												attrGroup,
+												groupScore,
+												summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.ScoreDot,
 											),
 											weight: 1,
 											...evalGroup && {
@@ -983,8 +977,7 @@
 															color: ratingToColor(attribute.evaluation.value.rating),
 															weight: attrGroup.attributeWeights[attributeId],
 															arcLabel: attribute.evaluation.value.icon ?? attribute.attribute.icon,
-															tooltip: `${attribute.attribute.displayName}`,
-															tooltipValue: ratingIcons[attribute.evaluation.value.rating],
+															titleText: formatAttributeTitleText(attribute),
 														}))
 												),
 											},
@@ -1155,6 +1148,14 @@
 							}
 						>
 							<Pie
+								title={
+									formatAttributeGroupTitleText(
+										attrGroup,
+										groupScore,
+										summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.ScoreDot,
+									)
+								}
+
 								layout={PieLayout.FullTop}
 								radius={44}
 								levels={[
@@ -1199,8 +1200,7 @@
 												color: ratingToColor(attribute.evaluation.value.rating),
 												weight: attrGroup.attributeWeights[attributeId],
 												arcLabel: icon,
-												tooltip: `${icon} ${attribute.evaluation.value.displayName}${tooltipSuffix}`,
-												tooltipValue: ratingIcons[attribute.evaluation.value.rating],
+												titleText: formatAttributeTitleText(attribute, tooltipSuffix),
 											}
 										}
 									)
@@ -1325,6 +1325,8 @@
 							}
 						>
 							<Pie
+								title={formatAttributeTitleText(attribute)}
+
 								layout={PieLayout.HalfTop}
 								radius={24}
 								levels={
@@ -1360,8 +1362,7 @@
 												color: ratingToColor(attribute.evaluation.value.rating),
 												weight: 1,
 												arcLabel: attribute.icon,
-												tooltip: `${attribute.icon} ${attribute.displayName}`,
-												tooltipValue: attribute.evaluation.value.rating,
+												titleText: formatAttributeTitleText(attribute),
 											}
 										]
 									:

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -920,6 +920,24 @@
 								filteredAttributes.map(a => `${a.attributeGroupId}.${a.attributeId}`)
 							) : null}
 							<Pie
+								layout={PieLayout.FullTop}
+								padding={8}
+								radius={80}
+								levels={[
+									{
+										outerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.7 : 0.65,
+										innerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.3 : 0.1,
+										gap: 4,
+										angleGap: 0
+									},
+									{
+										outerRadiusFraction: 1,
+										innerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.725 : 0.675,
+										gap: 2,
+										angleGap: 0,
+									}
+								]}
+
 								slices={
 									displayedAttributeGroups.map(attrGroup => {
 										const groupScore = calculateAttributeGroupScore(attrGroup.attributeWeights, wallet.overall[attrGroup.id])
@@ -966,23 +984,7 @@
 										}
 									})
 								}
-								layout={PieLayout.FullTop}
-								padding={8}
-								radius={80}
-								levels={[
-									{
-										outerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.7 : 0.65,
-										innerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.3 : 0.1,
-										gap: 4,
-										angleGap: 0
-									},
-									{
-										outerRadiusFraction: 1,
-										innerRadiusFraction: (summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.Stage) ? 0.725 : 0.675,
-										gap: 2,
-										angleGap: 0,
-									}
-								]}
+
 								{highlightedSliceId}
 								onSliceClick={sliceId => {
 									const [_attributeGroupId, attributeId] = sliceId.split('__').map(part => part.split('_')[1])
@@ -1157,6 +1159,7 @@
 									}
 								]}
 								padding={4}
+
 								slices={
 									!isNonEmptyArray(evalEntries) ?
 										[]
@@ -1339,6 +1342,9 @@
 									:
 										24
 								}
+
+								centerLabel={attribute.evaluation.value.rating}
+
 								slices={
 									attribute.evaluation.value.rating !== Rating.EXEMPT ?
 										[
@@ -1355,7 +1361,7 @@
 										[]
 								}
 								{highlightedSliceId}
-								centerLabel={attribute.evaluation.value.rating}
+
 								class="wallet-attribute-rating-pie"
 							/>
 


### PR DESCRIPTION
Dozens of quality-of-life fixes and progressive enhancements related to wallet attributes and stages.

<img width="1450" height="1295" alt="Screenshot 2026-01-15 at 08 12 13" src="https://github.com/user-attachments/assets/bd184c6d-19b0-43c1-929d-2326c8181436" />


## Views

* `<WalletPage>` / `<WalletTable>`:
    * standardize `title` attributes across text headings / pies / pie slices for wallet attributes / wallet attribute groups (fixes https://github.com/walletbeat/walletbeat/issues/350)

* `<WalletAttributeSummary>` / `<WalletPage>` / `<WalletTable>`:
  * use default `<Tooltip>` display settings (friendliest for no-JavaScript users)

* `<WalletTable>`:
    * show exempt attributes in attribute group `<Pie>`s if not exempt for at least one other filtered wallet (fixes https://github.com/walletbeat/walletbeat/issues/393)
    * set column alignments
    * hide interactive `<Filters>` if user has JavaScript disabled
    * add helper function for displaying legacy scores

* `<WalletStageSummary>` / `<WalletPage>`:
    * anchor link all stage badges to relevant sections within `<WalletStageOverview>`

* `<WalletStageOverview>`:
    * open the first stage by default if no stages apply

* `<WalletStageBadge>`:
    * improve styling for "No Stage" and "N/A" cases

* `<WalletPage>`:
    * improve derivation of relevant stages from attribute

## Data

* Stages
    * introduce `stage:` prefix for all `id`s

## Components

* `<Tooltip>`:
    * default to use Floating UI (native CSS anchor positioning doesn't seem to account for scroll position of anchor)
      * configure shift padding so tooltip stays in the viewport
      * fall back to native CSS anchor positioning when JavaScript is disabled / hasn't yet loaded
    * use `display: inline grid` for trigger
    * use `position: fixed` for tooltip
    * make `children` / `TooltipContent` snippets optional

* `<Pie>`:
    * improve slice label positioning formula – centroid of annular sector clamped between lower bound (geometric mean of inner and outer radii inset by label size) and upper bound (outer radius inset by label size)
    * accept single `titleText` prop per slice
    * accept SVG-level title
    * configure `opacity` per-slice

* `<Table>`:
    * make column alignment configurable

## Style primitives

* `[data-row]`
    * use `display: flex`

* `[data-badge]`
    * use `display: inline-flex`
