### PR TITLE
Fix: Add comparison of wallets for sorting

### DIFF
--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -575,6 +575,24 @@
 									sort: {
 										isDefault: true,
 										defaultDirection: SortDirection.Descending,
+										// Stages always take precedence over attribute scores when sorting:
+										// a stage 1 wallet should never appear below a stage 0 wallet
+										// regardless of how good its attribute scores are. Within the
+										// same stage, fall back to the attribute score as a tiebreaker.
+										compare: (scoreA, scoreB, walletA, walletB) => {
+											// Returns -1 for wallets that cleared no stage (or N/A);
+											// 0, 1, 2... for wallets that cleared stage 0, 1, 2...
+											const stageIndex = (wallet: RatedWallet): number => {
+												const { stage, ladderEvaluation } = getWalletStageAndLadder(wallet)
+												if (stage === 'NOT_APPLICABLE' || stage === null || ladderEvaluation === null) return -1
+												if (typeof stage === 'string') return -1 // QUALIFIED_FOR_NO_STAGES
+												const idx = ladderEvaluation.ladder.stages.findIndex(s => s.id === stage.id)
+												return idx >= 0 ? idx : -1
+											}
+											const stageDiff = stageIndex(walletA) - stageIndex(walletB)
+											if (stageDiff !== 0) return stageDiff
+											return ((scoreA as number | null) ?? 0) - ((scoreB as number | null) ?? 0)
+										},
 									},
 
 									align: ColumnAlignment.Center,


### PR DESCRIPTION
The default sort is by Overall Rating, but UNRATED attributes are excluded from the average rather than counting as zero. This meant a wallet with few rated attributes (all PASS) could outscore a well-documented Stage 1 wallet and appear above it.

Fixed by adding a custom `compare` to the Overall Rating column: wallets are sorted by highest cleared stage first, with the attribute score as a tiebreaker within the same stage.

A suggestion by @polymutex was adding `stageIndex * 1_000_000` to the score. The problem is this is stage 0 maps to `stageIndex = 0`, giving no bonus. Wallets that cleared Stage 0 would still mix with wallets that cleared no stage at all. A custom comparison avoids this.

Fixes #539 
