### PR TITLE
Refactor: Add calldata decoding to software wallets

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -38,7 +38,6 @@ import type {
 import type { SecurityAudit } from '@/schema/features/security/security-audits'
 import {
 	CalldataDecoding,
-	DataDecoded,
 	DataDisplayOptions,
 	MessageSigningDetails,
 } from '@/schema/features/security/transaction-legibility'
@@ -50,7 +49,7 @@ import { TransactionSubmissionL2Support } from '@/schema/features/self-sovereign
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { type References, refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
+import { type References, refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -584,6 +584,7 @@ export const ambire: SoftwareWallet = {
 					formatted: false,
 					rawHex: true,
 				},
+				legibility: null,
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -37,6 +37,8 @@ import type {
 } from '@/schema/features/security/scam-alerts'
 import type { SecurityAudit } from '@/schema/features/security/security-audits'
 import {
+	CalldataDecoding,
+	DataDecoded,
 	DataDisplayOptions,
 	MessageSigningDetails,
 } from '@/schema/features/security/transaction-legibility'
@@ -48,7 +50,7 @@ import { TransactionSubmissionL2Support } from '@/schema/features/self-sovereign
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
-import { type References, refTodo, type WithRef } from '@/schema/reference'
+import { type References, refNotNecessary, refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { SoftwareWallet } from '@/schema/wallet'
 import { paragraph } from '@/types/content'
@@ -584,7 +586,14 @@ export const ambire: SoftwareWallet = {
 					formatted: false,
 					rawHex: true,
 				},
-				legibility: null,
+				legibility: {
+					[CalldataDecoding.ETH_USDC_TRANSFER]: false,
+					[CalldataDecoding.ZKSYNC_USDC_TRANSFER]: false,
+					[CalldataDecoding.USDC_APPROVAL]: false,
+					[CalldataDecoding.AAVE_SUPPLY]: false,
+					[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED]: false,
+					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]: false
+				},
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -592,7 +592,7 @@ export const ambire: SoftwareWallet = {
 					[CalldataDecoding.USDC_APPROVAL]: false,
 					[CalldataDecoding.AAVE_SUPPLY]: false,
 					[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED]: false,
-					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]: false
+					[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]: false,
 				},
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/bitget.ts
+++ b/data/software-wallets/bitget.ts
@@ -204,6 +204,7 @@ export const bitget: SoftwareWallet = {
 					formatted: false,
 					rawHex: true,
 				},
+				legibility: null,
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.NOT_IN_UI,
 					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -138,6 +138,7 @@ export const frame: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -435,6 +435,7 @@ export const metamask: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: displaysFullCallData,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -174,6 +174,7 @@ export const nufi: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/okx.ts
+++ b/data/software-wallets/okx.ts
@@ -194,6 +194,7 @@ OKX Wallet is a universal crypto wallet available on multiple platforms, includi
 					formatted: false,
 					rawHex: true,
 				},
+				legibility: null,
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_OPTIONALLY,
 					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -137,6 +137,7 @@ export const phantom: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -635,6 +635,7 @@ export const rabby: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: displaysFullTransactionDetails,
 			},

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -142,6 +142,7 @@ export const rainbow: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -273,6 +273,7 @@ export const safe: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: displaysFullCallData,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: displaysFullTransactionDetails,
 			},

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -141,6 +141,7 @@ export const zerion: SoftwareWallet = {
 			transactionLegibility: {
 				ref: refTodo,
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: null,
 				transactionDetailsDisplay: {
 					chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/zeus.ts
+++ b/data/software-wallets/zeus.ts
@@ -274,6 +274,7 @@ export const zeus: SoftwareWallet = {
 					},
 				],
 				calldataDisplay: null,
+				legibility: null,
 				messageSigningLegibility: {
 					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -470,6 +470,10 @@ function hardwareFullTransactionLegibility(
 
 // Software wallet detail generation helpers
 interface SoftwareFeatureDetails {
+	calldataDecoding: {
+		supported: string[]
+		missing: string[]
+	}
 	calldataDisplay: {
 		supported: string[]
 		missing: string[]
@@ -485,14 +489,50 @@ interface SoftwareFeatureDetails {
 }
 
 function analyzeSoftwareFeatures({
+	legibility,
 	calldataDisplay,
 	transactionDetailsDisplay,
 	messageSigningLegibility,
 }: SoftwareTransactionLegibilityImplementation): SoftwareFeatureDetails {
 	const details: SoftwareFeatureDetails = {
+		calldataDecoding: { supported: [], missing: [] },
 		calldataDisplay: { supported: [], missing: [] },
 		transactionDetails: { supported: [], missing: [] },
 		messageSigning: { supported: [], missing: [] },
+	}
+
+	// Analyze calldata decoding
+	if (legibility !== null) {
+		const decodingChecks = [
+			{
+				key: CalldataDecoding.ETH_USDC_TRANSFER,
+				label: 'basic token transfers (ERC-20)',
+			},
+			{
+				key: CalldataDecoding.ZKSYNC_USDC_TRANSFER,
+				label: 'ZKSync token transfers',
+			},
+			{
+				key: CalldataDecoding.AAVE_SUPPLY,
+				label: 'DeFi interactions (e.g., Aave)',
+			},
+			{
+				key: CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED,
+				label: 'nested Safe transactions',
+			},
+			{
+				key: CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND,
+				label: 'complex nested multisend transactions',
+			},
+		]
+
+		decodingChecks.forEach(({ key, label }) => {
+			if (legibility[key] === true) {
+				details.calldataDecoding.supported.push(label)
+			} else {
+				details.calldataDecoding.missing.push(label)
+			}
+		})
 	}
 
 	// Analyze calldata display
@@ -566,12 +606,28 @@ function analyzeSoftwareFeatures({
 function generateSoftwareDetailsMarkdown(features: SoftwareFeatureDetails): string {
 	const sections: string[] = []
 
+	// Calldata Decoding section
+	if (
+		features.calldataDecoding.supported.length > 0 ||
+		features.calldataDecoding.missing.length > 0
+	) {
+		sections.push('**Calldata Decoding**\n')
+
+		if (features.calldataDecoding.supported.length > 0) {
+			sections.push(`✓ Supported: ${commaListFormat(features.calldataDecoding.supported)}\n`)
+		}
+
+		if (features.calldataDecoding.missing.length > 0) {
+			sections.push(`✗ Missing: ${commaListFormat(features.calldataDecoding.missing)}\n`)
+		}
+	}
+
 	// Calldata Display section
 	if (
 		features.calldataDisplay.supported.length > 0 ||
 		features.calldataDisplay.missing.length > 0
 	) {
-		sections.push('**Calldata Display**\n')
+		sections.push('\n**Calldata Display**\n')
 
 		if (features.calldataDisplay.supported.length > 0) {
 			sections.push(`✓ Supported: ${commaListFormat(features.calldataDisplay.supported)}\n`)
@@ -616,6 +672,12 @@ function generateSoftwareDetailsMarkdown(features: SoftwareFeatureDetails): stri
 
 function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string {
 	const improvements: string[] = []
+
+	if (features.calldataDecoding.missing.length > 0) {
+		improvements.push(
+			`**Calldata Decoding:** Add support for decoding ${commaListFormat(features.calldataDecoding.missing)}`,
+		)
+	}
 
 	if (features.calldataDisplay.missing.length > 0) {
 		improvements.push(
@@ -826,10 +888,10 @@ function evaluateSoftwareWalletTransactionLegibility(
 ): Evaluation<TransactionLegibilityValue> {
 	const { withoutRefs: transactionLegibilitySupport } = popRefs(softwareTransactionLegibility)
 
-	const { calldataDisplay, transactionDetailsDisplay, messageSigningLegibility } =
+	const { calldataDisplay, transactionDetailsDisplay, messageSigningLegibility, legibility } =
 		transactionLegibilitySupport
 
-	if (calldataDisplay === null || transactionDetailsDisplay === null) {
+	if (calldataDisplay === null || transactionDetailsDisplay === null || legibility === null) {
 		return unrated(transactionLegibility, brand, null)
 	}
 
@@ -840,6 +902,18 @@ function evaluateSoftwareWalletTransactionLegibility(
 	const calldataShown = calldataDisplay.rawHex
 	const calldataCopyable = calldataDisplay.copyHexToClipboard
 	const calldataFormatted = calldataDisplay.formatted
+
+	// Check calldata decoding capabilities
+	const supportsBasicDecoding: boolean =
+		legibility[CalldataDecoding.ETH_USDC_TRANSFER] === true &&
+		legibility[CalldataDecoding.ZKSYNC_USDC_TRANSFER] === true &&
+		legibility[CalldataDecoding.AAVE_SUPPLY] === true
+
+	const supportsComplexDecoding: boolean =
+		supportsBasicDecoding &&
+		(legibility[CalldataDecoding.SAFEWALLET_AAVE_SUPPLY_NESTED] === true ||
+			legibility[CalldataDecoding.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND] ===
+				true)
 
 	// For DisplayedTransactionDetails, SHOWN_BY_DEFAULT or SHOWN_OPTIONALLY count as supported
 	const transactionDetailsRatings = [
@@ -865,9 +939,11 @@ function evaluateSoftwareWalletTransactionLegibility(
 	// 2. If calldata is shown but neither copyable nor formatted, FAIL
 	// 3. If less than 3 types of transaction details shown, FAIL
 	// 4. Message signing fails, FAIL
-	// 5. If calldata is not copyable OR not formatted, PARTIAL
-	// 6. If more than 3 types of transaction details are shown but not all of them, PARTIAL
-	// 7. Otherwise, PASS (requires message signing to pass)
+	// 5. If basic calldata decoding not supported, FAIL
+	// 6. If calldata is not copyable OR not formatted, PARTIAL
+	// 7. If more than 3 types of transaction details are shown but not all of them, PARTIAL
+	// 8. If missing complex decoding, cap at PARTIAL
+	// 9. Otherwise, PASS (requires message signing to pass and complex calldata decoding)
 	let rating: Rating
 
 	if (!calldataShown) {
@@ -882,6 +958,9 @@ function evaluateSoftwareWalletTransactionLegibility(
 	} else if (messageSigningLegibility !== null && !messageSigningPasses) {
 		// Message signing data provided but fails criteria
 		rating = Rating.FAIL
+	} else if (!supportsBasicDecoding) {
+		// Require basic calldata decoding for passing.
+		rating = Rating.FAIL
 	} else if (!calldataCopyable || !calldataFormatted) {
 		// Calldata is not copyable OR not formatted
 		rating = Rating.PARTIAL
@@ -889,6 +968,9 @@ function evaluateSoftwareWalletTransactionLegibility(
 		// More than 3 types of transaction details are shown but not all of them
 		rating = Rating.PARTIAL
 	} else if (!messageSigningPasses) {
+		rating = Rating.PARTIAL
+	} else if (!supportsComplexDecoding) {
+		// Complex decoding not supported — cap at PARTIAL
 		rating = Rating.PARTIAL
 	} else {
 		rating = Rating.PASS
@@ -963,6 +1045,8 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 		- Formatted output: Users can view decoded, human-readable calldata
 		- Copy to clipboard: Users can copy the calldata directly for verification
 
+		Software wallets must also support calldata decoding for various transaction types, from basic token transfers to complex nested transactions.
+
 		**Hardware Wallet Specific Requirements:**
 		For hardware wallets, the signature/transaction information *must* be visible on the hardware wallet device itself. Any data shown on a software wallet component is ignored for hardware wallet ratings.
 
@@ -974,8 +1058,8 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 		**Rating Criteria:**
 
 		For software wallets:
-		- A wallet receives a passing rating if it displays calldata in all three formats (raw hex, formatted, copyable) and displays all essential transaction details.
-		- A wallet receives a partial rating if it has some combination of these features, but not all at the full level.
+		- A wallet receives a passing rating if it displays calldata in all three formats (raw hex, formatted, copyable), displays all essential transaction details, and supports complex calldata decoding (including nested transactions).
+		- A wallet receives a partial rating if it has some combination of these features but not all, or if calldata decoding data has not been provided.
 		- A wallet receives a failing rating if it lacks calldata display capabilities or does not display essential transaction details.
 
 		For hardware wallets:
@@ -1009,6 +1093,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					calldataDisplay: null,
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
+					legibility: null,
 					ref: refNotNecessary,
 				}),
 			),
@@ -1050,6 +1135,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
 					ref: refNotNecessary,
+					legibility: null,
 				}),
 			),
 		],
@@ -1075,6 +1161,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 					transactionDetailsDisplay: null,
 					messageSigningLegibility: null,
 					ref: refNotNecessary,
+					legibility: null,
 				}),
 			),
 		],

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -880,7 +880,7 @@ function evaluateSoftwareWalletTransactionLegibility(
 	const { calldataDisplay, transactionDetailsDisplay, messageSigningLegibility, legibility } =
 		transactionLegibilitySupport
 
-	if (calldataDisplay === null || transactionDetailsDisplay === null) {
+	if (calldataDisplay === null || transactionDetailsDisplay === null || legibility === null) {
 		return unrated(transactionLegibility, null)
 	}
 

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -379,6 +379,11 @@ export interface SoftwareTransactionLegibilitySupport {
 	 * What message signing data does the software wallet provide?
 	 */
 	messageSigningLegibility: SoftwareMessageSigningLegibility | null
+
+	/**
+	 * Does a wallet display transaction details clearly?
+	 */
+	legibility: CalldataDecodingTypes | null
 }
 
 export const isFullTransactionDetails = (details: DisplayedTransactionDetails): boolean => {

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -328,7 +328,7 @@ export function isSupportedOnDevice(
  */
 export interface HardwareTransactionLegibilitySupport {
 	/**
-	 * Does a wallet display transaction details clearly?
+	 * Does the wallet decode basic and complex transaction calldata to show function names and parameters?
 	 */
 	legibility: CalldataDecodingTypes | null
 	/**
@@ -357,7 +357,7 @@ export interface CallDataDisplay {
 	/* Can the user copy the raw hex code to the clipboard? */
 	copyHexToClipboard: boolean
 
-	/* Can display the calldata in some formatted output (e.g. JSON) */
+	/* Can display the calldata in some formatted output that shows function names and parameters (e.g. JSON / text) */
 	formatted: boolean
 }
 
@@ -386,7 +386,7 @@ export interface SoftwareTransactionLegibilitySupport {
 	messageSigningLegibility: SoftwareMessageSigningLegibility | null
 
 	/**
-	 * Does a wallet display transaction details clearly?
+	 * Does the wallet decode basic and complex transaction calldata to show function names and parameters?
 	 */
 	legibility: SoftwareCalldataDecodingTypes | null
 }

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -190,6 +190,11 @@ export type CalldataDecodingTypes = Record<
 	Support<WithRef<CalldataDecodingSupport>>
 >
 
+/**
+ * Types of transactions that a wallet can decode the calldata of.
+ */
+export type SoftwareCalldataDecodingTypes = Record<CalldataDecoding, boolean>
+
 /** If a wallet can decode the calldata for a specific transaction, what does that look like? */
 export interface CalldataDecodingSupport {
 	/** Where does the calldata decoding actually happen? */
@@ -383,7 +388,7 @@ export interface SoftwareTransactionLegibilitySupport {
 	/**
 	 * Does a wallet display transaction details clearly?
 	 */
-	legibility: CalldataDecodingTypes | null
+	legibility: SoftwareCalldataDecodingTypes | null
 }
 
 export const isFullTransactionDetails = (details: DisplayedTransactionDetails): boolean => {


### PR DESCRIPTION
## Add calldata decoding support to software wallet transaction legibility

### Summary
- Add `legibility` field (`SoftwareCalldataDecodingTypes`) to track which transaction types a software wallet can decode.
- Refactor `SoftwareCalldataDecodingTypes` to use simple booleans instead of the hardware wallet `CalldataDecodingSupport` structure
```ts
/**
 * Types of transactions that a wallet can decode the calldata of.
 */
export type SoftwareCalldataDecodingTypes = Record<CalldataDecoding, boolean>
```
- Added `legibility: null` to all 11 software wallets

### Changes
- New `SoftwareCalldataDecodingTypes` type and `legibility` field
- Updated evaluation logic, detail generation, and attribute description
- Add `legibility: null`

### Rating criteria changes
- **FAIL**: Missing basic calldata decoding support
- **PARTIAL**: Has basic decoding but missing complex decoding (nested transactions)
- **PASS**: Basic and complex calldata decoding

Fixes #524