### PR TITLE
Fix: Use new enums for wallet table

### DIFF
--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -79,7 +79,7 @@
 
 	const displayedAttributeGroups = $derived.by(() => {
 		let filtered = (
-			wallets.find(w => w.variants.browser || w.variants.desktop || w.variants.mobile) ?
+			wallets.find(w => w.variants[Variant.BROWSER] || w.variants[Variant.DESKTOP] || w.variants[Variant.MOBILE]) ?
 				// Filter attribute groups to only include non-exempt attributes
 				attributeGroups
 					.map(attrGroup => ({
@@ -88,7 +88,7 @@
 							Object.fromEntries(
 								Object.entries(attrGroup.attributes)
 									.filter(([attributeId, _]) => (
-										wallets.find(w => w.variants.browser || w.variants.desktop || w.variants.mobile)
+										wallets.find(w => w.variants[Variant.BROWSER] || w.variants[Variant.DESKTOP] || w.variants[Variant.MOBILE])
 											?.overall[attrGroup.id]?.[attributeId]?.evaluation?.value?.rating !== Rating.EXEMPT
 									))
 							)


### PR DESCRIPTION
Current UI shows `maintenance` column that is only dedicated for hardware wallets

<img width="1267" height="818" alt="image" src="https://github.com/user-attachments/assets/67840c88-9a14-40da-80f2-89ec1c6f9d97" />

The fix was using the new enums

```ts
/**
 * An enum of wallet variants.
 * Used to specify feature differences between variants of the same wallet
 * across different of its implementations.
 */
export enum Variant {
	MOBILE = 'MOBILE',
	DESKTOP = 'DESKTOP',
	BROWSER = 'BROWSER',
	EMBEDDED = 'EMBEDDED',
	HARDWARE = 'HARDWARE',
}
```