### PR TITLE
Fix: Account Recovery and Account Unruggability details not rendering

### DIFF
--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -199,6 +199,7 @@
 	import Tooltip from '@/components/Tooltip.svelte'
 	import Typography from '@/components/Typography.svelte'
 	import AccountRecoveryDetails from './attributes/security/AccountRecoveryDetails.svelte'
+	import AccountUnruggabilityDetails from './attributes/self-sovereignty/AccountUnruggabilityDetails.svelte'
 	import SecurityNews from '@/views/SecurityNews.svelte'
 </script>
 
@@ -894,6 +895,8 @@
 								<FundingDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'AccountRecoveryDetails'}
 								<AccountRecoveryDetails {...componentProps} {wallet} {value} />
+							{:else if componentName === 'AccountUnruggabilityDetails'}
+								<AccountUnruggabilityDetails {...componentProps} {wallet} {value} />
 							{:else if componentName === 'UnratedAttribute'}
 								<UnratedAttribute {...componentProps} {wallet} {value} />
 							{/if}

--- a/src/views/attributes/security/AccountRecoveryDetails.svelte
+++ b/src/views/attributes/security/AccountRecoveryDetails.svelte
@@ -21,7 +21,18 @@
 	import { guardianScenarioId } from '@/schema/features/guardian-scenario/guardian-scenario-expansion'
 </script>
 
-{#if value.outcomes !== null}
+{#if value.outcomes === null}
+	<Typography
+		content={{
+			contentType: ContentType.MARKDOWN,
+			markdown: trimWhitespacePrefix(`
+				{{WALLET_NAME}} does not implement guardian-based account recovery.
+				The user will lose access to their account if they lose their seed phrase.
+			`),
+		}}
+		strings={{ WALLET_NAME: wallet.metadata.displayName }}
+	/>
+{:else}
 	{@const successfulOutcomes = value.outcomes.filter(outcome =>
 		isAccountRecoverable(outcome.recovery),
 	)}

--- a/src/views/attributes/self-sovereignty/AccountUnruggabilityDetails.svelte
+++ b/src/views/attributes/self-sovereignty/AccountUnruggabilityDetails.svelte
@@ -3,7 +3,7 @@
 	import type { RatedWallet } from '@/schema/wallet'
 	import { ContentType } from '@/types/content'
 	import { trimWhitespacePrefix } from '@/types/utils/text'
-	import type { AccountRecoveryValue } from '@/schema/attributes/security/account-recovery'
+	import type { AccountUnruggabilityValue } from '@/schema/attributes/self-sovereignty/account-unruggability'
 
 	// Props
 	const {
@@ -11,7 +11,7 @@
 		value,
 	}: {
 		wallet: RatedWallet
-		value: AccountRecoveryValue
+		value: AccountUnruggabilityValue
 	} = $props()
 
 	// Components
@@ -21,7 +21,18 @@
 	import { guardianScenarioId } from '@/schema/features/guardian-scenario/guardian-scenario-expansion'
 </script>
 
-{#if value.outcomes !== null}
+{#if value.outcomes === null}
+	<Typography
+		content={{
+			contentType: ContentType.MARKDOWN,
+			markdown: trimWhitespacePrefix(`
+				Private key material never leaves {{WALLET_NAME}}, so no external
+				entity may take over your account.
+			`),
+		}}
+		strings={{ WALLET_NAME: wallet.metadata.displayName }}
+	/>
+{:else}
 	{@const successfulOutcomes = value.outcomes.filter(outcome =>
 		!isAccountTakeOverPossible(outcome.takeover),
 	)}


### PR DESCRIPTION
## Account Recovery

- Wallets without guardian recovery (e.g. Ambire) showed an empty details section.
AccountRecoveryDetails.svelte only rendered content inside a `value.outcomes !== null` block and had no fallback.

```ts
{#if value.outcomes === null}
	<Typography
		content={{
			contentType: ContentType.MARKDOWN,
			markdown: trimWhitespacePrefix(`
				{{WALLET_NAME}} does not implement guardian-based account recovery.
				The user will lose access to their account if they lose their seed phrase.
			`),
		}}
		strings={{ WALLET_NAME: wallet.metadata.displayName }}
	/>
{:else}
```

## Account Unruggability
- Same issue and we forgot to add `AccountUnruggabilityDetails` to `WalletPage.svelte`

closes #570 