### PR TITLE
Fix: make bullet points position relative and not absolute

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -840,6 +840,7 @@ ol {
 
 	> li,
 	> [data-list-item] {
+		position: relative;
 		--listItem-gap: 0.25lh;
 
 		&[data-list-item~='gap-0'] {


### PR DESCRIPTION
# fix: list bullets staying fixed while content scrolls

- Fix is one line: `position: relative` on `li` / `[data-list-item]`.