### PR TITLE
Fix: Update transaction details display for ambire

### DIFF
--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -638,8 +638,8 @@ export const ambire: SoftwareWallet = {
 					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
 						{
 							...ambireTransactionDisplayDefault,
-							calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
-							transactionOutcome: TransactionOutcome.EXPLAINED,
+							calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+							transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
 						},
 					[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
 						...ambireTransactionDisplayDefault,


### PR DESCRIPTION
Ambire's `ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND` doesnt have any calldata decoded and transaction outcome is not explained too.

I’m also starting to think `transactionOutcome` shouldn’t apply to Safe transactions.
In Safe flows, the “transaction” the wallet is presenting to the signer is basically confirming a Safe tx / approving a hash, not executing the underlying calls. The actual approve/supply/transfer outcome happens when the Safe executes

cc: @polymutex 