### PR TITLE
Remove Blumen dependency.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,7 +64,5 @@ jobs:
         env:
           ENS_DOMAIN: beta.walletbeat.eth
           DEPLOY_DIRECTORY: dist
-          BLUMEN_PK: ${{ secrets.BETA_WALLETBEAT_ETH_UPDATER_EOA_PRIVATE_KEY }}
           OMNIPIN_PK: ${{ secrets.BETA_WALLETBEAT_ETH_UPDATER_EOA_PRIVATE_KEY }}
-          BLUMEN_OR_OMNIPIN: omnipin
           SKIP_HELIOS: 'false'

--- a/deploy/update-ens.sh
+++ b/deploy/update-ens.sh
@@ -21,9 +21,8 @@ if [[ -z "${OMNIPIN_PK:-}" ]]; then
 fi
 
 DIRECTORY_CID="$(pnpm omnipin pack --only-hash "$DEPLOY_DIRECTORY")"
-SUBCOMMAND="${BLUMEN_OR_OMNIPIN:-blumen}"
 if [[ "${SKIP_HELIOS:-false}" == true ]]; then
-	exec pnpm "$SUBCOMMAND" ens "$DIRECTORY_CID" "$ENS_DOMAIN"
+	exec pnpm omnipin ens "$DIRECTORY_CID" "$ENS_DOMAIN"
 else
-	exec pnpm helios:wrap pnpm "$SUBCOMMAND" ens --rpc-url='$HELIOS_RPC_ENDPOINT' "$DIRECTORY_CID" "$ENS_DOMAIN"
+	exec pnpm helios:wrap pnpm omnipin ens --rpc-url='$HELIOS_RPC_ENDPOINT' "$DIRECTORY_CID" "$ENS_DOMAIN"
 fi

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"@kindspells/astro-shield": "^1.7.1",
 		"@types/prompts": "^2.4.9",
 		"ajv": "^8.18.0",
-		"blumen": "^1.3.0",
 		"cac": "^6.7.14",
 		"cross-env": "^10.1.0",
 		"cspell": "9.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
-      blumen:
-        specifier: ^1.3.0
-        version: 1.3.0
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -2733,11 +2730,6 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
-  blumen@1.3.0:
-    resolution: {integrity: sha512-JXgHWbAXSjNukkUge7ku2xRx++9PTvsSNBfFiaAnQ6nPsT1Xz/GRwZnyRA+Yj3pp1uSScKDP2uIkyHvmBBo7OQ==}
-    engines: {node: ^20.10.0 || >=21.1.0}
-    hasBin: true
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -10550,8 +10542,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  blumen@1.3.0: {}
 
   bn.js@5.2.3: {}
 


### PR DESCRIPTION
No longer needed with migration to Omnipin.

Updates issue #346.