### PR TITLE
Mobile layout / interaction + iOS Safari improvements

### DIFF
--- a/src/components/Table.svelte
+++ b/src/components/Table.svelte
@@ -527,7 +527,7 @@
 						<div data-sticky-container>
 							{#if isSortable}
 								<label class="sort-label" data-pressable="to-containing">
-									<span data-sticky="no-backdrop">
+									<span data-sticky="backdrop-none">
 										{@render HeaderTitle()}
 
 										<button

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -64,10 +64,10 @@
 	let isPopoverHovered = $state(false)
 
 	const hoverTriggerEvents = {
-		onmouseenter: () => {
+		onpointerenter: () => {
 			isTriggerHovered = true
 		},
-		onmouseleave: () => {
+		onpointerleave: () => {
 			isTriggerHovered = false
 		},
 		onfocus: () => {
@@ -151,10 +151,10 @@
 			popover="auto"
 			id={popoverId}
 
-			onmouseenter={() => {
+			onpointerenter={() => {
 				isPopoverHovered = true
 			}}
-			onmouseleave={() => {
+			onpointerleave={() => {
 				isPopoverHovered = false
 			}}
 			{@attach node => {

--- a/src/components/Tooltip.svelte
+++ b/src/components/Tooltip.svelte
@@ -254,6 +254,7 @@
 
 		margin: var(--offset);
 		width: max-content;
+		max-width: calc(100vw - var(--offset) * 2);
 
 		background-color: var(--popover-backgroundColor);
 		border-radius: 0.5rem;

--- a/src/components/TooltipOrAccordion.svelte
+++ b/src/components/TooltipOrAccordion.svelte
@@ -107,6 +107,10 @@
 					display: none;
 				}
 			}
+
+			> :global(:first-child) {
+				flex: 1;
+			}
 		}
 
 		.expanded-content {

--- a/src/global.css
+++ b/src/global.css
@@ -862,6 +862,25 @@ ol {
 			font-size: 0.875em;
 		}
 
+		@supports not selector(::before::marker) {
+			&::marker {
+				color: transparent;
+			}
+
+			&::before {
+				position: absolute;
+				margin-inline-start: calc(-1 * var(--list-marker-inlineSize) - var(--list-markerGap));
+				width: var(--list-marker-inlineSize);
+
+				content: '●';
+				font-size: 1em;
+				text-align: center;
+			}
+			&[data-list-item-marker]::before {
+				content: attr(data-list-item-marker);
+			}
+		}
+
 		padding-inline-start: var(--list-markerGap);
 
 		> * + * {

--- a/src/global.css
+++ b/src/global.css
@@ -143,7 +143,6 @@
 ::before,
 ::after,
 [popover] {
-	transition-duration: 0.25s;
 	transition-timing-function: var(--transition-easeOutExpo);
 }
 
@@ -151,8 +150,16 @@
 	background-color: transparent;
 }
 
-::details-content,
-::picker(select),
+::details-content {
+	transition-duration: 0.25s;
+	transition-timing-function: var(--transition-easeOutExpo);
+	transition-behavior: allow-discrete;
+}
+::picker(select) {
+	transition-duration: 0.25s;
+	transition-timing-function: var(--transition-easeOutExpo);
+	transition-behavior: allow-discrete;
+}
 ::scroll-marker {
 	transition-duration: 0.25s;
 	transition-timing-function: var(--transition-easeOutExpo);

--- a/src/global.css
+++ b/src/global.css
@@ -857,7 +857,7 @@ ol {
 			--listItem-gap: 1.5lh;
 		}
 
-		&::marker {
+		/* &::marker {
 			content: '●' ' ';
 			font-size: 1em;
 		}
@@ -866,7 +866,7 @@ ol {
 			font-size: 0.875em;
 		}
 
-		@supports not selector(::before::marker) {
+		@supports not selector(::before::marker) { */
 			&::marker {
 				color: transparent;
 			}
@@ -883,7 +883,7 @@ ol {
 			&[data-list-item-marker]::before {
 				content: attr(data-list-item-marker);
 			}
-		}
+		/* } */
 
 		padding-inline-start: var(--list-markerGap);
 

--- a/src/global.css
+++ b/src/global.css
@@ -1122,7 +1122,7 @@ ol {
 				}
 			}
 
-			&:not([data-sticky~='no-backdrop'])::before {
+			&:not([data-sticky~='backdrop-none'])::before {
 				content: '';
 				z-index: -1;
 				position: absolute;

--- a/src/global.css
+++ b/src/global.css
@@ -109,7 +109,7 @@
 	overflow: hidden;
 
 	font-family: 'Montserrat', 'Noto Color Emoji';
-	font-size: min(3.8vw, 16px);
+	font-size: min(3.2vw, 16px);
 
 	color-scheme: light dark;
 	color: var(--text-primary);

--- a/src/global.css
+++ b/src/global.css
@@ -117,6 +117,8 @@
 	outline-color: var(--accent);
 
 	transition-property: background-color, color;
+
+	touch-action: none;
 }
 
 *,
@@ -901,7 +903,8 @@ ol {
 	--scrollContainer-sizeInline: 100cqi;
 
 	/* Rules */
-	container-name: ScrollContainer;
+	overscroll-behavior: none;
+	touch-action: pan-x pan-y;
 
 	&:not([data-scroll-container~='block']):not([data-scroll-container~='inline']) {
 		container-type: size;

--- a/src/global.css
+++ b/src/global.css
@@ -305,9 +305,11 @@ label:has(
 	padding: 0.66em;
 	gap: 0.5em;
 
+	appearance: none;
 	background-color: var(--background-primary);
 	border: 1px solid var(--border-color);
 	border-radius: 0.5em;
+	color: inherit;
 
 	font: inherit;
 	font-size: smaller;

--- a/src/global.css
+++ b/src/global.css
@@ -1122,20 +1122,30 @@ ol {
 				}
 			}
 
-			&:not([data-sticky~='backdrop-none'])::before {
-				content: '';
-				z-index: -1;
-				position: absolute;
-				inset: 0;
-				background-color: var(--sticky-backgroundColor);
-				backdrop-filter: var(--sticky-backdropFilter);
-				border-radius: inherit;
+			&:not([data-sticky~='backdrop-none']) {
+				&[data-scroll-container],
+				&:not([data-scroll-container])::before {
+					background-color: var(--sticky-backgroundColor);
+					backdrop-filter: var(--sticky-backdropFilter);
+					border-radius: inherit;
 
-				transition-property: background-color, backdrop-filter;
+					transition-property: background-color, backdrop-filter;
+				}
 
-				@container scroll-state(stuck: none) {
-					background-color: transparent !important;
-					backdrop-filter: blur(0px);
+				&:not([data-scroll-container])::before {
+					content: '';
+					z-index: -1;
+					position: absolute;
+					inset: 0;
+				}
+
+				&:not([data-sticky~='backdrop-always']) {
+					&:not([data-scroll-container])::before {
+						@container scroll-state(stuck: none) {
+							background-color: transparent !important;
+							backdrop-filter: blur(0px);
+						}
+					}
 				}
 			}
 		}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,7 +25,10 @@ import Metadata from '@/layouts/Metadata.astro'
 <html lang='en'>
 	<head>
 		<meta charset='UTF-8' />
-		<meta name='viewport' content='width=device-width, viewport-fit=cover' />
+		<meta
+			name='viewport'
+			content='width=device-width, viewport-fit=cover, maximum-scale=1.0, user-scalable=no'
+		/>
 		<Metadata {metadata} />
 		<ClientRouter />
 		<script is:inline>

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -21,7 +21,13 @@ const currentPathname = Astro.url.pathname
 	})
 </script>
 
-<nav id='nav' popover='auto' data-sticky data-scroll-container data-sticky-container>
+<nav
+	id='nav'
+	popover='auto'
+	data-sticky='backdrop-always'
+	data-scroll-container
+	data-sticky-container
+>
 	<header data-sticky='block' data-row data-scroll-container>
 		<a href='/'>
 			<picture>

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -56,7 +56,7 @@ const currentPathname = Astro.url.pathname
 	</div>
 
 	<footer data-sticky>
-		<p>
+		<p data-card>
 			Wallets listed on Walletbeat do not represent endorsements and are for informational purposes
 			only.
 		</p>
@@ -132,10 +132,11 @@ const currentPathname = Astro.url.pathname
 			padding: 1rem;
 
 			p {
-				padding: 0.75rem 1rem;
+				&[data-card] {
+					--card-backgroundColor: var(--accent-backgroundColor);
+				}
+
 				line-height: 1.4;
-				background-color: var(--accent-backgroundColor);
-				border-radius: 0.5rem;
 				font-size: 0.875rem;
 				color: var(--text-secondary);
 			}

--- a/src/views/NavigationItems.svelte
+++ b/src/views/NavigationItems.svelte
@@ -170,7 +170,10 @@
 			}
 			data-sticky-container
 		>
-			<summary data-sticky>
+			<summary
+				data-sticky
+				data-row="gap-2"
+			>
 				{@render linkable(item)}
 			</summary>
 
@@ -189,6 +192,7 @@
 				target: '_blank',
 				rel: 'noreferrer',
 			}}
+			data-row="start gap-2"
 		>
 			{#if item.icon}
 				<span class="icon">{@html item.icon}</span>
@@ -242,10 +246,6 @@
 
 	summary,
 	a {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-
 		> .icon {
 			display: flex;
 			font-size: 1.25em;
@@ -294,8 +294,18 @@
 		}
 	}
 
-	details:not([open]) > summary::after {
-		transform: perspective(100px) rotateX(180deg) rotate(-90deg);
+	summary {
+		&::after {
+			margin-inline-start: auto;
+		}
+
+		details:not([open]) > &::after {
+			transform: perspective(100px) rotateX(180deg) rotate(-90deg);
+		}
+	}
+
+	summary > a {
+		flex: 0 auto;
 	}
 
 	summary ~ * {

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -718,7 +718,9 @@
 									{@const stage = ladderEvaluation?.ladder.stages[stageNumber]}
 
 									{#if stage && ladderEvaluation}
-										<Tooltip>
+										<Tooltip
+											style="--accent: var(--accent-color)"
+										>
 											<a
 												href={`#${stage.id}`}
 												data-link="camouflaged"

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1441,10 +1441,6 @@
 
 						transition-property: opacity, scale, min-block-size, padding-block-end;
 						min-block-size: var(--walletTable-rowClosed-blockSize);
-
-						> :global(:first-child) {
-							flex: 1;
-						}
 					}
 
 					&:open summary {


### PR DESCRIPTION
Improvements to responsive layouts, touch interactions and iOS Safari compatibility.

## Global styles:

* Styles:
  * improve pseudo-element compatibility
  * `<html>`: reduce proportional font size at small screen widths
  * form elements: reset appearance / color


## Views

* `<Layout>`:
  * disable pinch-to-zoom and double-tap zoom on mobile devices

* `<Navigation>`:
  * use [data-card] for disclaimer
  * use data-sticky="backdrop-always"

* `<NavigationItems>`:
  * fix alignment; minimize summary a interactive area

* `<WalletPage>`:
  * reset accent color for stage toolltips


## Components

* `<Tooltip>`:
  * set max-width
  * support touch events

* `<TooltipOrAccordion>`:
  * ensure trigger element expands to fit


### Layout primitives

* `[data-list-item]`:
  * emulate ::marker with ::before on Safari
  * use ::before instead of ::marker or all browsers (`::marker` can't be center-aligned)

* `[data-scroll-container]`:
  * set overscroll-behavior; constrain available `touch-action`s to panning only

* `[data-sticky]`:
  * introduce backdrop-always that applies regardless of `@container scroll-state(stuck: none)`
  * no-backdrop → backdrop-none
