### PR TITLE
Allow multiple wallets to be included in wallet news.

### DIFF
--- a/data/news/2025-12-25-browser-extension-v268-incident.ts
+++ b/data/news/2025-12-25-browser-extension-v268-incident.ts
@@ -24,4 +24,5 @@ export default {
 		'A malicious version of Trust Wallet Browser Extension (v2.68) was published to the Chrome Web Store on December 24, 2025, through a compromised API key. The attack, linked to the industry-wide Sha1-Hulud supply chain incident, affected users who logged in during December 24-26, 2025. Approximately 2,520 wallet addresses were impacted with $8.5M in losses. Trust Wallet has committed to reimbursing all affected users.',
 	title: 'Trust Wallet Browser Extension v2.68 Supply Chain Attack',
 	updatedAt: '2026-01-06',
+	wallets: [],
 } as const satisfies WalletSecurityNews

--- a/data/news/2026-01-06-global-e-breach.ts
+++ b/data/news/2026-01-06-global-e-breach.ts
@@ -6,8 +6,6 @@ import {
 	type WalletSecurityNews,
 } from '@/types/content/news'
 
-import { ledgerWalletMetadata } from '../hardware-wallets/ledger'
-
 export default {
 	slug: 'global-e-breach',
 	type: NewsType.DATA_BREACH,
@@ -26,5 +24,5 @@ export default {
 		'Global-e, an independent e-commerce platform used by Ledger.com, experienced unauthorized access to their cloud systems. Personal data including names and contact information of Ledger customers who made purchases through Global-e were improperly accessed. No payment information, account credentials, or passwords were compromised.',
 	title: 'Global-e Independent Provider Data Breach Affecting Ledger Customers',
 	updatedAt: '2026-01-06',
-	wallet: ledgerWalletMetadata,
+	wallets: ['ledger'],
 } as const satisfies WalletSecurityNews

--- a/data/news/index.ts
+++ b/data/news/index.ts
@@ -16,5 +16,5 @@ export const allWalletSecurityNews: WalletSecurityNews[] = [
  * @returns Array of WalletSecurityNews items affecting the given wallet
  */
 export function getNewsForWallet(walletId: string): WalletSecurityNews[] {
-	return allWalletSecurityNews.filter(news => news.wallet?.id === walletId)
+	return allWalletSecurityNews.filter(news => news.wallets.includes(walletId))
 }

--- a/data/wallets.ts
+++ b/data/wallets.ts
@@ -1,4 +1,4 @@
-import { type BaseWallet, type RatedWallet, rateWallet } from '@/schema/wallet'
+import { type BaseWallet, type RatedWallet, rateWallet, type WalletMetadata } from '@/schema/wallet'
 import { WalletType } from '@/schema/wallet-types'
 
 import { unratedEmbeddedWallet } from './embedded-wallets'
@@ -53,4 +53,13 @@ export function representativeWalletForType(walletType: WalletType): RatedWallet
 		case WalletType.EMBEDDED:
 			return unratedEmbeddedWallet
 	}
+}
+
+/**
+ * Get wallet metadata by ID, or undefined if not found.
+ */
+export function getWalletMetadataById(id: string): WalletMetadata | undefined {
+	const wallet = Object.values(allWallets).find(w => w.metadata.id === id)
+
+	return wallet?.metadata
 }

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -2,6 +2,7 @@
 // Types/constants
 import { defaultNavigationItems } from '@/constants/navigation'
 import { allWalletSecurityNews } from '@/data/news'
+import { getWalletMetadataById } from '@/data/wallets'
 import { impactCategories, incidentStatuses, newsTypes, severities } from '@/types/content/news'
 
 // Functions
@@ -47,20 +48,30 @@ import ExternalLinkIcon from 'lucide-static/icons/external-link.svg?raw'
 						<article id={news.slug}>
 							<details data-card='padding-6' data-column='gap-6'>
 								<summary data-row='wrap wrap-first-last'>
-									{news.wallet && (
-										<div data-row-item='basis-full'>
-											<a
-												class='wallet-link'
-												href={`/${news.wallet.id}`}
-												data-link='camouflaged'
-												data-badge='medium'
-											>
-												<img
-													src={`/images/wallets/${news.wallet.id}.${news.wallet.iconExtension}`}
-													alt={news.wallet.displayName}
-												/>
-												<span>{news.wallet.displayName}</span>
-											</a>
+									{news.wallets.length > 0 && (
+										<div
+											class='wallet-links'
+											data-row-item='basis-full'
+											data-row='start wrap gap-2'
+										>
+											{news.wallets.map(walletId => {
+												const wallet = getWalletMetadataById(walletId)
+
+												return wallet ? (
+													<a
+														class='wallet-link'
+														href={`/${wallet.id}`}
+														data-link='camouflaged'
+														data-badge='medium'
+													>
+														<img
+															src={`/images/wallets/${wallet.id}.${wallet.iconExtension}`}
+															alt={wallet.displayName}
+														/>
+														<span>{wallet.displayName}</span>
+													</a>
+												) : null
+											})}
 										</div>
 									)}
 

--- a/src/types/content/news.ts
+++ b/src/types/content/news.ts
@@ -1,5 +1,4 @@
 import type { WithRef } from '@/schema/reference'
-import type { WalletMetadata } from '@/schema/wallet'
 
 import type { CalendarDate } from '../date'
 
@@ -182,8 +181,11 @@ export type WalletSecurityNews = WithRef<{
 	title: string
 	/** Brief description of the incident */
 	summary: string
-	/** Wallet involved */
-	wallet?: WalletMetadata
+	/**
+	 * Wallet ID(s) affected by this incident.
+	 * Empty array indicates a general incident not specific to tracked wallets.
+	 */
+	wallets: string[]
 
 	/** Details about the impact of the incident */
 	impact: {

--- a/tests/news-integrity.test.ts
+++ b/tests/news-integrity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { allWalletSecurityNews, getNewsForWallet } from '@/data/news'
+import { allWallets } from '@/data/wallets'
+
+describe('wallet security news', () => {
+	for (const news of allWalletSecurityNews) {
+		describe(`news item "${news.slug}"`, () => {
+			it('has unique slug', () => {
+				const matchingNews = allWalletSecurityNews.filter(n => n.slug === news.slug)
+
+				expect(matchingNews.length).toBe(1)
+			})
+
+			it('references only valid wallet IDs', () => {
+				for (const walletId of news.wallets) {
+					const walletExists = Object.values(allWallets).some(w => w.metadata.id === walletId)
+
+					expect(walletExists, `Wallet ID "${walletId}" not found in allWallets`).toBe(true)
+				}
+			})
+
+			it('has publishedAt not after updatedAt', () => {
+				expect(news.publishedAt <= news.updatedAt).toBe(true)
+			})
+		})
+	}
+})
+
+describe('getNewsForWallet', () => {
+	it('returns news items that include the wallet', () => {
+		for (const news of allWalletSecurityNews) {
+			for (const walletId of news.wallets) {
+				const newsForWallet = getNewsForWallet(walletId)
+
+				expect(newsForWallet).toContain(news)
+			}
+		}
+	})
+
+	it('returns empty array for wallet with no news', () => {
+		const walletsWithNews = new Set(allWalletSecurityNews.flatMap(n => n.wallets))
+		const walletWithoutNews = Object.values(allWallets).find(
+			w => !walletsWithNews.has(w.metadata.id),
+		)
+
+		if (walletWithoutNews !== undefined) {
+			const result = getNewsForWallet(walletWithoutNews.metadata.id)
+
+			expect(result).toEqual([])
+		}
+	})
+
+	it('returns news sorted by date (newest first)', () => {
+		for (const wallet of Object.values(allWallets)) {
+			const newsForWallet = getNewsForWallet(wallet.metadata.id)
+
+			for (let i = 1; i < newsForWallet.length; i++) {
+				expect(newsForWallet[i - 1].publishedAt >= newsForWallet[i].publishedAt).toBe(true)
+			}
+		}
+	})
+})


### PR DESCRIPTION
Closes #479.

* Updated WalletSecurityNews to support multiple affected wallets by changing wallet?: WalletMetadata to wallets: string[]
* Added getWalletMetadataById() helper function for looking up wallet metadata by ID
* Updated the news page to display multiple wallet badges when applicable
* Migrated existing news files to the new format
* Added tests/news-integrity.test.ts which validates valid wallet ID references exist in allWallets. The test catches typos like wallets: ['ledgerr'] that would otherwise silently fail to display the affected wallet on the news page.