### PR TITLE
Change address resolution

### DIFF
--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -155,15 +155,17 @@ function evaluateAddressResolution(
 	if (addressResolution.nonChainSpecificEnsResolution.medium === 'CHAIN_CLIENT') {
 		return {
 			value: {
-				id: 'support_basic_resolution_onchain',
-				rating: Rating.PASS,
-				displayName: 'Supports ENS addresses',
+				id: 'support_plain_ens_onchain',
+				rating: Rating.PARTIAL,
+				displayName: 'Supports plain ENS addresses only',
 				addressResolution,
-				shortExplanation: sentence('{{WALLET_NAME}} supports sending to ENS addresses.'),
+				shortExplanation: sentence(
+					'{{WALLET_NAME}} supports sending to plain ENS addresses but not chain-specific human-readable addresses.',
+				),
 				__brand: brand,
 			},
 			details: markdown(`
-				{{WALLET_NAME}} supports sending funds to human-readable ENS addresses such as \`username.eth\`.
+				{{WALLET_NAME}} supports sending funds to human-readable ENS addresses such as \`username.eth\`, but does not support chain-specific address formats that specify the destination chain.
 
 				It does so using onchain data sources using the same code as when interacting with the chain in general, inheriting its privacy and verifiability properties.
 			`),
@@ -254,15 +256,18 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 		Wallets are rated based on the types of addresses they support sending
 		funds to.
 
-		Specifically, Walletbeat recognizes the following destination address
-		formats. Wallets must be able to resolve **at least one** of them to
-		fulfill this attribute:
+		Walletbeat recognizes the following destination address formats:
 
 		* Plain ENS addresses (\`username.eth\`) without destination chain information
 		* ${eipMarkdownLinkAndTitle(erc7828)}: \`user@l2chain.eth\`
 		* ${eipMarkdownLinkAndTitle(erc7831)}: \`user.eth:l2chain\`
 
-		Additionally, the mechanism used to perform the resolution must either:
+		Wallets receive a **pass** only if they support ${eipMarkdownLink(erc7828)} or
+		${eipMarkdownLink(erc7831)} (chain-specific human-readable addresses).
+		Wallets that support only plain ENS, with or without onchain resolution,
+		receive a **partial** rating.
+
+		For a pass, the mechanism used to perform the resolution must either:
 
 		* Be done using onchain data and reusing the wallet's common chain
 		  interaction client, inheriting its verifiability (e.g. via light
@@ -289,28 +294,6 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 		display: 'fail-pass',
 		exhaustive: false,
 		pass: [
-			exampleRating(
-				mdSentence(
-					'The wallet resolves plain ENS addresses (`username.eth`) when sending tokens, using onchain data for resolution.',
-				),
-				evaluateAddressResolution(
-					{
-						chainSpecificAddressing: {
-							erc7828: {
-								support: 'NOT_SUPPORTED',
-							},
-							erc7831: {
-								support: 'NOT_SUPPORTED',
-							},
-						},
-						nonChainSpecificEnsResolution: {
-							support: 'SUPPORTED',
-							medium: 'CHAIN_CLIENT',
-						},
-					},
-					[],
-				),
-			),
 			exampleRating(
 				mdSentence(
 					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses, using onchain data for resolution.`,
@@ -360,6 +343,28 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 			),
 		],
 		partial: [
+			exampleRating(
+				mdSentence(
+					'The wallet resolves plain ENS addresses (`username.eth`) when sending tokens, using onchain data for resolution.',
+				),
+				evaluateAddressResolution(
+					{
+						chainSpecificAddressing: {
+							erc7828: {
+								support: 'NOT_SUPPORTED',
+							},
+							erc7831: {
+								support: 'NOT_SUPPORTED',
+							},
+						},
+						nonChainSpecificEnsResolution: {
+							support: 'SUPPORTED',
+							medium: 'CHAIN_CLIENT',
+						},
+					},
+					[],
+				),
+			),
 			exampleRating(
 				mdSentence(
 					`The wallet resolves ${eipMarkdownLink(erc7828)} or ${eipMarkdownLink(erc7831)} addresses using an offchain external provider, without verifying the address.`,

--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -157,7 +157,7 @@ function evaluateAddressResolution(
 			value: {
 				id: 'support_plain_ens_onchain',
 				rating: Rating.PARTIAL,
-				displayName: 'Supports plain ENS addresses only',
+				displayName: 'Supports non-chain-specific ENS addresses',
 				addressResolution,
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} supports sending to plain ENS addresses but not chain-specific human-readable addresses.',
@@ -345,7 +345,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 		partial: [
 			exampleRating(
 				mdSentence(
-					'The wallet resolves plain ENS addresses (`username.eth`) when sending tokens, using onchain data for resolution.',
+					'The wallet resolves non-chain-specific ENS addresses (`username.eth`) when sending tokens, using onchain data for resolution.',
 				),
 				evaluateAddressResolution(
 					{

--- a/src/schema/stages/software-wallet-stages.ts
+++ b/src/schema/stages/software-wallet-stages.ts
@@ -243,12 +243,17 @@ export const softwareWalletStageOne: WalletStage = {
 			criteria: [
 				{
 					id: 'address_resolution',
-					description: sentence('The wallet can send funds to human-readable Ethereum addresses.'),
+					description: sentence(
+						'The wallet can send funds to human-readable Ethereum addresses (e.g. ENS).',
+					),
 					rationale: sentence(`
 						This improves the user experience of Ethereum and its layer 2 ecosystem
 						while reducing the potential for mistakes when sending funds.
 					`),
-					evaluate: variantsMustPassAttribute(softwareWalletVariants, addressResolution),
+					evaluate: variantsMustPassAttribute(softwareWalletVariants, addressResolution, {
+						allowPartial: true,
+						ifNoVariantInScope: null,
+					}),
 				},
 				{
 					id: 'browser_integration',
@@ -446,6 +451,20 @@ const softwareWalletStageTwo: WalletStage = {
 				'The wallet is aligned with advanced Ethereum ecosystem best practices for usability.',
 			),
 			criteria: [
+				{
+					id: 'chain_specific_address_resolution',
+					description: sentence(
+						'The wallet supports chain-specific human-readable addresses (e.g. ERC-7828, ERC-7831).',
+					),
+					rationale: sentence(`
+						Including the destination chain in the address reduces wrong-chain sends
+						and improves the user experience of Ethereum's layer 2 ecosystem.
+					`),
+					evaluate: variantsMustPassAttribute(softwareWalletVariants, addressResolution, {
+						allowPartial: false,
+						ifNoVariantInScope: null,
+					}),
+				},
 				{
 					id: 'account_abstraction',
 					description: sentence('The wallet is Account Abstraction ready.'),

--- a/src/utils/stage-attributes.ts
+++ b/src/utils/stage-attributes.ts
@@ -13,7 +13,7 @@ import type { RatedWallet } from '@/schema/wallet'
  * Get all stages across all ladders with their ladder type and index.
  */
 const allStages = Object.entries(ladders).flatMap(([ladderType, ladder]) =>
-	ladder.stages.map((stage, stageIndex) => ({ ladderType, stage, stageIndex })),
+	ladder.stages.map((stage, stageIndex) => ({ ladderType, ladder, stage, stageIndex })),
 )
 
 /**
@@ -105,12 +105,15 @@ export const getCriterionAttributeId = (criterion: WalletStageCriterion): string
 /**
  * Get all criteria that reference a specific attribute across all ladders.
  * @param attribute The attribute to find criteria for
+ * @param wallet The wallet to find criteria for
  * @returns An array of objects containing ladder type, stage number, and criterion
  */
-export function getAttributeCriteria(
+export function getAttributeCriteriaForWallet(
 	attribute: Attribute,
+	wallet: StageEvaluatableWallet,
 ): Array<{ ladderType: WalletLadderType; stageNumber: number; criterion: WalletStageCriterion }> {
 	return allStages
+		.filter(({ ladder }) => ladder.applicableTo(wallet))
 		.filter(({ stage }) => isAttributeUsedInStageObject(attribute, stage))
 		.flatMap(({ ladderType, stage, stageIndex }) =>
 			allCriteriaInStage(stage)
@@ -139,7 +142,7 @@ export function getAttributeStagesForWallet(
 	wallet: RatedWallet,
 ): Array<{ ladderType: WalletLadderType; stageNumbers: number[] }> {
 	const stageEvaluatable = toStageEvaluatable(wallet)
-	const criteria = getAttributeCriteria(attribute)
+	const criteria = getAttributeCriteriaForWallet(attribute, wallet)
 	const stagesPassed = criteria
 		.filter(
 			({ criterion }) => criterion.evaluate(stageEvaluatable).rating === StageCriterionRating.PASS,

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -10,7 +10,7 @@
 	import { type EvaluatedAttribute, ratingIcons, ratingToColor, type Value } from '@/schema/attributes'
 	import type { Variant } from '@/schema/variants'
 	import { attributeVariantSpecificity, type RatedWallet,VariantSpecificity } from '@/schema/wallet'
-	import { getAttributeStages } from '@/utils/stage-attributes'
+	import { getAttributeStagesForWallet } from '@/utils/stage-attributes'
 	import { getWalletStageAndLadder } from '@/utils/stage'
 
 
@@ -57,7 +57,7 @@
 	)
 
 	const attributeStages = $derived(
-		getAttributeStages(attribute.attribute)
+		getAttributeStagesForWallet(attribute.attribute, wallet)
 	)
 
 	const relevantStages = $derived(

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -35,7 +35,7 @@
 	import { renderStrings, slugifyCamelCase } from '@/types/utils/text'
 	import { getWalletStageAndLadder } from '@/utils/stage'
 	import { scoreToColor } from '@/utils/colors'
-	import { getAttributeStages, isAttributeUsedInStages } from '@/utils/stage-attributes'
+	import { getAttributeStagesForWallet, isAttributeUsedInStages } from '@/utils/stage-attributes'
 	import { WalletLadderType } from '@/schema/ladders'
 
 
@@ -758,7 +758,7 @@
 										undefined
 								)}
 
-								{@const attributeStages = getAttributeStages(attribute)}
+								{@const attributeStages = getAttributeStagesForWallet(attribute, wallet)}
 
 								{@const stageNumbers = (
 									ladderType &&


### PR DESCRIPTION
Closes #507  

Address resolution changes:
- ENS is PARTIAL instead of PASS
- ERC-7828 and ERC-7831 were already PASS so keep the same
- Removed the “plain ENS onchain” example from ratingScale.pass
- Inserted that same example as the first item in ratingScale.partial

Split Address Resolution into Two Stage Requirements:
- Stage 1 (Basic): Requires basic human-readable address support (e.g., ENS)
  - Updated to allow PARTIAL ratings (allowPartial: true)
  - Wallets with basic ENS support can pass Stage 1
- Stage 2 (Advanced): Requires chain-specific human-readable addresses (ERC-7828, ERC-7831)
  - New criterion added: chain_specific_address_resolution
  - Requires PASS rating (allowPartial: false)
  - Only wallets supporting chain-specific formats like user@l2chain.eth or user.eth:l2chain pass Stage 2

New Wallet-Specific Stage Lookup Function:
Ensures the UI reflects the wallet's actual performance rather than just where the attribute is defined.
- Added getAttributeStagesForWallet() in stage-attributes.ts:
- Filters stages to those where the wallet actually passes the criterion
- Returns only the highest stage passed per ladder (e.g., if a wallet passes Stage 2, it doesn't also show Stage 1)
- Replaces the generic getAttributeStages() which showed all stages where an attribute is used, regardless of wallet performance