### PR TITLE
Schema: remove unused `__brand` types from rating values

### DIFF
--- a/resources/docs/contribute/ui.md
+++ b/resources/docs/contribute/ui.md
@@ -92,7 +92,6 @@ return {
 		displayName,
 		shortExplanation,
 		securityAudits: audits,
-		__brand: brand,
 	},
 	details: securityAuditsDetailsContent({
 		// Props defined in SecurityAuditsDetailsProps:

--- a/src/schema/attributes/common.ts
+++ b/src/schema/attributes/common.ts
@@ -14,14 +14,10 @@ import type { AtLeastOneVariant, Variant } from '../variants'
 
 /**
  * Helper for constructing "Unrated" values.
- * @param brand Brand string to distinguish `Value` subtypes.
  */
 export function unrated<V extends Value>(
 	attribute: Attribute<V>,
-	brand: string,
-	extraProps: Omit<V, keyof (Value & { __brand: string })> extends Record<string, never>
-		? null
-		: Omit<V, keyof (Value & { __brand: string })>,
+	extraProps: Omit<V, keyof Value> extends Record<string, never> ? null : Omit<V, keyof Value>,
 ): Evaluation<V> {
 	const value: Value = {
 		id: 'unrated',
@@ -30,11 +26,7 @@ export function unrated<V extends Value>(
 		shortExplanation: sentence('Walletbeat lacks the information needed to determine this.'),
 	}
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Combining the fields of Value with the fields of V that are not in Value creates a correct V-typed object.
-	const v: V = {
-		__brand: brand,
-		...value,
-		...(extraProps ?? {}),
-	} as unknown as V
+	const v: V = { ...value, ...(extraProps ?? {}) } as unknown as V
 
 	return {
 		value: v,
@@ -42,17 +34,10 @@ export function unrated<V extends Value>(
 	}
 }
 
-/**
- * Helper for constructing "Exempt" values.
- * @param brand Brand string to distinguish `Value` subtypes.
- */
 export function exempt<V extends Value>(
 	attribute: Attribute<V>,
 	whyExempt: Sentence<WalletNameStrings>,
-	brand: string,
-	extraProps: Omit<V, keyof (Value & { __brand: string })> extends Record<string, never>
-		? null
-		: Omit<V, keyof (Value & { __brand: string })>,
+	extraProps: Omit<V, keyof Value> extends Record<string, never> ? null : Omit<V, keyof Value>,
 ): ExemptEvaluation<V> {
 	const value: Value & { rating: Rating.EXEMPT } = {
 		id: 'exempt',
@@ -62,7 +47,6 @@ export function exempt<V extends Value>(
 	}
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Combining the fields of Value with the fields of V that are not in Value creates a correct V-typed object.
 	const v: V & { rating: Rating.EXEMPT } = {
-		__brand: brand,
 		...value,
 		...(extraProps ?? {}),
 	} as unknown as V & { rating: Rating.EXEMPT }

--- a/src/schema/attributes/ecosystem/account-abstraction.ts
+++ b/src/schema/attributes/ecosystem/account-abstraction.ts
@@ -24,11 +24,7 @@ import { markdown, mdParagraph, mdSentence, sentence } from '@/types/content'
 import { eipMarkdownLink, eipMarkdownLinkAndTitle } from '../../eips'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.ecosystem.account_abstraction'
-
-export type AccountAbstractionValue = Value & {
-	__brand: 'attributes.ecosystem.account_abstraction'
-}
+export type AccountAbstractionValue = Value
 
 function supportsErc4337AndEip7702(
 	references: ReferenceArray,
@@ -41,7 +37,6 @@ function supportsErc4337AndEip7702(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports Account Abstraction via ERC-4337 and EIP-7702.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports Account Abstraction via ${eipMarkdownLinkAndTitle(erc4337)} and ${eipMarkdownLinkAndTitle(eip7702)}.`,
@@ -57,7 +52,6 @@ function supportsErc4337(references: ReferenceArray): Evaluation<AccountAbstract
 			rating: Rating.PASS,
 			displayName: 'Account Abstraction ready',
 			shortExplanation: sentence('{{WALLET_NAME}} supports Account Abstraction via ERC-4337.'),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports Account Abstraction via ${eipMarkdownLinkAndTitle(erc4337)}.`,
@@ -73,7 +67,6 @@ function supportsEip7702(references: ReferenceArray): Evaluation<AccountAbstract
 			rating: Rating.PASS,
 			displayName: 'Account Abstraction ready',
 			shortExplanation: sentence('{{WALLET_NAME}} supports Account Abstraction via EIP-7702.'),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports Account Abstraction via ${eipMarkdownLinkAndTitle(eip7702)}.`,
@@ -91,7 +84,6 @@ function supportsEoaAndMpc(references: ReferenceArray): Evaluation<AccountAbstra
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports EOA and MPC accounts only, with no Account Abstraction support.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			'{{WALLET_NAME}} supports EOA and MPC accounts only, with no Account Abstraction support.',
@@ -115,7 +107,6 @@ function supportsMpcOnly(references: ReferenceArray): Evaluation<AccountAbstract
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports MPC accounts only, with no Account Abstraction support.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			'{{WALLET_NAME}} supports MPC accounts only, with no Account Abstraction support.',
@@ -139,7 +130,6 @@ function supportsRawEoaOnly(references: ReferenceArray): Evaluation<AccountAbstr
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports EOAs only, with no Account Abstraction support.',
 			),
-			__brand: brand,
 		},
 		details: markdown('{{WALLET_NAME}} supports EOAs only, with no Account Abstraction support.'),
 		impact: mdParagraph(
@@ -225,7 +215,7 @@ export const accountAbstraction: Attribute<AccountAbstractionValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<AccountAbstractionValue> => {
 		if (features.accountSupport === null) {
-			return unrated(accountAbstraction, brand, null)
+			return unrated(accountAbstraction, null)
 		}
 
 		const supported: Record<AccountType, boolean> = {

--- a/src/schema/attributes/ecosystem/address-resolution.ts
+++ b/src/schema/attributes/ecosystem/address-resolution.ts
@@ -20,11 +20,8 @@ import type {
 } from '../../features/privacy/address-resolution'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.ecosystem.address_resolution'
-
 export type AddressResolutionValue = Value & {
 	addressResolution?: AddressResolution<Support<AddressResolutionData>>
-	__brand: 'attributes.ecosystem.address_resolution'
 }
 
 function getOffchainProviderInfo(
@@ -95,7 +92,6 @@ function evaluateAddressResolution(
 					shortExplanation: sentence(
 						`{{WALLET_NAME}} supports chain-specific human-readable addresses in ${eipShortLabel(erc)} format.`,
 					),
-					__brand: brand,
 				},
 				details: mdParagraph(
 					`{{WALLET_NAME}} supports chain-specific human-readable addresses in ${eipShortLabel(erc)} format, such as \`${exampleAddress}\`. It does so using onchain data sources using the same code as when interacting with the chain in general, inheriting its privacy and verifiability properties. For more information on ${eipShortLabel(erc)} addresses, see ${eipMarkdownLinkAndTitle(erc)}.`,
@@ -115,7 +111,6 @@ function evaluateAddressResolution(
 				shortExplanation: sentence(
 					`{{WALLET_NAME}} supports chain-specific human-readable addresses in ${eipShortLabel(erc)} format using an offchain provider.`,
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				`{{WALLET_NAME}} supports chain-specific human-readable addresses in ${eipShortLabel(erc)} format, such as \`${exampleAddress}\`. ${offchainInfo} For more information on ${eipShortLabel(erc)} addresses, see ${eipMarkdownLinkAndTitle(erc)}.`,
@@ -140,7 +135,6 @@ function evaluateAddressResolution(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not resolve human-readable addresses such as ENS names.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} does not support resolving human-readable addresses, such as ENS (.eth) names.',
@@ -160,7 +154,6 @@ function evaluateAddressResolution(
 				displayName: 'Supports ENS addresses',
 				addressResolution,
 				shortExplanation: sentence('{{WALLET_NAME}} supports sending to ENS addresses.'),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} supports sending funds to human-readable ENS addresses such as \`username.eth\`.
@@ -190,7 +183,6 @@ function evaluateAddressResolution(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports sending to ENS addresses but uses an offchain service for resolution.',
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			{{WALLET_NAME}} supports sending funds to human-readable ENS addresses such as \`username.eth\`.
@@ -431,7 +423,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<AddressResolutionValue> => {
 		if (features.addressResolution === null) {
-			return unrated(addressResolution, brand, {})
+			return unrated(addressResolution, {})
 		}
 
 		if (
@@ -439,7 +431,7 @@ export const addressResolution: Attribute<AddressResolutionValue> = {
 			features.addressResolution.chainSpecificAddressing.erc7828 === null ||
 			features.addressResolution.chainSpecificAddressing.erc7831 === null
 		) {
-			return unrated(addressResolution, brand, {})
+			return unrated(addressResolution, {})
 		}
 
 		// We've checked all the nulls, so recreate the object without nulls in

--- a/src/schema/attributes/ecosystem/browser-integration.ts
+++ b/src/schema/attributes/ecosystem/browser-integration.ts
@@ -28,11 +28,8 @@ import { exempt, pickWorstRating, unrated } from '../common'
 
 type ResolvedSupport = Record<BrowserIntegrationEip, Support>
 
-const brand = 'attributes.ecosystem.browser_integration'
-
 export type BrowserIntegrationValue = Value & {
 	support?: ResolvedSupport
-	__brand: 'attributes.ecosystem.browser_integration'
 }
 
 function browserIntegrationSupport(
@@ -58,7 +55,6 @@ function browserIntegrationSupport(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not integrate with the browser in a standard way.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} does not adhere to any of the Ethereum standards for integration in web browsers.',
@@ -84,7 +80,6 @@ function browserIntegrationSupport(
 			shortExplanation: sentence(
 				`{{WALLET_NAME}} supports ${unsupported.length === 0 ? 'all' : 'a subset of'} the prominent standards for web browser integration.`,
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			{{WALLET_NAME}} supports ${unsupported.length === 0 ? 'all' : 'a subset of'} the prominent standards for web browser integration:
@@ -169,7 +164,6 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
 			return exempt(
 				browserIntegration,
 				sentence('Only browser-based wallets are rated on their browser integration support.'),
-				brand,
 				{},
 			)
 		}
@@ -181,7 +175,7 @@ export const browserIntegration: Attribute<BrowserIntegrationValue> = {
 		}
 
 		if (Object.values(features.integration.browser).includes(null)) {
-			return unrated(browserIntegration, brand, {})
+			return unrated(browserIntegration, {})
 		}
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- We just verified that none of the values are null.

--- a/src/schema/attributes/ecosystem/chain-abstraction.ts
+++ b/src/schema/attributes/ecosystem/chain-abstraction.ts
@@ -27,11 +27,7 @@ import { markdown, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.ecosystem.chain_abstraction'
-
-export type ChainAbstractionValue = Value & {
-	__brand: 'attributes.ecosystem.chain_abstraction'
-}
+export type ChainAbstractionValue = Value
 
 function evaluateChainAbstraction(
 	chainAbstraction: ChainAbstraction,
@@ -55,7 +51,6 @@ function evaluateChainAbstraction(
 				shortExplanation: sentence(
 					"{{WALLET_NAME}} does not display your account's total value across chains.",
 				),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} does not display your account's total value across
@@ -87,7 +82,6 @@ function evaluateChainAbstraction(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not display token balances across chains.',
 				),
-				__brand: brand,
 			},
 			details: markdown(`
 				While {{WALLET_NAME}} can display your account's total value across
@@ -121,7 +115,6 @@ function evaluateChainAbstraction(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not provide an easy cross-chain bridging feature.',
 				),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} does not provide a built-in way to bridge assets
@@ -148,7 +141,6 @@ function evaluateChainAbstraction(
 				displayName: 'No cross-chain token balance',
 				rating: Rating.PARTIAL,
 				shortExplanation: sentence('{{WALLET_NAME}} does not add up token balances across chains.'),
-				__brand: brand,
 			},
 			details: markdown(`
 				While {{WALLET_NAME}} can display your account's total value across
@@ -188,7 +180,6 @@ function evaluateChainAbstraction(
 					but does not display the fees involved in doing
 					so${feesHidden ? '' : ' by default'}.
 				`),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} has a built-in cross-chain bridging feature, but
@@ -239,7 +230,6 @@ function evaluateChainAbstraction(
 					${risksHidden ? 'straightforwardly display' : 'display'}
 					the risks involved in doing so.
 				`),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} has a built-in cross-chain bridging feature, but
@@ -280,7 +270,6 @@ function evaluateChainAbstraction(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} implements most cross-chain features, but does not automatically suggest cross-chain bridging.',
 				),
-				__brand: brand,
 			},
 			details: markdown(`
 				{{WALLET_NAME}} abstracts away most cross-chain complexity by
@@ -312,7 +301,6 @@ function evaluateChainAbstraction(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} transparently implements cross-chain token balances and bridging.',
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			{{WALLET_NAME}} abstracts away cross-chain complexity by
@@ -513,13 +501,12 @@ export const chainAbstraction: Attribute<ChainAbstractionValue> = {
 			return exempt(
 				chainAbstraction,
 				sentence('Only software wallets are expected to deal with chain abstraction.'),
-				brand,
 				null,
 			)
 		}
 
 		if (features.chainAbstraction === null) {
-			return unrated(chainAbstraction, brand, null)
+			return unrated(chainAbstraction, null)
 		}
 
 		return evaluateChainAbstraction(features.chainAbstraction)

--- a/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
+++ b/src/schema/attributes/ecosystem/hardware-wallet-interoperability.ts
@@ -24,11 +24,8 @@ import type { NonEmptyArray } from '@/types/utils/non-empty'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.hardware_wallet_interoperability'
-
 export type HardwareWalletInteroperabilityValue = Value & {
 	hardwareWalletSupport: HardwareWalletSupport
-	__brand: 'attributes.security.hardware_wallet_interoperability'
 }
 
 const majorHardwareWalletManufacturers: NonEmptyArray<HardwareWalletType> = [
@@ -78,7 +75,6 @@ function singleHardwareWalletManufacturerSupport(
 				{{WALLET_NAME}} only supports hardware wallets from a single major manufacturer.
 			`),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details:
 			mdParagraph(`{{WALLET_NAME}} supports ${supportsHardwareWalletTypesMarkdown(hardwareWalletSupport.wallets, false)}
@@ -106,7 +102,6 @@ function insufficientHardwareWalletManufacturerSupport(
 				{{WALLET_NAME}} supports a limited selection of hardware wallets.
 			`),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details:
 			mdParagraph(`{{WALLET_NAME}} supports ${supportsHardwareWalletTypesMarkdown(hardwareWalletSupport.wallets, false)}
@@ -128,7 +123,6 @@ function comprehensiveHardwareWalletSupport(
 			displayName: 'Interoperable hardware wallet support',
 			shortExplanation: sentence('{{WALLET_NAME}} supports a wide range of hardware wallets.'),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details: mdParagraph(
 			`{{WALLET_NAME}} supports ${supportsHardwareWalletTypesMarkdown(hardwareWalletSupport.wallets, false)}`,
@@ -273,13 +267,12 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 				sentence(
 					'This attribute is not applicable for {{WALLET_NAME}} as it is a hardware wallet itself.',
 				),
-				brand,
 				{ hardwareWalletSupport: { ref: refNotNecessary, wallets: {} } },
 			)
 		}
 
 		if (features.security.hardwareWalletSupport === null) {
-			return unrated(hardwareWalletInteroperability, brand, {
+			return unrated(hardwareWalletInteroperability, {
 				hardwareWalletSupport: { ref: refNotNecessary, wallets: {} },
 			})
 		}
@@ -306,7 +299,6 @@ export const hardwareWalletInteroperability: Attribute<HardwareWalletInteroperab
 					return exempt(
 						hardwareWalletInteroperability,
 						sentence('{{WALLET_NAME}} does not support any hardware wallet'),
-						brand,
 						{ hardwareWalletSupport: features.security.hardwareWalletSupport },
 					)
 				case 1:

--- a/src/schema/attributes/ecosystem/hw-app-connection-support.ts
+++ b/src/schema/attributes/ecosystem/hw-app-connection-support.ts
@@ -23,8 +23,6 @@ import { commaListFormat } from '@/types/utils/text'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.app_connection_support'
-
 /**
  * Converts a connection method enum value to its string representation
  */
@@ -64,9 +62,7 @@ function describeConnectionMethods(
 	return commaListFormat(methods)
 }
 
-export type AppConnectionSupportValue = Value & {
-	__brand: 'attributes.security.app_connection_support'
-}
+export type AppConnectionSupportValue = Value
 
 function noAppConnectionSupport(): Evaluation<AppConnectionSupportValue> {
 	return {
@@ -75,7 +71,6 @@ function noAppConnectionSupport(): Evaluation<AppConnectionSupportValue> {
 			rating: Rating.FAIL,
 			displayName: 'No app connection support',
 			shortExplanation: sentence('{{WALLET_NAME}} cannot connect to apps.'),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} does not provide any supported way to connect to Web3 applications. This prevents users from approving transactions, signing messages, or interacting with DeFi, NFT marketplaces, and other onchain apps. In practice, the wallet is limited to basic asset management (send/receive) and cannot be used as a primary Web3 wallet.',
@@ -95,7 +90,6 @@ function unverifiableAppConnectionSupport(): Evaluation<AppConnectionSupportValu
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} can connect to apps, but requires trusting unverifiable code.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			"{{WALLET_NAME}} can connect to apps, but only through its proprietary closed-source application. This requires users to trust the wallet provider's software without the ability to verify its security. This increases supply-chain risk, creates vendor lock-in, and limits interoperability with the broader Web3 ecosystem.",
@@ -117,7 +111,6 @@ function limitedVerifiableAppConnectionSupport(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} can connect to some apps using verifiable code or open standards, but with limitations.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			`{{WALLET_NAME}} supports connecting to apps through ${describeConnectionMethods(connectionDetails)}, which uses verifiable code and/or open standards. However, this support is not universal—users may be restricted to specific apps, specific connection flows, or a limited compatibility surface. As a result, some apps, or software wallets may not work reliably with {{WALLET_NAME}}.`,
@@ -139,7 +132,6 @@ function verifiableUniversalAppConnectionSupport(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} can connect to any app using entirely verifiable code or open standards.',
 			),
-			__brand: brand,
 		},
 		details: mdParagraph(
 			`{{WALLET_NAME}} supports connecting to apps through ${describeConnectionMethods(connectionDetails)} using open standards and verifiable components. This enables broad compatibility with Web3 apps while maintaining transparency—integrations can be inspected and do not depend on trusting closed, proprietary connection software.`,
@@ -158,7 +150,6 @@ function restrictedAppConnectionSupport(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} can connect to apps, but requires manufacturer approval for integrations.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			`{{WALLET_NAME}} supports connecting to apps through ${describeConnectionMethods(connectionDetails)}. However, integrating {{WALLET_NAME}} into software wallets or apps requires manufacturer consent. This creates friction for developers, limits ecosystem growth, and gives the manufacturer gatekeeping power over which apps and wallets can support {{WALLET_NAME}}.`,
@@ -296,7 +287,6 @@ limiting its utility.
 				sentence(
 					'This attribute is not applicable for {{WALLET_NAME}} as it is an ERC-4337 smart contract wallet.',
 				),
-				brand,
 				null,
 			)
 		}
@@ -312,7 +302,6 @@ limiting its utility.
 					shortExplanation: sentence(
 						'This attribute evaluates hardware wallet app connection capabilities and is not applicable for software wallets.',
 					),
-					__brand: brand,
 				},
 				details: paragraph(
 					'As {{WALLET_NAME}} is a software wallet, this attribute which evaluates hardware wallet app connection capabilities is not applicable. Software wallets inherently support app connections.',
@@ -324,7 +313,7 @@ limiting its utility.
 		const appSupport = features.appConnectionSupport
 
 		if (!appSupport) {
-			return unrated(appConnectionSupport, brand, null)
+			return unrated(appConnectionSupport, null)
 		}
 
 		// Extract references if supported
@@ -345,7 +334,7 @@ limiting its utility.
 			}
 
 			if (appSupport.requiresManufacturerConsent === null) {
-				return unrated(appConnectionSupport, brand, null)
+				return unrated(appConnectionSupport, null)
 			}
 
 			// Determine rating based on the best connection method available

--- a/src/schema/attributes/ecosystem/transaction-batching.ts
+++ b/src/schema/attributes/ecosystem/transaction-batching.ts
@@ -32,11 +32,7 @@ import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.ecosystem.transaction_batching'
-
-export type TransactionBatchingValue = Value & {
-	__brand: 'attributes.ecosystem.transaction_batching'
-}
+export type TransactionBatchingValue = Value
 
 function evaluateTransactionBatching(
 	accountSupport: AccountSupport,
@@ -54,7 +50,6 @@ function evaluateTransactionBatching(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not support transaction batching, as it does not support any type of smart account.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(`
 				{{WALLET_NAME}} does not implement any type of smart account.
@@ -83,7 +78,6 @@ function evaluateTransactionBatching(
 				displayName: 'No transaction batching support',
 				rating: Rating.FAIL,
 				shortExplanation: sentence('{{WALLET_NAME}} does not support transaction batching.'),
-				__brand: brand,
 			},
 			details: mdParagraph(`
 				{{WALLET_NAME}} does not implement ${eipMarkdownLinkAndTitle(eip5792)}.
@@ -110,7 +104,6 @@ function evaluateTransactionBatching(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} supports transaction batching, but not atomic transaction bundles.',
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(`
 				{{WALLET_NAME}} implements ${eipMarkdownLinkAndTitle(eip5792)}.
@@ -141,7 +134,6 @@ function evaluateTransactionBatching(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports transaction batching and atomic transaction bundles.',
 			),
-			__brand: brand,
 		},
 		details: mdParagraph(`
 			{{WALLET_NAME}} implements ${eipMarkdownLinkAndTitle(eip5792)}.
@@ -286,7 +278,6 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 			return exempt(
 				transactionBatching,
 				sentence('Only software wallets are expected to deal with transaction batching.'),
-				brand,
 				null,
 			)
 		}
@@ -298,13 +289,12 @@ export const transactionBatching: Attribute<TransactionBatchingValue> = {
 					{{WALLET_NAME}} is exempt as it is a payments-focused wallet,
 					for which transaction batching is not very useful.
 				`),
-				brand,
 				null,
 			)
 		}
 
 		if (features.accountSupport === null || features.integration.walletCall === null) {
-			return unrated(transactionBatching, brand, null)
+			return unrated(transactionBatching, null)
 		}
 
 		return evaluateTransactionBatching(features.accountSupport, features.integration.walletCall)

--- a/src/schema/attributes/privacy/address-correlation.ts
+++ b/src/schema/attributes/privacy/address-correlation.ts
@@ -38,11 +38,8 @@ import {
 } from '../../reference'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.privacy.address_correlation'
-
 export type AddressCorrelationValue = Value & {
 	worstLeak: WalletAddressLinkableBy | null
-	__brand: 'attributes.privacy.address_correlation'
 }
 
 const uncorrelated: AddressCorrelationValue = {
@@ -52,7 +49,6 @@ const uncorrelated: AddressCorrelationValue = {
 	displayName: 'Wallet address is kept private',
 	shortExplanation: sentence('{{WALLET_NAME}} keeps your wallet address private.'),
 	worstLeak: null,
-	__brand: brand,
 }
 
 export interface WalletAddressLinkableTo {
@@ -121,7 +117,6 @@ function linkable(
 					: `{{WALLET_NAME}} allows ${worstLeak.by.name} to link your wallet address with your ${userInfoName(worstLeak.info).short}.`,
 			),
 			worstLeak,
-			__brand: brand,
 		},
 		details: addressCorrelationDetailsContent({ linkables }),
 		howToImprove: paragraph(howToImprove),
@@ -301,7 +296,7 @@ export const addressCorrelation: Attribute<AddressCorrelationValue> = {
 		const allDataCollection = dataCollectionForAllSupportedFlows(features.privacy.dataCollection)
 
 		if (features.privacy.dataCollection === null || allDataCollection === null) {
-			return unrated(addressCorrelation, brand, { worstLeak: null })
+			return unrated(addressCorrelation, { worstLeak: null })
 		}
 
 		const linkables: WalletAddressLinkableBy[] = []

--- a/src/schema/attributes/privacy/app-isolation.ts
+++ b/src/schema/attributes/privacy/app-isolation.ts
@@ -27,11 +27,7 @@ import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.privacy.app_isolation'
-
-export type AppIsolationValue = Value & {
-	__brand: 'attributes.privacy.app_isolation'
-}
+export type AppIsolationValue = Value
 
 function rateAppIsolation(
 	appIsolation: Exclude<AppIsolation, typeof appConnectionNotSupported>,
@@ -48,7 +44,6 @@ function rateAppIsolation(
 					{{WALLET_NAME}} does not have an option to create a new account
 					as part of the app connection flow.
 				`),
-				__brand: brand,
 			},
 			details: markdown(`
 				When connecting to an app, {{WALLET_NAME}} does not provide a way
@@ -81,7 +76,6 @@ function rateAppIsolation(
 					{{WALLET_NAME}} does not remember which set of addresses you last
 					used when connecting to an app.
 				`),
-				__brand: brand,
 			},
 			details: markdown(`
 				When connecting to an app you have connected to before,
@@ -140,7 +134,6 @@ function rateAppIsolation(
 						{{WALLET_NAME}} defaults to reusing the same account when
 						connecting to various apps.
 					`),
-					__brand: brand,
 				},
 				details: markdown(`
 					When connecting to a new app, {{WALLET_NAME}} uses the same
@@ -169,7 +162,6 @@ function rateAppIsolation(
 						{{WALLET_NAME}} exposes all your accounts to all connected
 						apps by default.
 					`),
-					__brand: brand,
 				},
 				details: markdown(`
 					When connecting to an app, {{WALLET_NAME}} exposes all your
@@ -197,7 +189,6 @@ function rateAppIsolation(
 					shortExplanation: sentence(`
 						{{WALLET_NAME}} creates app-specific accounts by default.
 					`),
-					__brand: brand,
 				},
 				details: markdown(`
 					When connecting to an app, {{WALLET_NAME}} offers the user to
@@ -217,7 +208,6 @@ function rateAppIsolation(
 						{{WALLET_NAME}} supports the creation of app-specific accounts.
 						However, this isn't the default.
 					`),
-					__brand: brand,
 				},
 				details: markdown(`
 					When connecting to an app, {{WALLET_NAME}} offers the user to
@@ -369,20 +359,18 @@ export const appIsolation: Attribute<AppIsolationValue> = {
 			return exempt(
 				appIsolation,
 				sentence('Only software wallets are expected to deal with connecting to apps.'),
-				brand,
 				null,
 			)
 		}
 
 		if (features.privacy.appIsolation === null) {
-			return unrated(appIsolation, brand, null)
+			return unrated(appIsolation, null)
 		}
 
 		if (isAppConnectionSupportedInAppIsolation(features.privacy.appIsolation)) {
 			return exempt(
 				appIsolation,
 				sentence('{{WALLET_NAME}} does not support connecting to apps.'),
-				brand,
 				null,
 			)
 		}

--- a/src/schema/attributes/privacy/hardware-privacy.ts
+++ b/src/schema/attributes/privacy/hardware-privacy.ts
@@ -11,13 +11,10 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.hardware_privacy'
-
 export type HardwarePrivacyValue = Value & {
 	phoningHome: HardwarePrivacyType
 	inspectableRemoteCalls: HardwarePrivacyType
 	wirelessPrivacy: HardwarePrivacyType
-	__brand: 'attributes.hardware_privacy'
 }
 
 function evaluateHardwarePrivacy(features: HardwarePrivacySupport): Rating {
@@ -89,7 +86,7 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
 		pickWorstRating<HardwarePrivacyValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<HardwarePrivacyValue> => {
 		if (features.type !== WalletType.HARDWARE) {
-			return exempt(hardwarePrivacy, sentence('Only rated for hardware wallets'), brand, {
+			return exempt(hardwarePrivacy, sentence('Only rated for hardware wallets'), {
 				phoningHome: HardwarePrivacyType.FAIL,
 				inspectableRemoteCalls: HardwarePrivacyType.FAIL,
 				wirelessPrivacy: HardwarePrivacyType.FAIL,
@@ -99,7 +96,7 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
 		const hwPrivacy = features.privacy.hardwarePrivacy
 
 		if (hwPrivacy === null) {
-			return unrated(hardwarePrivacy, brand, {
+			return unrated(hardwarePrivacy, {
 				phoningHome: HardwarePrivacyType.FAIL,
 				inspectableRemoteCalls: HardwarePrivacyType.FAIL,
 				wirelessPrivacy: HardwarePrivacyType.FAIL,
@@ -115,7 +112,6 @@ export const hardwarePrivacy: Attribute<HardwarePrivacyValue> = {
 				displayName: 'Hardware Privacy',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} hardware privacy.`),
 				...hwPrivacy, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} hardware privacy evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/privacy/multi-address-correlation.ts
+++ b/src/schema/attributes/privacy/multi-address-correlation.ts
@@ -25,11 +25,7 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.privacy.multi_address_correlation'
-
-export type MultiAddressCorrelationValue = Value & {
-	__brand: 'attributes.privacy.multi_address_correlation'
-}
+export type MultiAddressCorrelationValue = Value
 
 function uniqueDestinations(references: ReferenceArray): Evaluation<MultiAddressCorrelationValue> {
 	return {
@@ -41,7 +37,6 @@ function uniqueDestinations(references: ReferenceArray): Evaluation<MultiAddress
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} uses unique endpoints for each wallet address, which keeps them uncorrelated.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'When configured with multiple addresses, {{WALLET_NAME}} uses unique RPC endpoints for each wallet address. Therefore, no single RPC endpoint gets to learn about more than one of your addresses.',
@@ -60,7 +55,6 @@ function activeAddressOnly(references: ReferenceArray): Evaluation<MultiAddressC
 			shortExplanation: sentence(
 				"{{WALLET_NAME}} only makes requests about one active address at a time, so it can't be correlated with other addresses.",
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} only has one active address at a time, and all outgoing RPC requests are only about that address. Additionally, the account switching UI does not perform bulk queries about all configured addresses in close succession.',
@@ -83,7 +77,6 @@ function activeAddressOnlyWithTrackingIdentifier(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} only makes requests about one active address at a time, but uses a tracking cookie across requests allowing addresses to be correlated over time.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(`
 			{{WALLET_NAME}} only has one active address at a time, and all outgoing RPC requests are only about that address.
@@ -109,7 +102,6 @@ function bulkRequests(references: ReferenceArray): Evaluation<MultiAddressCorrel
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} makes bulk requests containing multiple addresses to the same endpoint, which allows it to correlate your addresses.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'When configured with multiple addresses, {{WALLET_NAME}} makes requests that contain multiple addresses simultaneously.',
@@ -135,7 +127,6 @@ function correlatableRequests(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} makes requests about multiple addresses simultaneously to the same endpoint, which allows it to correlate your addresses.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'When configured with multiple addresses, {{WALLET_NAME}} makes separate requests for each wallet address, but these requests are sent simultaneously and without proxying. This allows the RPC endpoint to correlate your addresses.',
@@ -159,7 +150,6 @@ function staggeredRequests(references: ReferenceArray): Evaluation<MultiAddressC
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} staggers requests about multiple addresses over time time, which makes it harder to correlate your addresses.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(`
 			When configured with multiple addresses, {{WALLET_NAME}} makes requests
@@ -188,7 +178,6 @@ function separateCircuits(references: ReferenceArray): Evaluation<MultiAddressCo
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} uses distinct proxies to make requests about multiple addresses, which makes it harder to correlate your addresses.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'When configured with multiple addresses, {{WALLET_NAME}} makes requests that contain only one of your addresses at a time. While each of these requests go to the same endpoint, they each use a different proxy circuit in order to appear as coming from different IP addresses from the perspective of the endpoint. This provides an imperfect degree of privacy, as it makes it harder for the endpoint to correlate these requests as coming from the same user. However, since these requests are all made together simultaneously, the endpoint is still able to correlate them by grouping them across time.',
@@ -212,7 +201,6 @@ function staggeredAndSeparateCircuits(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} uses distinct proxies and staggers requests about multiple addresses over time, which makes it harder to correlate your addresses.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'When configured with multiple addresses, {{WALLET_NAME}} makes requests that contain only one of your addresses at a time. While each of these requests go to the same endpoint, they each use a different proxy circuit in order to appear as coming from different IP addresses from the perspective of the endpoint, and they are staggered over time. This provides a good degree of privacy, as it makes it harder for the endpoint to correlate these requests as coming from the same user. From the perspective of the endpoint, these requests come in from random IP addresses at random times, avoiding both IP-based and time-based correlation.',
@@ -229,7 +217,6 @@ function unsupported(): Evaluation<MultiAddressCorrelationValue> {
 			icon: '\u{1f4ce}', // Single paperclip
 			displayName: 'Multiple addresses unsupported',
 			shortExplanation: sentence('You can only use one address in {{WALLET_NAME}}.'),
-			__brand: brand,
 		},
 		details: paragraph(
 			'You can only use one address in {{WALLET_NAME}}, so multi-address privacy is irrelevant.',
@@ -429,7 +416,7 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<MultiAddressCorrelationValue> => {
 		if (features.multiAddress === null) {
-			return unrated(multiAddressCorrelation, brand, null)
+			return unrated(multiAddressCorrelation, null)
 		}
 
 		if (!isSupported(features.multiAddress)) {
@@ -439,7 +426,7 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 		const dataCollection = dataCollectionForAllSupportedFlows(features.privacy.dataCollection)
 
 		if (dataCollection === null) {
-			return unrated(multiAddressCorrelation, brand, null)
+			return unrated(multiAddressCorrelation, null)
 		}
 
 		let worstHandling: DataCollectionByEntity | null = null
@@ -454,7 +441,7 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 			}
 
 			if (!isQualifiedDataCollectionWithMultiAddress(dataCollection)) {
-				return unrated(multiAddressCorrelation, brand, null)
+				return unrated(multiAddressCorrelation, null)
 			}
 
 			allRefs.push(...refs(collected))
@@ -467,13 +454,13 @@ export const multiAddressCorrelation: Attribute<MultiAddressCorrelationValue> = 
 		}
 
 		if (worstHandling === null) {
-			return unrated(multiAddressCorrelation, brand, null)
+			return unrated(multiAddressCorrelation, null)
 		}
 
 		const worstCollection = qualifiedDataCollectionWithEndpoint(worstHandling.dataCollection)
 
 		if (!isQualifiedDataCollectionWithMultiAddress(worstCollection)) {
-			return unrated(multiAddressCorrelation, brand, null)
+			return unrated(multiAddressCorrelation, null)
 		}
 
 		const handling = worstCollection.multiAddress

--- a/src/schema/attributes/privacy/private-transfers.ts
+++ b/src/schema/attributes/privacy/private-transfers.ts
@@ -46,10 +46,7 @@ import { entityMarkdownLink } from '../../entity'
 import { mergeRefs, type ReferenceArray, refNotNecessary, refs } from '../../reference'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.privacy.private_transfers'
-
 export type PrivateTransfersValue = Value & {
-	__brand: 'attributes.privacy.private_transfers'
 	defaultFungibleTokenTransferMode: FungibleTokenTransferMode
 	perTechnology: Map<PrivateTransferTechnology, PrivateTransfersPrivacyLevels>
 }
@@ -145,7 +142,6 @@ function mergeEvaluations(
 			icon: worse.value.icon,
 			score: worse.value.score,
 			perTechnology: mergedMap,
-			__brand: brand,
 		},
 		details,
 		howToImprove: worse.howToImprove,
@@ -162,7 +158,6 @@ const noPrivateTransfers: Evaluation<PrivateTransfersValue> = {
 		shortExplanation: sentence('{{WALLET_NAME}} does not support private token transfers.'),
 		defaultFungibleTokenTransferMode: 'PUBLIC',
 		perTechnology: new Map(),
-		__brand: brand,
 	},
 	details: mdParagraph(
 		`
@@ -216,7 +211,6 @@ const nonDefault: Evaluation<PrivateTransfersValue> = {
 		),
 		defaultFungibleTokenTransferMode: 'PUBLIC',
 		perTechnology: new Map(),
-		__brand: brand,
 	},
 	details: privateTransfersDetailsContent({
 		privateTransferDetails: new Map(),
@@ -559,7 +553,6 @@ function rateStealthAddressSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.STEALTH_ADDRESSES,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -576,7 +569,6 @@ function rateStealthAddressSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.STEALTH_ADDRESSES,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -594,7 +586,6 @@ function rateStealthAddressSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.STEALTH_ADDRESSES,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -814,7 +805,6 @@ function rateTornadoCashNovaSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.TORNADO_CASH_NOVA,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -831,7 +821,6 @@ function rateTornadoCashNovaSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.TORNADO_CASH_NOVA,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -849,7 +838,6 @@ function rateTornadoCashNovaSupport(
 						),
 						defaultFungibleTokenTransferMode: PrivateTransferTechnology.TORNADO_CASH_NOVA,
 						perTechnology,
-						__brand: brand,
 					},
 					details,
 					howToImprove,
@@ -868,7 +856,6 @@ function rateTornadoCashNovaSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.TORNADO_CASH_NOVA,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -1164,7 +1151,6 @@ function ratePrivacyPoolsSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.PRIVACY_POOLS,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -1181,7 +1167,6 @@ function ratePrivacyPoolsSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.PRIVACY_POOLS,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -1198,7 +1183,6 @@ function ratePrivacyPoolsSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.PRIVACY_POOLS,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -1216,7 +1200,6 @@ function ratePrivacyPoolsSupport(
 						),
 						defaultFungibleTokenTransferMode: PrivateTransferTechnology.PRIVACY_POOLS,
 						perTechnology,
-						__brand: brand,
 					},
 					details,
 					howToImprove,
@@ -1235,7 +1218,6 @@ function ratePrivacyPoolsSupport(
 					),
 					defaultFungibleTokenTransferMode: PrivateTransferTechnology.PRIVACY_POOLS,
 					perTechnology,
-					__brand: brand,
 				},
 				details,
 				howToImprove,
@@ -1514,7 +1496,7 @@ export const privateTransfers: Attribute<PrivateTransfersValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<PrivateTransfersValue> => {
 		if (features.privacy.transactionPrivacy === null) {
-			return unrated(privateTransfers, brand, {
+			return unrated(privateTransfers, {
 				defaultFungibleTokenTransferMode: 'PUBLIC',
 				perTechnology: new Map(),
 			})

--- a/src/schema/attributes/security/account-recovery.ts
+++ b/src/schema/attributes/security/account-recovery.ts
@@ -39,10 +39,7 @@ import {
 import { evaluateAllGuardianScenarios } from '../../features/guardian-scenario/guardian-scenario-expansion'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.account_recovery'
-
 export type AccountRecoveryValue = Value & {
-	__brand: 'attributes.security.account_recovery'
 	minimumGuardianPolicy: GuardianPolicy | null
 	outcomes: NonEmptyArray<GuardianScenarioOutcome<GuardianScenarioType>> | null
 }
@@ -76,7 +73,6 @@ function evaluateGuardianRecoveryPolicy(
 				`),
 				minimumGuardianPolicy: guardianPolicy,
 				outcomes,
-				__brand: brand,
 			},
 			details: accountRecoveryDetailsContent({}),
 		}
@@ -93,7 +89,6 @@ function evaluateGuardianRecoveryPolicy(
 				),
 				minimumGuardianPolicy: guardianPolicy,
 				outcomes,
-				__brand: brand,
 			},
 			details: accountRecoveryDetailsContent({}),
 		}
@@ -110,7 +105,6 @@ function evaluateGuardianRecoveryPolicy(
 			`),
 			minimumGuardianPolicy: guardianPolicy,
 			outcomes,
-			__brand: brand,
 		},
 		details: accountRecoveryDetailsContent({}),
 	}
@@ -134,7 +128,6 @@ function evaluateAccountRecovery(
 			`),
 			minimumGuardianPolicy: null,
 			outcomes: null,
-			__brand: brand,
 		},
 		details: accountRecoveryDetailsContent({}),
 	}
@@ -311,7 +304,7 @@ export const accountRecovery: Attribute<AccountRecoveryValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<AccountRecoveryValue> => {
 		if (features.security.accountRecovery === null) {
-			return unrated(accountRecovery, brand, { minimumGuardianPolicy: null, outcomes: null })
+			return unrated(accountRecovery, { minimumGuardianPolicy: null, outcomes: null })
 		}
 
 		let references: FullyQualifiedReference[] = []

--- a/src/schema/attributes/security/bug-bounty-program.ts
+++ b/src/schema/attributes/security/bug-bounty-program.ts
@@ -26,11 +26,7 @@ import { commaListFormat } from '@/types/utils/text'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.bug_bounty_program'
-
-export type BugBountyProgramValue = Value & {
-	__brand: 'attributes.security.bug_bounty_program'
-}
+export type BugBountyProgramValue = Value
 
 function getCoverageDescription(breadth: AtLeastOneCoverageBreadth): string {
 	const items = setItems(breadth)
@@ -113,7 +109,6 @@ function noBugBountyProgram(): Evaluation<BugBountyProgramValue> {
 			shortExplanation: sentence(
 				"{{WALLET_NAME}} does not implement a bug bounty program and doesn't provide security updates.",
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} does not implement a bug bounty program and does not provide a clear path for security researchers to report vulnerabilities. The wallet also lacks a documented process for providing security updates to address critical issues.',
@@ -174,7 +169,6 @@ function bugBountyAvailable(support: BugBountyProgramSupport): Evaluation<BugBou
 			shortExplanation: mdSentence(
 				`{{WALLET_NAME}} has a bug bounty program${rewardInfo ? ` ${rewardInfo}` : ''}${isActive ? '' : ', but it is currently inactive'}.`,
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			${coverageInfo}
@@ -347,13 +341,12 @@ export const bugBountyProgram: Attribute<BugBountyProgramValue> = {
 			return exempt(
 				bugBountyProgram,
 				sentence('This attribute is only applicable for hardware wallets.'),
-				brand,
 				null,
 			)
 		}
 
 		if (features.security.bugBountyProgram === null) {
-			return unrated(bugBountyProgram, brand, null)
+			return unrated(bugBountyProgram, null)
 		}
 
 		if (!isSupported(features.security.bugBountyProgram)) {

--- a/src/schema/attributes/security/chain-verification.ts
+++ b/src/schema/attributes/security/chain-verification.ts
@@ -23,11 +23,7 @@ import {
 import { type FullyQualifiedReference, popRefs } from '../../reference'
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.chain_verification'
-
-export type ChainVerificationValue = Value & {
-	__brand: 'attributes.security.chain_verification'
-}
+export type ChainVerificationValue = Value
 
 function supportsChainVerification(
 	lightClients: NonEmptyArray<EthereumL1LightClient>,
@@ -39,7 +35,6 @@ function supportsChainVerification(
 			rating: Rating.PASS,
 			displayName: 'L1 chain state verification',
 			shortExplanation: sentence('{{WALLET_NAME}} verifies chain integrity of the Ethereum L1.'),
-			__brand: brand,
 		},
 		details: chainVerificationDetailsContent({ lightClients, refs }),
 		references: refs,
@@ -72,7 +67,6 @@ function noChainVerification(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} does not verify chain integrity of the Ethereum L1.',
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			{{WALLET_NAME}} does not verify the integrity of the Ethereum L1 blockchain when retrieving chain state or simulating transactions.
@@ -140,7 +134,6 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
 			return exempt(
 				chainVerification,
 				sentence('This attribute is not applicable for hardware wallets.'),
-				brand,
 				null,
 			)
 		}
@@ -148,7 +141,7 @@ export const chainVerification: Attribute<ChainVerificationValue> = {
 		const l1Client = features.security.lightClient.ethereumL1
 
 		if (l1Client === null) {
-			return unrated(chainVerification, brand, null)
+			return unrated(chainVerification, null)
 		}
 
 		if (!isSupported(l1Client)) {

--- a/src/schema/attributes/security/firmware.ts
+++ b/src/schema/attributes/security/firmware.ts
@@ -8,14 +8,11 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.firmware'
-
 export type FirmwareValue = Value & {
 	silentUpdateProtection: FirmwareType | null
 	firmwareOpenSource: FirmwareType | null
 	reproducibleBuilds: FirmwareType | null
 	customFirmware: FirmwareType | null
-	__brand: 'attributes.firmware'
 }
 
 function evaluateFirmware(features: FirmwareSupport): Rating {
@@ -93,7 +90,7 @@ export const firmware: Attribute<FirmwareValue> = {
 		pickWorstRating<FirmwareValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<FirmwareValue> => {
 		if (features.type !== WalletType.HARDWARE) {
-			return exempt(firmware, sentence('Firmware is only rated for hardware wallets'), brand, {
+			return exempt(firmware, sentence('Firmware is only rated for hardware wallets'), {
 				silentUpdateProtection: FirmwareType.FAIL,
 				firmwareOpenSource: FirmwareType.FAIL,
 				reproducibleBuilds: FirmwareType.FAIL,
@@ -104,7 +101,7 @@ export const firmware: Attribute<FirmwareValue> = {
 		const firmwareFeature = features.security.firmware
 
 		if (firmwareFeature === null) {
-			return unrated(firmware, brand, {
+			return unrated(firmware, {
 				silentUpdateProtection: FirmwareType.FAIL,
 				firmwareOpenSource: FirmwareType.FAIL,
 				reproducibleBuilds: FirmwareType.FAIL,
@@ -115,7 +112,7 @@ export const firmware: Attribute<FirmwareValue> = {
 		const rating = evaluateFirmware(firmwareFeature)
 
 		if (rating === Rating.UNRATED) {
-			return unrated(firmware, brand, {
+			return unrated(firmware, {
 				silentUpdateProtection: FirmwareType.FAIL,
 				firmwareOpenSource: FirmwareType.FAIL,
 				reproducibleBuilds: FirmwareType.FAIL,
@@ -130,7 +127,6 @@ export const firmware: Attribute<FirmwareValue> = {
 				displayName: 'Firmware',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} firmware.`),
 				...firmwareFeature, // TODO: Filter fields.
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} firmware evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/security/hardware-wallet-support.ts
+++ b/src/schema/attributes/security/hardware-wallet-support.ts
@@ -22,11 +22,8 @@ import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.hardware_wallet_support'
-
 export type HardwareWalletSupportValue = Value & {
 	hardwareWalletSupport: HardwareWalletSupport
-	__brand: 'attributes.security.hardware_wallet_support'
 }
 
 function noHardwareWalletSupport(
@@ -39,7 +36,6 @@ function noHardwareWalletSupport(
 			displayName: 'No hardware wallet support',
 			shortExplanation: sentence('{{WALLET_NAME}} does not support hardware wallets.'),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details: paragraph(`
 			{{WALLET_NAME}} does not support hardware wallets.
@@ -65,7 +61,6 @@ function indirectHardwareWalletSupport(
 				Using a hardware wallet with {{WALLET_NAME}} requires additional software.
 			`),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details:
 			paragraph(`{{WALLET_NAME}} supports ${supportsHardwareWalletTypesMarkdown(hardwareWalletSupport.wallets, true)}
@@ -94,7 +89,6 @@ function directHardwareWalletSupport(
 			displayName: 'Supports hardware wallets',
 			shortExplanation: sentence('{{WALLET_NAME}} supports hardware wallets.'),
 			hardwareWalletSupport,
-			__brand: brand,
 		},
 		details: mdParagraph(
 			`{{WALLET_NAME}} supports ${supportsHardwareWalletTypesMarkdown(hardwareWalletSupport.wallets, true)}`,
@@ -190,7 +184,6 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 				sentence(
 					'This attribute is not applicable for {{WALLET_NAME}} as it is a hardware wallet itself.',
 				),
-				brand,
 				{ hardwareWalletSupport: { wallets: {}, ref: refNotNecessary } },
 			)
 		}
@@ -199,7 +192,7 @@ export const hardwareWalletSupport: Attribute<HardwareWalletSupportValue> = {
 		// 	all such wallets have the opportunity to support hardware wallets to provide better security for the user
 
 		if (features.security.hardwareWalletSupport === null) {
-			return unrated(hardwareWalletSupport, brand, {
+			return unrated(hardwareWalletSupport, {
 				hardwareWalletSupport: { wallets: {}, ref: refNotNecessary },
 			})
 		}

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -17,12 +17,9 @@ import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.passkey_implementation'
-
 export type PasskeyImplementationValue = Value & {
 	library: PasskeyVerificationLibrary | null
 	libraryUrl?: string
-	__brand: 'attributes.security.passkey_implementation'
 }
 
 function noPasskeyImplementation(): Evaluation<PasskeyImplementationValue> {
@@ -35,7 +32,6 @@ function noPasskeyImplementation(): Evaluation<PasskeyImplementationValue> {
 				'{{WALLET_NAME}} does not implement passkeys or does not use a recognized verification library.',
 			),
 			library: null,
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} either does not implement passkeys or does not use a recognized verification library for P256/R1 curve operations. Passkeys provide a more secure authentication method than traditional passwords, but proper implementation is crucial for security.',
@@ -59,7 +55,6 @@ function otherPasskeyImplementation(
 			),
 			library: PasskeyVerificationLibrary.OTHER,
 			libraryUrl: support.libraryUrl,
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} implements passkeys using a less common verification library. While this provides better security than no passkey support, using a well-audited and widely recognized library would provide stronger security guarantees.',
@@ -86,7 +81,6 @@ function freshCryptoLibImplementation(
 				support.libraryUrl !== undefined && support.libraryUrl !== ''
 					? support.libraryUrl
 					: 'https://github.com/rdubois-crypto/FreshCryptoLib',
-			__brand: brand,
 		},
 		details: mdParagraph(
 			'{{WALLET_NAME}} implements passkeys using [Fresh Crypto Lib](https://github.com/rdubois-crypto/FreshCryptoLib). While this is a well-regarded library, it has not undergone as extensive auditing and testing as [Smooth Crypto Lib](https://github.com/get-smooth/crypto-lib).',
@@ -113,7 +107,6 @@ function smoothCryptoLibImplementation(
 				support.libraryUrl !== undefined && support.libraryUrl !== ''
 					? support.libraryUrl
 					: 'https://github.com/get-smooth/crypto-lib',
-			__brand: brand,
 		},
 		details: mdParagraph(
 			'{{WALLET_NAME}} implements passkeys using [Smooth Crypto Lib](https://github.com/get-smooth/crypto-lib), at 159K this the most gas-efficient ( and [triple audited](https://github.com/get-smooth/crypto-lib/tree/main/doc/Audits) verification library for P256/R1 curve operations.',
@@ -138,7 +131,6 @@ function daimoP256VerifierImplementation(
 				support.libraryUrl !== undefined && support.libraryUrl !== ''
 					? support.libraryUrl
 					: 'https://github.com/daimo-eth/p256-verifier',
-			__brand: brand,
 		},
 		details: mdParagraph(
 			'{{WALLET_NAME}} implements passkeys using [Daimo P256 verifier](https://github.com/daimo-eth/p256-verifier), a well-audited verification library for P256/R1 curve operations. Costs 330K gas.',
@@ -163,7 +155,6 @@ function openZeppelinP256VerifierImplementation(
 				support.libraryUrl !== undefined && support.libraryUrl !== ''
 					? support.libraryUrl
 					: 'https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/P256.sol',
-			__brand: brand,
 		},
 		details: mdParagraph(
 			'{{WALLET_NAME}} implements passkeys using [OpenZeppelin P256 verifier](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/P256.sol), a well-audited verification library for P256/R1 curve operations from the respected OpenZeppelin team. This implementation provides strong security guarantees and has been [thoroughly reviewed.](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/audits/2024-10-v5.1.pdf)',
@@ -186,7 +177,6 @@ function webAuthnSolImplementation(
 				support.libraryUrl !== undefined && support.libraryUrl !== ''
 					? support.libraryUrl
 					: 'https://github.com/base/webauthn-sol',
-			__brand: brand,
 		},
 		details: mdParagraph(
 			"{{WALLET_NAME}} implements passkeys using WebAuthn.sol from Base, a Solidity library for verifying WebAuthn authentication assertions. It builds on Daimo's WebAuthn.sol. This library is optimized for Ethereum layer 2 rollup chains but will work on all EVM chains. Signature verification always attempts to use the RIP-7212 precompile and, if this fails, falls back to using FreshCryptoLib. The library has been [audited](https://github.com/coinbase/smart-wallet/tree/main/audits)",
@@ -309,7 +299,7 @@ export const passkeyImplementation: Attribute<PasskeyImplementationValue> = {
 		const passkeyVerification = features.security.passkeyVerification
 
 		if (passkeyVerification === null) {
-			return unrated(passkeyImplementation, brand, { library: null })
+			return unrated(passkeyImplementation, { library: null })
 		}
 
 		if (!isSupported(passkeyVerification)) {

--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -26,8 +26,6 @@ export type ScamAlertSupport = WithRef<{
 	listFeature: string
 }>
 
-const brand = 'attributes.security.scam_alert'
-
 export type ScamPreventionValue = Value &
 	(
 		| {
@@ -43,9 +41,7 @@ export type ScamPreventionValue = Value &
 				}
 		  }
 		| { scamAlerts: null }
-	) & {
-		__brand: 'attributes.security.scam_alert'
-	}
+	)
 
 function rateSendTransactionWarning(scamAlerts: ScamAlerts): ScamAlertSupport & {
 	feature: 'sendTransactionWarning'
@@ -212,7 +208,6 @@ function evaluateScamAlerts(
 				sendTransactionWarning,
 				contractTransactionWarning,
 				scamUrlWarning,
-				__brand: brand,
 			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: paragraph('{{WALLET_NAME}} should implement scam alerting features.'),
@@ -241,7 +236,6 @@ function evaluateScamAlerts(
 					sendTransactionWarning,
 					contractTransactionWarning,
 					scamUrlWarning,
-					__brand: brand,
 				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
@@ -269,7 +263,6 @@ function evaluateScamAlerts(
 					sendTransactionWarning,
 					contractTransactionWarning,
 					scamUrlWarning,
-					__brand: brand,
 				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
@@ -296,7 +289,6 @@ function evaluateScamAlerts(
 				sendTransactionWarning,
 				contractTransactionWarning,
 				scamUrlWarning,
-				__brand: brand,
 			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: markdown(`
@@ -331,7 +323,6 @@ function evaluateScamAlerts(
 				sendTransactionWarning,
 				contractTransactionWarning,
 				scamUrlWarning,
-				__brand: brand,
 			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: markdown(`
@@ -371,7 +362,6 @@ function evaluateScamAlerts(
 			sendTransactionWarning,
 			contractTransactionWarning,
 			scamUrlWarning,
-			__brand: brand,
 		},
 		details: scamAlertsDetailsContent({}),
 		references: allRefs,
@@ -559,7 +549,7 @@ export const scamPrevention: Attribute<ScamPreventionValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<ScamPreventionValue> => {
 		if (features.security.scamAlerts === null) {
-			return unrated(scamPrevention, brand, { scamAlerts: null })
+			return unrated(scamPrevention, { scamAlerts: null })
 		}
 
 		return evaluateScamAlerts(features.profile, features.security.scamAlerts)

--- a/src/schema/attributes/security/security-audits.ts
+++ b/src/schema/attributes/security/security-audits.ts
@@ -18,11 +18,8 @@ import { isNonEmptyArray, type NonEmptyArray } from '@/types/utils/non-empty'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.security_audits'
-
 export type SecurityAuditsValue = Value & {
 	securityAudits: SecurityAudit[]
-	__brand: 'attributes.security.security_audits'
 }
 
 function noAudits(): Evaluation<SecurityAuditsValue> {
@@ -33,7 +30,6 @@ function noAudits(): Evaluation<SecurityAuditsValue> {
 			displayName: 'No security audits',
 			shortExplanation: sentence('{{WALLET_NAME}} has not undergone security auditing.'),
 			securityAudits: [],
-			__brand: brand,
 		},
 		details: paragraph('{{WALLET_NAME}} has not undergone any security auditing.'),
 		references: [],
@@ -103,7 +99,6 @@ function audited(
 			displayName,
 			shortExplanation,
 			securityAudits: audits,
-			__brand: brand,
 		},
 		details: securityAuditsDetailsContent({
 			auditedInLastYear,
@@ -204,13 +199,12 @@ export const securityAudits: Attribute<SecurityAuditsValue> = {
 			return exempt(
 				securityAudits,
 				sentence('This attribute is not applicable to hardware wallets.'),
-				brand,
 				{ securityAudits: [] },
 			)
 		}
 
 		if (features.security.publicSecurityAudits === null) {
-			return unrated(securityAudits, brand, { securityAudits: [] })
+			return unrated(securityAudits, { securityAudits: [] })
 		}
 
 		if (!isNonEmptyArray(features.security.publicSecurityAudits)) {

--- a/src/schema/attributes/security/supply-chain-diy.ts
+++ b/src/schema/attributes/security/supply-chain-diy.ts
@@ -19,12 +19,9 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.supply_chain_diy'
-
 export type SupplyChainDIYValue = Value & {
 	diyNoNda: SupplyChainDIYType
 	componentSourcingComplexity: SupplyChainDIYType
-	__brand: 'attributes.supply_chain_diy'
 }
 
 function evaluateSupplyChainDIY(features: SupplyChainDIYSupport): Rating {
@@ -97,15 +94,10 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 			features.variant === Variant.HARDWARE &&
 			metadata.hardwareWalletManufactureType !== HardwareWalletManufactureType.DIY
 		) {
-			return exempt(
-				supplyChainDIY,
-				sentence('Attribute only applies to DIY hardware wallets.'),
-				brand,
-				{
-					diyNoNda: SupplyChainDIYType.FAIL,
-					componentSourcingComplexity: SupplyChainDIYType.FAIL,
-				},
-			)
+			return exempt(supplyChainDIY, sentence('Attribute only applies to DIY hardware wallets.'), {
+				diyNoNda: SupplyChainDIYType.FAIL,
+				componentSourcingComplexity: SupplyChainDIYType.FAIL,
+			})
 		}
 
 		return null
@@ -117,7 +109,6 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 				sentence(
 					'This attribute is not applicable for {{WALLET_NAME}} as it is not a hardware wallet.',
 				),
-				brand,
 				{
 					diyNoNda: SupplyChainDIYType.FAIL,
 					componentSourcingComplexity: SupplyChainDIYType.FAIL,
@@ -128,7 +119,7 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 		const diyFeature = features.security.supplyChainDIY
 
 		if (diyFeature === null) {
-			return unrated(supplyChainDIY, brand, {
+			return unrated(supplyChainDIY, {
 				diyNoNda: SupplyChainDIYType.FAIL,
 				componentSourcingComplexity: SupplyChainDIYType.FAIL,
 			})
@@ -143,7 +134,6 @@ export const supplyChainDIY: Attribute<SupplyChainDIYValue> = {
 				displayName: 'Supply Chain DIY',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} DIY supply chain.`),
 				...diyFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} DIY supply chain evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/security/supply-chain-factory.ts
+++ b/src/schema/attributes/security/supply-chain-factory.ts
@@ -19,8 +19,6 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.supply_chain_factory'
-
 export type SupplyChainFactoryValue = Value & {
 	factoryOpsecDocs: SupplyChainFactoryType
 	factoryOpsecAudit: SupplyChainFactoryType
@@ -28,7 +26,6 @@ export type SupplyChainFactoryValue = Value & {
 	hardwareVerification: SupplyChainFactoryType
 	tamperResistance: SupplyChainFactoryType
 	genuineCheck: SupplyChainFactoryType
-	__brand: 'attributes.security.supply_chain_factory'
 }
 
 function evaluateSupplyChainFactory(features: SupplyChainFactorySupport): Rating {
@@ -119,7 +116,6 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 			return exempt(
 				supplyChainFactory,
 				sentence('Attribute only applies to factory-made hardware wallets.'),
-				brand,
 				{
 					factoryOpsecDocs: SupplyChainFactoryType.FAIL,
 					factoryOpsecAudit: SupplyChainFactoryType.FAIL,
@@ -140,7 +136,6 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 				sentence(
 					'This attribute is not applicable for {{WALLET_NAME}} as it is not a hardware wallet.',
 				),
-				brand,
 				{
 					factoryOpsecDocs: SupplyChainFactoryType.FAIL,
 					factoryOpsecAudit: SupplyChainFactoryType.FAIL,
@@ -155,7 +150,7 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 		const factoryFeature = features.security.supplyChainFactory
 
 		if (factoryFeature === null) {
-			return unrated(supplyChainFactory, brand, {
+			return unrated(supplyChainFactory, {
 				factoryOpsecDocs: SupplyChainFactoryType.FAIL,
 				factoryOpsecAudit: SupplyChainFactoryType.FAIL,
 				tamperEvidence: SupplyChainFactoryType.FAIL,
@@ -176,7 +171,6 @@ export const supplyChainFactory: Attribute<SupplyChainFactoryValue> = {
 					`{{WALLET_NAME}} has ${rating.toLowerCase()} factory supply chain.`,
 				),
 				...factoryFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(
 				`{{WALLET_NAME}} factory supply chain evaluation is ${rating.toLowerCase()}.`,

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -29,11 +29,7 @@ import { commaListFormat } from '@/types/utils/text'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.transaction_legibility'
-
-export type TransactionLegibilityValue = Value & {
-	__brand: 'attributes.transaction_legibility'
-}
+export type TransactionLegibilityValue = Value
 
 // Message signing evaluation helpers
 
@@ -383,7 +379,6 @@ function hardwareNoTransactionLegibility(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} does not display clear transaction details on the hardware device when signing.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} implements either zero or very little transaction legibility on the hardware device itself. Transaction legibility is important for security as it allows users to verify transaction details directly on their hardware wallet screen before signing, without relying on potentially compromised software.\n\n${featureDetailsMarkdown}`,
@@ -409,7 +404,6 @@ function hardwareBasicTransactionLegibility(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports basic transaction legibility on the hardware device.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports basic transaction legibility on the hardware device, but the implementation does not provide full transparency. The device may display some transaction details or support basic calldata decoding, but lacks comprehensive support for complex transactions, all essential details, or advanced data extraction methods.\n\n${featureDetailsMarkdown}`,
@@ -435,7 +429,6 @@ function hardwarePartialTransactionLegibility(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports partial transaction legibility on the hardware device.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports partial transaction legibility on the hardware device. The device displays most transaction details and may support calldata decoding for some transaction types, but may not fully decode complex nested transactions or provide all data extraction methods. Showing transaction details directly on the hardware device is crucial for security as it allows users to verify transaction details independently of potentially compromised software.\n\n${featureDetailsMarkdown}`,
@@ -460,7 +453,6 @@ function hardwareFullTransactionLegibility(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports full transaction legibility on the hardware device.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} implements full transaction legibility on the hardware device itself. All transaction details are clearly displayed on the device screen, the device supports decoding of complex nested transactions, and provides comprehensive data extraction methods (QR codes, hashes) for independent verification before signing, providing maximum security and transparency for users.\n\n${featureDetailsMarkdown}`,
@@ -658,7 +650,6 @@ function softwareNoTransactionLegibility(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} does not display clear transaction details when signing.',
 			),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} implements either zero or very little transaction legibility. The wallet does not adequately display calldata in multiple formats (raw hex, formatted, copyable) or essential transaction details (gas, nonce, from, to, chain, value). Transaction legibility is important for security as it allows users to verify transaction details on their wallet screen before signing.\n\n${featureDetailsMarkdown}`,
@@ -682,7 +673,6 @@ function softwarePartialTransactionLegibility(
 			rating: Rating.PARTIAL,
 			displayName: 'Partial transaction legibility support',
 			shortExplanation: sentence('{{WALLET_NAME}} supports partial transaction legibility.'),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} supports some transaction legibility features, but not all. The wallet may display some calldata formats or some transaction details, but lacks comprehensive support for all calldata display methods (raw hex, formatted, copyable) or all essential transaction details (gas, nonce, from, to, chain, value). Showing transaction details is crucial for security as it allows users to verify transaction details before signing.\n\n${featureDetailsMarkdown}`,
@@ -705,7 +695,6 @@ function softwareFullTransactionLegibility(
 			rating: Rating.PASS,
 			displayName: 'Full transaction legibility support',
 			shortExplanation: sentence('{{WALLET_NAME}} supports full transaction legibility.'),
-			__brand: brand,
 		},
 		details: markdown(
 			`{{WALLET_NAME}} implements full transaction legibility. The wallet supports comprehensive calldata display (raw hex format, formatted output, and copy to clipboard) and displays all essential transaction details clearly on the wallet screen/window for verification before signing, providing maximum security and transparency for users.\n\n${featureDetailsMarkdown}`,
@@ -795,7 +784,7 @@ function evaluateHardwareWalletTransactionLegibility(
 
 	const result = ((): Evaluation<TransactionLegibilityValue> => {
 		if (overallRating === Rating.UNRATED) {
-			return unrated(transactionLegibility, brand, null)
+			return unrated(transactionLegibility, null)
 		}
 
 		if (overallRating === Rating.FAIL) {
@@ -830,7 +819,7 @@ function evaluateSoftwareWalletTransactionLegibility(
 		transactionLegibilitySupport
 
 	if (calldataDisplay === null || transactionDetailsDisplay === null) {
-		return unrated(transactionLegibility, brand, null)
+		return unrated(transactionLegibility, null)
 	}
 
 	// Evaluate message signing (PASS/FAIL only)
@@ -1081,7 +1070,7 @@ export const transactionLegibility: Attribute<TransactionLegibilityValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<TransactionLegibilityValue> => {
 		if (features.security.transactionLegibility === null) {
-			return unrated(transactionLegibility, brand, null)
+			return unrated(transactionLegibility, null)
 		}
 
 		if (isHardwareTransactionLegibility(features.security.transactionLegibility)) {

--- a/src/schema/attributes/security/user-safety.ts
+++ b/src/schema/attributes/security/user-safety.ts
@@ -13,8 +13,6 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.user_safety'
-
 export type UserSafetyValue = Value & {
 	readableAddress: UserSafetyType
 	contractLabeling: UserSafetyType
@@ -32,7 +30,6 @@ export type UserSafetyValue = Value & {
 	txSimulation: UserSafetyType
 	txSimulationLocal: UserSafetyType
 	fullyLocalTxSimulation: UserSafetyType
-	__brand: 'attributes.user_safety'
 }
 
 function evaluateUserSafety(features: UserSafetySupport): Rating {
@@ -153,7 +150,6 @@ export const userSafety: Attribute<UserSafetyValue> = {
 				sentence(
 					'This attribute evaluates hardware wallet user safety features and is not applicable for {{WALLET_NAME}}.',
 				),
-				brand,
 				{
 					readableAddress: UserSafetyType.FAIL,
 					contractLabeling: UserSafetyType.FAIL,
@@ -178,7 +174,7 @@ export const userSafety: Attribute<UserSafetyValue> = {
 		const userSafetyFeature = features.security.userSafety
 
 		if (userSafetyFeature === null) {
-			return unrated(userSafety, brand, {
+			return unrated(userSafety, {
 				readableAddress: UserSafetyType.FAIL,
 				contractLabeling: UserSafetyType.FAIL,
 				rawTxReview: UserSafetyType.FAIL,
@@ -235,7 +231,6 @@ export const userSafety: Attribute<UserSafetyValue> = {
 				displayName: 'User Safety',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} user safety.`),
 				...userSafetyFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(detailsText),
 			// TODO: Add references

--- a/src/schema/attributes/self-sovereignty/account-portability.ts
+++ b/src/schema/attributes/self-sovereignty/account-portability.ts
@@ -26,11 +26,7 @@ import { isNonEmptyArray, nonEmptyGet } from '@/types/utils/non-empty'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.self_sovereignty.account_portability'
-
-export type AccountPortabilityValue = Value & {
-	__brand: 'attributes.self_sovereignty.account_portability'
-}
+export type AccountPortabilityValue = Value
 
 function evaluateEoa(
 	eoa: AccountTypeEoa,
@@ -49,7 +45,6 @@ function evaluateEoa(
 				rating: Rating.PASS,
 				displayName: 'Standards-compliant EOA with seed phrase',
 				shortExplanation: sentence('{{WALLET_NAME}} follows EOA key derivation standards.'),
-				__brand: brand,
 			},
 			details: mdParagraph(`
 				{{WALLET_NAME}} generates EOA keys in a
@@ -84,7 +79,6 @@ function evaluateEoa(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not follow key derivation standards for EOA keys, but lets you export them to other wallets.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} generates EOA keys in a non-standard way. However, these keys can be exported into other wallets, avoiding lock-in.',
@@ -108,7 +102,6 @@ function evaluateEoa(
 			shortExplanation: sentence(
 				"{{WALLET_NAME}} locks you in by not allowing you to export your account's private key.",
 			),
-			__brand: brand,
 		},
 		details: paragraph("{{WALLET_NAME}} does not allow you to export your account's private key."),
 		impact: paragraph(
@@ -133,7 +126,6 @@ function evaluateMpc(
 				shortExplanation: sentence(
 					"By default, users of {{WALLET_NAME}} do not custody enough shares of the account's private key to control it.",
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. By default, the user does not custody enough shares of this private key in order to control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet.',
@@ -161,7 +153,6 @@ function evaluateMpc(
 				shortExplanation: sentence(
 					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on an external party.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully own the account, but generating an asset withdrawal transaction nonetheless requires interaction with an external service.',
@@ -188,7 +179,6 @@ function evaluateMpc(
 				shortExplanation: sentence(
 					'Withdrawing assets out of {{WALLET_NAME}} requires the use of a proprietary application.',
 				),
-				__brand: brand,
 			},
 			details: paragraph(
 				'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully own the account, but generating an asset withdrawal transaction nonetheless requires the use of a proprietary application.',
@@ -211,7 +201,6 @@ function evaluateMpc(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} puts the user in control of their MPC private key.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} is an MPC wallet, with the private key split up into multiple shares. The user owns enough shares to fully control the account, and can generate transactions without relying on an external provider.',
@@ -237,7 +226,6 @@ function evaluateMultifactor(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} is not self-custodial, and cannot be converted to become self-custodial.',
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				`{{WALLET_NAME}} is an ${eipMarkdownLink(eip)} (Smart Contract) wallet. The account control logic in the smart contract cannot be updated to put the user fully in control of the account.`,
@@ -266,7 +254,6 @@ function evaluateMultifactor(
 					shortExplanation: sentence(
 						'{{WALLET_NAME}} is not self-custodial by default, and changing this requires cooperation from an external provider.',
 					),
-					__brand: brand,
 				},
 				details: markdown(`
 					{{WALLET_NAME}} is an ${eipMarkdownLink(eip)} (Smart Contract) wallet. By default, the user does not have the ability to unilaterally control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet.
@@ -298,7 +285,6 @@ function evaluateMultifactor(
 					shortExplanation: sentence(
 						'{{WALLET_NAME}} is not self-custodial by default, and changing this requires a proprietary application.',
 					),
-					__brand: brand,
 				},
 				details: mdParagraph(`
 					{{WALLET_NAME}} is an ${eipMarkdownLink(eip)} (Smart Contract) wallet. By default, the user does not have the ability to unilaterally control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet.
@@ -327,7 +313,6 @@ function evaluateMultifactor(
 				shortExplanation: sentence(
 					'Withdrawing assets out of {{WALLET_NAME}} cannot be done without relying on an external provider.',
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				'Users of {{WALLET_NAME}} cannot generate asset transfer transactions without relying on an external provider.',
@@ -355,7 +340,6 @@ function evaluateMultifactor(
 				shortExplanation: sentence(
 					'Withdrawing assets out of {{WALLET_NAME}} requires the use of a proprietary application.',
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				'Generating an asset transfer transaction with {{WALLET_NAME}} requires the user of a proprietary application.',
@@ -381,7 +365,6 @@ function evaluateMultifactor(
 				rating: Rating.PARTIAL,
 				displayName: 'Not self-custodial by default',
 				shortExplanation: sentence('{{WALLET_NAME}} is not self-custodial by default.'),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				`{{WALLET_NAME}} is an ${eipMarkdownLink(erc4337)} (Smart Contract) wallet. By default, the user does not have the ability to unilaterally control the account. Therefore, {{WALLET_NAME}} is not a self-custodial wallet. However, the user *can* update the smart contract control logic to turn the account into a self-custodial wallet.`,
@@ -401,7 +384,6 @@ function evaluateMultifactor(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} is self-custodial and puts the user in control of their smart contract wallet without lock-in.',
 			),
-			__brand: brand,
 		},
 		details: mdParagraph(
 			`{{WALLET_NAME}} is an ${eipMarkdownLink(erc4337)} (Smart Contract) wallet. By default, the user holds sufficient authority to generate and broadcast arbitrary transactions and can do so without relying on an external provider, including transactions which update the smart contract's control logic over the account (e.g. for key rotation).`,
@@ -424,7 +406,6 @@ function evaluateSafe(
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} is not self-custodial, and cannot be converted to become self-custodial.',
 				),
-				__brand: brand,
 			},
 			details: mdParagraph(
 				'{{WALLET_NAME}} is a Safe multisig wallet. The account control logic cannot be updated to put the user fully in control of the account.',
@@ -447,7 +428,6 @@ function evaluateSafe(
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} is self-custodial and puts the user in control of their Safe wallet without lock-in.',
 			),
-			__brand: brand,
 		},
 		details: mdParagraph(
 			'{{WALLET_NAME}} is a Safe multisig wallet. By default, the user holds sufficient authority to generate and broadcast arbitrary transactions and can do so without relying on an external provider, including transactions which update the control logic (e.g., for owner changes).',
@@ -789,7 +769,7 @@ export const accountPortability: Attribute<AccountPortabilityValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<AccountPortabilityValue> => {
 		if (features.accountSupport === null) {
-			return unrated(accountPortability, brand, null)
+			return unrated(accountPortability, null)
 		}
 
 		const allRefs = mergeRefs(

--- a/src/schema/attributes/self-sovereignty/account-unruggability.ts
+++ b/src/schema/attributes/self-sovereignty/account-unruggability.ts
@@ -43,10 +43,7 @@ import {
 import { evaluateAllGuardianScenarios } from '../../features/guardian-scenario/guardian-scenario-expansion'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.security.account_unruggability'
-
 export type AccountUnruggabilityValue = Value & {
-	__brand: 'attributes.security.account_unruggability'
 	minimumGuardianPolicy: GuardianPolicy | null
 	outcomes: NonEmptyArray<GuardianScenarioOutcome<GuardianScenarioType>> | null
 }
@@ -80,7 +77,6 @@ function evaluateGuardianUnruggabilityPolicy(
 				`),
 				minimumGuardianPolicy: guardianPolicy,
 				outcomes,
-				__brand: brand,
 			},
 			details: accountUnruggabilityDetailsContent({}),
 		}
@@ -97,7 +93,6 @@ function evaluateGuardianUnruggabilityPolicy(
 				),
 				minimumGuardianPolicy: guardianPolicy,
 				outcomes,
-				__brand: brand,
 			},
 			details: accountUnruggabilityDetailsContent({}),
 		}
@@ -114,7 +109,6 @@ function evaluateGuardianUnruggabilityPolicy(
 			`),
 			minimumGuardianPolicy: guardianPolicy,
 			outcomes,
-			__brand: brand,
 		},
 		details: accountUnruggabilityDetailsContent({}),
 	}
@@ -141,7 +135,6 @@ function evaluateAccountUnruggability(
 					`),
 					minimumGuardianPolicy: null,
 					outcomes: null,
-					__brand: brand,
 				},
 				details: markdown(`
 					Key generation with {{WALLET_NAME}} occurs off-device. This means
@@ -172,7 +165,6 @@ function evaluateAccountUnruggability(
 					`),
 					minimumGuardianPolicy: null,
 					outcomes: null,
-					__brand: brand,
 				},
 				details: markdown(`
 					{{WALLET_NAME}} uses multi-party computation to derive the account's
@@ -203,7 +195,6 @@ function evaluateAccountUnruggability(
 			`),
 			minimumGuardianPolicy: null,
 			outcomes: null,
-			__brand: brand,
 		},
 		details: accountUnruggabilityDetailsContent({}),
 	}
@@ -394,7 +385,7 @@ export const accountUnruggability: Attribute<AccountUnruggabilityValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<AccountUnruggabilityValue> => {
 		if (features.security.keysHandling === null || features.security.accountRecovery === null) {
-			return unrated(accountUnruggability, brand, { minimumGuardianPolicy: null, outcomes: null })
+			return unrated(accountUnruggability, { minimumGuardianPolicy: null, outcomes: null })
 		}
 
 		let references: FullyQualifiedReference[] = []

--- a/src/schema/attributes/self-sovereignty/interoperability.ts
+++ b/src/schema/attributes/self-sovereignty/interoperability.ts
@@ -11,12 +11,9 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.interoperability'
-
 export type InteroperabilityValue = Value & {
 	interoperability: InteroperabilityType
 	noSupplierLinkage: InteroperabilityType
-	__brand: 'attributes.interoperability'
 }
 
 function evaluateInteroperability(features: InteroperabilitySupport): Rating {
@@ -80,7 +77,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 		pickWorstRating<InteroperabilityValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<InteroperabilityValue> => {
 		if (features.type !== WalletType.HARDWARE) {
-			return exempt(interoperability, sentence('Only rated for hardware wallets'), brand, {
+			return exempt(interoperability, sentence('Only rated for hardware wallets'), {
 				interoperability: InteroperabilityType.FAIL,
 				noSupplierLinkage: InteroperabilityType.FAIL,
 			})
@@ -89,7 +86,7 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 		const interoperabilityFeature = features.selfSovereignty.interoperability
 
 		if (interoperabilityFeature === null) {
-			return unrated(interoperability, brand, {
+			return unrated(interoperability, {
 				interoperability: InteroperabilityType.FAIL,
 				noSupplierLinkage: InteroperabilityType.FAIL,
 			})
@@ -104,7 +101,6 @@ export const interoperability: Attribute<InteroperabilityValue> = {
 				displayName: 'Interoperability',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} interoperability.`),
 				...interoperabilityFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} interoperability evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
+++ b/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
@@ -16,11 +16,7 @@ import {
 } from '../../features/self-sovereignty/chain-configurability'
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.self_sovereignty.l1_provider_independence'
-
-export type L1ProviderIndependence = Value & {
-	__brand: 'attributes.self_sovereignty.l1_provider_independence'
-}
+export type L1ProviderIndependence = Value
 
 function supportsSelfHostedNode(references: ReferenceArray): Evaluation<L1ProviderIndependence> {
 	return {
@@ -32,7 +28,6 @@ function supportsSelfHostedNode(references: ReferenceArray): Evaluation<L1Provid
 			shortExplanation: sentence(`
 				{{WALLET_NAME}} lets you use your own self-hosted Ethereum node to interact with Ethereum mainnet.
 			`),
-			__brand: brand,
 		},
 		details: paragraph(`
 			{{WALLET_NAME}} lets you use your own self-hosted Ethereum node to interact with Ethereum mainnet.
@@ -52,7 +47,6 @@ function supportsSelfHostedNodeAfterRequests(
 			shortExplanation: sentence(`
 				{{WALLET_NAME}} contacts its default L1 RPC endpoint before letting you configure a self-hosted node.
 			`),
-			__brand: brand,
 		},
 		details: paragraph(`
 			{{WALLET_NAME}} lets you use a self-hosted Ethereum node,
@@ -79,7 +73,6 @@ function supportsSelfHostedNodeButCannotDoBasicOperations(
 				Even with your self-hosted node, {{WALLET_NAME}} depends on external
 				services to perform basic tasks on Ethereum mainnet.
 			`),
-			__brand: brand,
 		},
 		details: mdParagraph(`
 			While {{WALLET_NAME}} lets you use a self-hosted Ethereum node to
@@ -110,7 +103,6 @@ function noSelfHostedNode(references: ReferenceArray): Evaluation<L1ProviderInde
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} does not let you use your own self-hosted node to interact with Ethereum mainnet.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} does not let you use your own self-hosted Ethereum node when interacting with Ethereum mainnet.',
@@ -217,7 +209,7 @@ export const l1ProviderIndependence: Attribute<L1ProviderIndependence> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<L1ProviderIndependence> => {
 		if (features.chainConfigurability === null) {
-			return unrated(l1ProviderIndependence, brand, null)
+			return unrated(l1ProviderIndependence, null)
 		}
 
 		if (!isSupported(features.chainConfigurability)) {

--- a/src/schema/attributes/self-sovereignty/transaction-inclusion.ts
+++ b/src/schema/attributes/self-sovereignty/transaction-inclusion.ts
@@ -19,11 +19,7 @@ import { isNonEmptyArray } from '@/types/utils/non-empty'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.self_sovereignty.transaction_inclusion'
-
-export type TransactionInclusionValue = Value & {
-	__brand: 'attributes.self_sovereignty.transaction_inclusion'
-}
+export type TransactionInclusionValue = Value
 
 export type L1BroadcastSupport = 'NO' | 'SELF_GOSSIP' | 'OWN_NODE'
 
@@ -49,7 +45,6 @@ function transactionSubmissionEvaluation({
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} requires trusting intermediaries in order to withdraw funds from L2s.',
 				),
-				__brand: brand,
 			},
 			details: transactionInclusionDetailsContent({
 				supportsL1Broadcast,
@@ -73,7 +68,6 @@ function transactionSubmissionEvaluation({
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} relies on intermediaries when performing L1 transactions. This makes it possible for L1 transactions to be censored.',
 				),
-				__brand: brand,
 			},
 			details: transactionInclusionDetailsContent({
 				supportsL1Broadcast,
@@ -99,7 +93,6 @@ function transactionSubmissionEvaluation({
 				shortExplanation: sentence(
 					'{{WALLET_NAME}} does not implement L2 force-withdrawal transactions for all types of L2s.',
 				),
-				__brand: brand,
 			},
 			details: transactionInclusionDetailsContent({
 				supportsL1Broadcast,
@@ -122,7 +115,6 @@ function transactionSubmissionEvaluation({
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} supports L2 force-withdrawal transactions for all L2 types.',
 			),
-			__brand: brand,
 		},
 		details: transactionInclusionDetailsContent({
 			supportsL1Broadcast,
@@ -258,14 +250,14 @@ export const transactionInclusion: Attribute<TransactionInclusionValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<TransactionInclusionValue> => {
 		if (features.selfSovereignty.transactionSubmission === null) {
-			return unrated(transactionInclusion, brand, null)
+			return unrated(transactionInclusion, null)
 		}
 
 		if (
 			features.selfSovereignty.transactionSubmission.l1.selfBroadcastViaDirectGossip === null ||
 			features.selfSovereignty.transactionSubmission.l1.selfBroadcastViaSelfHostedNode === null
 		) {
-			return unrated(transactionInclusion, brand, null)
+			return unrated(transactionInclusion, null)
 		}
 
 		const supportsL1Broadcast: L1BroadcastSupport = isSupported(
@@ -290,7 +282,7 @@ export const transactionInclusion: Attribute<TransactionInclusionValue> = {
 			const support = features.selfSovereignty.transactionSubmission.l2[l2]
 
 			if (support === null) {
-				return unrated(transactionInclusion, brand, null)
+				return unrated(transactionInclusion, null)
 			}
 
 			if (support === TransactionSubmissionL2Support.NOT_SUPPORTED_BY_WALLET_BY_DEFAULT) {

--- a/src/schema/attributes/transparency/fee-transparency.ts
+++ b/src/schema/attributes/transparency/fee-transparency.ts
@@ -17,8 +17,6 @@ import { markdownListFormat } from '@/types/utils/text'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.transparency.fee_transparency'
-
 /**
  * All possible fee types that a wallet may charge.
  */
@@ -297,7 +295,6 @@ function computeWorstFees(feeTransparency: FeeTransparency): WorstFeeDisplay | n
 
 export type FeeTransparencyValue = Value & {
 	worstFeeDisplay: WorstFeeDisplay | null
-	__brand: 'attributes.transparency.fee_transparency'
 }
 
 function evaluateWorstFeeDisplay(
@@ -306,7 +303,6 @@ function evaluateWorstFeeDisplay(
 	const references = worstFeeDisplay.references
 	const baseValue = {
 		worstFeeDisplay,
-		__brand: brand,
 	} as const
 	const worstFeeTypesMarkdown = (indent: string): string =>
 		markdownListFormat(nonEmptyMap(worstFeeDisplay.feeTypes, feeTypeDescription), {
@@ -580,7 +576,7 @@ export const feeTransparency: Attribute<FeeTransparencyValue> = {
 		const worstFeeDisplay = computeWorstFees(feeTransparencyData)
 
 		if (worstFeeDisplay === null) {
-			return unrated(feeTransparency, brand, { worstFeeDisplay: null })
+			return unrated(feeTransparency, { worstFeeDisplay: null })
 		}
 
 		return evaluateWorstFeeDisplay(worstFeeDisplay)

--- a/src/schema/attributes/transparency/funding.ts
+++ b/src/schema/attributes/transparency/funding.ts
@@ -20,11 +20,7 @@ import { fundingDetailsContent } from '@/types/content/funding-details'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.transparency.funding'
-
-export type FundingValue = Value & {
-	__brand: 'attributes.transparency.funding'
-}
+export type FundingValue = Value
 
 /** Funding is transparent and at least partially non-extractive. */
 function transparent(
@@ -38,7 +34,6 @@ function transparent(
 			rating: Rating.PASS,
 			displayName: `Transparent funding (${sourceName})`,
 			shortExplanation: sentence('{{WALLET_NAME}} is transparently funded.'),
-			__brand: brand,
 		},
 		details: fundingDetailsContent({ monetization }),
 		references: toFullyQualified(monetization.ref),
@@ -60,7 +55,6 @@ function extractive(
 			shortExplanation: sentence(
 				`{{WALLET_NAME}} is funded through user-extractive means${sourceName !== '' ? ` (${sourceName})` : ''}.`,
 			),
-			__brand: brand,
 		},
 		details: fundingDetailsContent({ monetization }),
 		howToImprove: paragraph(
@@ -77,7 +71,6 @@ const noFunding: Evaluation<FundingValue> = {
 		rating: Rating.FAIL,
 		displayName: 'No funding source',
 		shortExplanation: sentence('{{WALLET_NAME}} has no funding sources.'),
-		__brand: brand,
 	},
 	details: paragraph(
 		'{{WALLET_NAME}} has no funding sources, making its future unclear. Wallets need a consistent source of funding to ensure they keep up with security vulnerabilities and ecosystem progress.',
@@ -95,7 +88,6 @@ const unclear: Evaluation<FundingValue> = {
 		rating: Rating.FAIL,
 		displayName: 'Unclear funding source',
 		shortExplanation: sentence('How {{WALLET_NAME}} is funded is unclear.'),
-		__brand: brand,
 	},
 	details: paragraph('How {{WALLET_NAME}} is funded is unclear.'),
 	howToImprove: paragraph(
@@ -228,7 +220,7 @@ export const funding: Attribute<FundingValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<FundingValue> => {
 		if (features.monetization === null) {
-			return unrated(funding, brand, null)
+			return unrated(funding, null)
 		}
 
 		const strategies: MonetizationStrategy[] = []
@@ -236,7 +228,7 @@ export const funding: Attribute<FundingValue> = {
 		for (const { strategy, value } of monetizationStrategies(features.monetization)) {
 			switch (value) {
 				case null:
-					return unrated(funding, brand, null)
+					return unrated(funding, null)
 				case true:
 					strategies.push(strategy)
 					break

--- a/src/schema/attributes/transparency/maintenance.ts
+++ b/src/schema/attributes/transparency/maintenance.ts
@@ -11,15 +11,12 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.maintenance'
-
 export type MaintenanceValue = Value & {
 	physicalDurability: MaintenanceType
 	mtbfDocumentation: MaintenanceType
 	repairability: MaintenanceType
 	batteryHandling: MaintenanceType
 	warrantyExtensions: MaintenanceType
-	__brand: 'attributes.maintenance'
 }
 
 function evaluateMaintenance(features: MaintenanceSupport): Rating {
@@ -100,7 +97,6 @@ export const maintenance: Attribute<MaintenanceValue> = {
 			return exempt(
 				maintenance,
 				sentence('These attributes only refer to hardware wallet maintenance'),
-				brand,
 				{
 					physicalDurability: MaintenanceType.FAIL,
 					mtbfDocumentation: MaintenanceType.FAIL,
@@ -114,7 +110,7 @@ export const maintenance: Attribute<MaintenanceValue> = {
 		const maintenanceFeature = features.transparency.maintenance
 
 		if (maintenanceFeature === null) {
-			return unrated(maintenance, brand, {
+			return unrated(maintenance, {
 				physicalDurability: MaintenanceType.FAIL,
 				mtbfDocumentation: MaintenanceType.FAIL,
 				repairability: MaintenanceType.FAIL,
@@ -134,7 +130,6 @@ export const maintenance: Attribute<MaintenanceValue> = {
 					`{{WALLET_NAME}} has ${rating.toLowerCase()} maintenance practices.`,
 				),
 				...maintenanceFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} maintenance evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/transparency/open-source.ts
+++ b/src/schema/attributes/transparency/open-source.ts
@@ -24,11 +24,7 @@ import { assertNonEmptyArray, nonEmptyGet } from '@/types/utils/non-empty'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.transparency.open_source'
-
-export type OpenSourceValue = Value & {
-	__brand: 'attributes.transparency.open_source'
-}
+export type OpenSourceValue = Value
 
 function open(license: FOSSLicense): Evaluation<OpenSourceValue> {
 	return {
@@ -40,7 +36,6 @@ function open(license: FOSSLicense): Evaluation<OpenSourceValue> {
 			shortExplanation: sentence(
 				`{{WALLET_NAME}}'s source code is under an open-source license (${licenseName(license)}).`,
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			**{{WALLET_NAME}}** is licensed under the
@@ -60,7 +55,6 @@ function openInTheFuture(license: FutureFOSSLicense): Evaluation<OpenSourceValue
 			shortExplanation: sentence(
 				`{{WALLET_NAME}} (${licenseName(license)})'s code license commits to transition to open-source in the future.`,
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			**{{WALLET_NAME}}** is licensed under the
@@ -82,7 +76,6 @@ function mixedIncludingProprietary(fossLicense: FOSSLicense): Evaluation<OpenSou
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} uses a proprietary license for some of its code.',
 			),
-			__brand: brand,
 		},
 		details: markdown(`
 			While part of **{{WALLET_NAME}}** is licensed under the
@@ -103,7 +96,6 @@ function proprietary(): Evaluation<OpenSourceValue> {
 			icon: '💔', // Broken heart
 			displayName: 'Proprietary code license',
 			shortExplanation: sentence('{{WALLET_NAME}} uses a proprietary source code license.'),
-			__brand: brand,
 		},
 		details: paragraph(`
 			{{WALLET_NAME}} uses a proprietary or non-FOSS source code license.
@@ -125,7 +117,6 @@ function unlicensed(): Evaluation<OpenSourceValue> {
 			shortExplanation: sentence(
 				'{{WALLET_NAME}} does not have a valid license for its source code.',
 			),
-			__brand: brand,
 		},
 		details: paragraph(
 			'{{WALLET_NAME}} does not have a valid license for its source code. This is most likely an accidental omission, but a lack of license means that even if {{WALLET_NAME}} is functionally identical to an open-source project, it may later decide to set its license to a proprietary license. Therefore, {{WALLET_NAME}} is assumed to not be Free & Open Source Software until it does have a valid license file.',
@@ -192,7 +183,7 @@ export const openSource: Attribute<OpenSourceValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<OpenSourceValue> => {
 		if (features.licensing === null || features.licensing.walletAppLicense === null) {
-			return unrated(openSource, brand, null)
+			return unrated(openSource, null)
 		}
 
 		const allLicenses = new Set<License>()
@@ -212,7 +203,7 @@ export const openSource: Attribute<OpenSourceValue> = {
 				break // Nothing more to do.
 			case LicensingType.SEPARATE_CORE_CODE_LICENSE_VS_WALLET_CODE_LICENSE:
 				if (features.licensing.coreLicense === null) {
-					return unrated(openSource, brand, null)
+					return unrated(openSource, null)
 				}
 
 				allLicenses.add(features.licensing.coreLicense.license)

--- a/src/schema/attributes/transparency/reputation.ts
+++ b/src/schema/attributes/transparency/reputation.ts
@@ -8,15 +8,12 @@ import { markdown, paragraph, sentence } from '@/types/content'
 
 import { exempt, pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.reputation'
-
 export type ReputationValue = Value & {
 	originalProduct: ReputationType
 	availability: ReputationType
 	warrantySupportRisk: ReputationType
 	disclosureHistory: ReputationType
 	bugBounty: ReputationType
-	__brand: 'attributes.reputation'
 }
 
 function evaluateReputation(features: ReputationSupport): Rating {
@@ -94,7 +91,7 @@ export const reputation: Attribute<ReputationValue> = {
 		pickWorstRating<ReputationValue>(perVariant),
 	evaluate: (features: ResolvedFeatures): Evaluation<ReputationValue> => {
 		if (features.type !== WalletType.HARDWARE) {
-			return exempt(reputation, sentence('Only rated for hardware wallets'), brand, {
+			return exempt(reputation, sentence('Only rated for hardware wallets'), {
 				originalProduct: ReputationType.FAIL,
 				availability: ReputationType.FAIL,
 				warrantySupportRisk: ReputationType.FAIL,
@@ -106,7 +103,7 @@ export const reputation: Attribute<ReputationValue> = {
 		const reputationFeature = features.transparency.reputation
 
 		if (reputationFeature === null) {
-			return unrated(reputation, brand, {
+			return unrated(reputation, {
 				originalProduct: ReputationType.FAIL,
 				availability: ReputationType.FAIL,
 				warrantySupportRisk: ReputationType.FAIL,
@@ -124,7 +121,6 @@ export const reputation: Attribute<ReputationValue> = {
 				displayName: 'Reputation',
 				shortExplanation: sentence(`{{WALLET_NAME}} has ${rating.toLowerCase()} reputation.`),
 				...reputationFeature, // TODO: Filter fields
-				__brand: brand,
 			},
 			details: paragraph(`{{WALLET_NAME}} reputation evaluation is ${rating.toLowerCase()}.`),
 			howToImprove: paragraph('{{WALLET_NAME}} should improve sub-criteria rated PARTIAL or FAIL.'),

--- a/src/schema/attributes/transparency/source-visibility.ts
+++ b/src/schema/attributes/transparency/source-visibility.ts
@@ -6,11 +6,7 @@ import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
 
 import { pickWorstRating, unrated } from '../common'
 
-const brand = 'attributes.transparency.source_visibility'
-
-export type SourceVisibilityValue = Value & {
-	__brand: 'attributes.transparency.source_visibility'
-}
+export type SourceVisibilityValue = Value
 
 function sourcePublic(references: ReferenceArray): Evaluation<SourceVisibilityValue> {
 	return {
@@ -21,7 +17,6 @@ function sourcePublic(references: ReferenceArray): Evaluation<SourceVisibilityVa
 			shortExplanation: sentence(`
 				The source code for {{WALLET_NAME}} is public.
 			`),
-			__brand: brand,
 		},
 		details: markdown(`
 			The source code for **{{WALLET_NAME}}** is publicly viewable.
@@ -43,7 +38,6 @@ function sourcePartiallyPrivate(references: ReferenceArray): Evaluation<SourceVi
 			shortExplanation: sentence(`
 				The source code for {{WALLET_NAME}} is not fully public.
 			`),
-			__brand: brand,
 		},
 		details: paragraph(`
 			Some but not all parts of the source code for {{WALLET_NAME}}
@@ -71,7 +65,6 @@ function sourcePrivate(references: ReferenceArray): Evaluation<SourceVisibilityV
 			shortExplanation: sentence(`
 				The source code for {{WALLET_NAME}} is not public.
 			`),
-			__brand: brand,
 		},
 		details: paragraph(`
 			The source code for {{WALLET_NAME}} is not available
@@ -122,13 +115,13 @@ export const sourceVisibility: Attribute<SourceVisibilityValue> = {
 	},
 	evaluate: (features: ResolvedFeatures): Evaluation<SourceVisibilityValue> => {
 		if (features.licensing === null) {
-			return unrated(sourceVisibility, brand, null)
+			return unrated(sourceVisibility, null)
 		}
 
 		switch (features.licensing.type) {
 			case LicensingType.SINGLE_WALLET_REPO_AND_LICENSE:
 				if (features.licensing.walletAppLicense === null) {
-					return unrated(sourceVisibility, brand, null)
+					return unrated(sourceVisibility, null)
 				}
 
 				if (licenseSourceIsVisible(features.licensing.walletAppLicense.license)) {
@@ -142,7 +135,7 @@ export const sourceVisibility: Attribute<SourceVisibilityValue> = {
 						features.licensing.coreLicense === null ||
 						features.licensing.walletAppLicense === null
 					) {
-						return unrated(sourceVisibility, brand, null)
+						return unrated(sourceVisibility, null)
 					}
 
 					const refs = mergeRefs(


### PR DESCRIPTION
We don't meaningfully use these for type discrimination.