### PR TITLE
Refactor: Safe account type

### DIFF
--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -120,16 +120,14 @@ export const rabby: SoftwareWallet = {
 			rawErc4337: notSupported,
 			safe: supported({
 				ref: refTodo,
-				canDeployNew: notSupported,
+				canDeployNew: false,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {
-					maxOwners: 10,
-					minOwners: 1,
-					moduleSupport: 'partial',
-					supportsAnyThreshold: true,
+					owners: 'MULTI_SIGNER',
 				},
+				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -124,7 +124,7 @@ export const rabby: SoftwareWallet = {
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				owners: 'ANY_NUMBER_OF_SIGNERS',
+				supportedOwners: 'ANY_NUMBER_OF_SIGNERS',
 				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -124,9 +124,7 @@ export const rabby: SoftwareWallet = {
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				supportedConfigs: {
-					owners: 'MULTI_SIGNER',
-				},
+				owners: 'ANY_NUMBER_OF_SIGNERS',
 				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -64,7 +64,7 @@ export const safe: SoftwareWallet = {
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				owners: 'ANY_NUMBER_OF_SIGNERS',
+				supportedOwners: 'ANY_NUMBER_OF_SIGNERS',
 				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -60,22 +60,14 @@ export const safe: SoftwareWallet = {
 			}),
 			safe: supported({
 				ref: refNotNecessary,
-				canDeployNew: supported({
-					defaultConfig: {
-						modules: [],
-						owners: 1,
-						threshold: 1,
-					},
-				}),
+				canDeployNew: true,
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
 				supportedConfigs: {
-					maxOwners: 'unlimited',
-					minOwners: 1,
-					moduleSupport: 'full',
-					supportsAnyThreshold: true,
+					owners: 'ANY_NUMBER_OF_SIGNERS',
 				},
+				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -64,9 +64,7 @@ export const safe: SoftwareWallet = {
 				controllingSharesInSelfCustodyByDefault: 'YES',
 				keyRotationTransactionGeneration:
 					TransactionGenerationCapability.USING_OPEN_SOURCE_STANDALONE_APP,
-				supportedConfigs: {
-					owners: 'ANY_NUMBER_OF_SIGNERS',
-				},
+				owners: 'ANY_NUMBER_OF_SIGNERS',
 				supportsAddingOrRemovingSigners: true,
 				supportsKeyRotationWithoutModules: true,
 				tokenTransferTransactionGeneration:

--- a/docs/features.md
+++ b/docs/features.md
@@ -421,22 +421,28 @@ Support information for Safe multisig accounts.
 
 To test:
 
-- `canDeployNew`: Go through the wallet's UI to create a new Safe and
-  observe the default owner count and threshold.
+- `canDeployNew`: Go through the wallet's UI and check whether it offers
+  a flow to deploy a new Safe contract.
+- `supportsAddingOrRemovingSigners`: In an existing Safe, attempt to add
+  or remove an owner using only the wallet's native UI (no extra modules).
+  Check whether the wallet generates the `addOwnerWithThreshold` /
+  `removeOwner` transaction directly.
 - `supportsKeyRotationWithoutModules`: In an existing Safe, attempt to
-  add or remove an owner using only the wallet's native UI (no extra
-  modules). Check whether the wallet generates the `addOwnerWithThreshold`
-  / `removeOwner` transaction directly.
-- `supportedConfigs`: Try connecting the wallet to Safes with 1, 2, and
-  many owners at various thresholds, and note the limits.
+  replace an owner key using only the wallet's native UI (no extra
+  modules). Check whether the wallet generates the `swapOwner` transaction
+  directly.
+- `supportedConfigs.owners`: Try connecting the wallet to Safes with 1,
+  2, and many owners and note the limits.
 
-- `canDeployNew` (`Support<{ defaultConfig: { owners: number threshold: number modules: string[] } }>`): Can the wallet deploy new Safe contracts?
+- `canDeployNew` (`boolean`): Can the wallet deploy new Safe contracts?
+- `supportsAddingOrRemovingSigners` (`boolean`): Does the wallet support adding or removing signers without additional modules?
 - `supportsKeyRotationWithoutModules` (`boolean`): Does the wallet support key rotation without additional modules?
-- `supportedConfigs` (object): Supported configurations for existing Safes.
-  - `minOwners` (`number`): Minimum number of owners supported.
-  - `maxOwners` (`number | 'unlimited'`): Maximum number of owners supported (or 'unlimited').
-  - `supportsAnyThreshold` (`boolean`): Whether any threshold is supported.
-  - `moduleSupport` (`'none' | 'partial' | 'full'`): Level of module support.
+- `supportedConfigs` (object): Supported signer configurations for existing Safes.
+  - `owners` (`'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'`): Range of signers (owners) the wallet can work with.
+
+  - SINGLE_SIGNER: only single-owner Safes are supported.
+  - MULTI_SIGNER: multiple owners are supported but with a cap.
+  - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -437,11 +437,8 @@ To test:
 - `canDeployNew` (`boolean`): Can the wallet deploy new Safe contracts?
 - `supportsAddingOrRemovingSigners` (`boolean`): Does the wallet support adding or removing signers without additional modules?
 - `supportsKeyRotationWithoutModules` (`boolean`): Does the wallet support key rotation without additional modules?
-- `supportedConfigs` (object): Supported signer configurations for existing Safes.
-  - `owners` (`'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'`): Range of signers (owners) the wallet can work with.
-
+- `owners` (`'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'`): Range of signers (owners) the wallet can work with.
   - SINGLE_SIGNER: only single-owner Safes are supported.
-  - MULTI_SIGNER: multiple owners are supported but with a cap.
   - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
 
 ---

--- a/docs/features.md
+++ b/docs/features.md
@@ -437,7 +437,7 @@ To test:
 - `canDeployNew` (`boolean`): Can the wallet deploy new Safe contracts?
 - `supportsAddingOrRemovingSigners` (`boolean`): Does the wallet support adding or removing signers without additional modules?
 - `supportsKeyRotationWithoutModules` (`boolean`): Does the wallet support key rotation without additional modules?
-- `owners` (`'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'`): Range of signers (owners) the wallet can work with.
+- `supportedOwners` (`'SINGLE_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'`): Range of signers (owners) the wallet can work with.
   - SINGLE_SIGNER: only single-owner Safes are supported.
   - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
 

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -310,14 +310,10 @@ export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
 	/** Does the wallet support key rotation without additional modules? */
 	supportsKeyRotationWithoutModules: boolean
 
-	/** Supported signer configurations for existing Safes. */
-	supportedConfigs: {
-		/**
-		 * Range of signers (owners) the wallet can work with.
-		 * - SINGLE_SIGNER: only single-owner Safes are supported.
-		 * - MULTI_SIGNER: multiple owners are supported but with a cap.
-		 * - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
-		 */
-		owners: 'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'
-	}
+	/**
+	 * Range of signers (owners) the wallet can work with.
+	 * - SINGLE_SIGNER: only single-owner Safes are supported.
+	 * - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
+	 */
+	owners: 'SINGLE_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'
 }

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -315,5 +315,5 @@ export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
 	 * - SINGLE_SIGNER: only single-owner Safes are supported.
 	 * - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
 	 */
-	owners: 'SINGLE_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'
+	supportedOwners: 'SINGLE_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'
 }

--- a/src/schema/features/account-support.ts
+++ b/src/schema/features/account-support.ts
@@ -287,41 +287,37 @@ export type AccountType7702 = SmartAccountType
  * Support information for Safe multisig accounts.
  *
  * To test:
- * - `canDeployNew`: Go through the wallet's UI to create a new Safe and
- *   observe the default owner count and threshold.
+ * - `canDeployNew`: Go through the wallet's UI and check whether it offers
+ *   a flow to deploy a new Safe contract.
+ * - `supportsAddingOrRemovingSigners`: In an existing Safe, attempt to add
+ *   or remove an owner using only the wallet's native UI (no extra modules).
+ *   Check whether the wallet generates the `addOwnerWithThreshold` /
+ *   `removeOwner` transaction directly.
  * - `supportsKeyRotationWithoutModules`: In an existing Safe, attempt to
- *   add or remove an owner using only the wallet's native UI (no extra
- *   modules). Check whether the wallet generates the `addOwnerWithThreshold`
- *   / `removeOwner` transaction directly.
- * - `supportedConfigs`: Try connecting the wallet to Safes with 1, 2, and
- *   many owners at various thresholds, and note the limits.
+ *   replace an owner key using only the wallet's native UI (no extra
+ *   modules). Check whether the wallet generates the `swapOwner` transaction
+ *   directly.
+ * - `supportedConfigs.owners`: Try connecting the wallet to Safes with 1,
+ *   2, and many owners and note the limits.
  */
 export interface AccountTypeSafe extends AccountTypeMutableMultifactor {
 	/** Can the wallet deploy new Safe contracts? */
-	canDeployNew: Support<{
-		/** Default configuration when creating a new Safe. */
-		defaultConfig: {
-			/** Number of owners by default. */
-			owners: number
-			/** Signature threshold by default. */
-			threshold: number
-			/** Enabled modules by default. */
-			modules: string[] // or more specific type if needed
-		}
-	}>
+	canDeployNew: boolean
+
+	/** Does the wallet support adding or removing signers without additional modules? */
+	supportsAddingOrRemovingSigners: boolean
 
 	/** Does the wallet support key rotation without additional modules? */
 	supportsKeyRotationWithoutModules: boolean
 
-	/** Supported configurations for existing Safes. */
+	/** Supported signer configurations for existing Safes. */
 	supportedConfigs: {
-		/** Minimum number of owners supported. */
-		minOwners: number
-		/** Maximum number of owners supported (or 'unlimited'). */
-		maxOwners: number | 'unlimited'
-		/** Whether any threshold is supported. */
-		supportsAnyThreshold: boolean
-		/** Level of module support. */
-		moduleSupport: 'none' | 'partial' | 'full'
+		/**
+		 * Range of signers (owners) the wallet can work with.
+		 * - SINGLE_SIGNER: only single-owner Safes are supported.
+		 * - MULTI_SIGNER: multiple owners are supported but with a cap.
+		 * - ANY_NUMBER_OF_SIGNERS: no practical upper limit on owners.
+		 */
+		owners: 'SINGLE_SIGNER' | 'MULTI_SIGNER' | 'ANY_NUMBER_OF_SIGNERS'
 	}
 }


### PR DESCRIPTION
### Changes

Simplifies the `AccountTypeSafe` schema. The previous shape collected fields that are unused to our methodology.

- Removed `canDeployNew.defaultConfig`
- Flattened `canDeployNew` to a plain `boolean`
- Updated `supportedConfigs.{minOwners,maxOwners,supportsAnyThreshold,moduleSupport}` with a single `owners` enum: `SINGLE_SIGNER | MULTI_SIGNER | ANY_NUMBER_OF_SIGNERS`
- Added `supportsAddingOrRemovingSigners`

### Other changes
- Updated `safe.ts` and `rabby.ts` to match.
- Updated `features.md`

Fixes #573 