### PR TITLE
Fix: issue with harper using windows

### DIFF
--- a/tests/utils/grammar.ts
+++ b/tests/utils/grammar.ts
@@ -60,7 +60,7 @@ let harperLinter: harper.LocalLinter | null = null
 async function getHarperLinter(): Promise<harper.LocalLinter> {
 	if (harperLinter === null) {
 		harperLinter = new harper.LocalLinter({
-			binary: harper.binary,
+			binary: harper.binaryInlined,
 		})
 		await prepareHarperLinter(harperLinter)
 	}


### PR DESCRIPTION
# Fix: Harper linter failing on Windows

`harper.binary` loads the `.wasm` from disk via a `file://` URL, which breaks on Windows CI.

`harper.binaryInlined` - no file system access needed, works on all platforms.

Fixes #569