### PR TITLE
Fix: Add the base uri for token uri

### DIFF
--- a/resources/contracts/src/WalletbeatTestErc721.sol
+++ b/resources/contracts/src/WalletbeatTestErc721.sol
@@ -55,6 +55,9 @@ contract WalletbeatTestErc721 is ERC721 {
 
         revert WalletbeatTestErc721__Soulbound();
     }
+    function _baseURI() internal pure override returns (string memory) {
+        return "data:application/json;base64,";
+    }
 
     function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         if (ownerOf(tokenId) == address(0)) {


### PR DESCRIPTION
Adds base URI override and formats tokenURI() as a base64-encoded on-chain JSON data URI.