### PR TITLE
<Pie>: SVG → HTML/CSS with `clip-path: shape()`

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -396,24 +396,10 @@
 				--slice-scale: 1;
 				--slice-strokeColor: transparent;
 				--slice-strokeWidth: 0px;
-				--slice-filter:
-					brightness(var(--slice-brightness))
-				;
-				--slice-hover-filter:
-					brightness(var(--slice-brightness))
-					drop-shadow(var(--slice-strokeWidth) 0 var(--slice-strokeColor))
-					drop-shadow(0 calc(-1 * var(--slice-strokeWidth)) var(--slice-strokeColor))
-					drop-shadow(calc(-1 * var(--slice-strokeWidth)) 0 var(--slice-strokeColor))
-					drop-shadow(0 var(--slice-strokeWidth) var(--slice-strokeColor))
-				;
 
 				display: grid;
 
-				filter: var(--slice-filter);
-
 				pointer-events: none;
-				transition-property: filter;
-				will-change: filter;
 
 				> * {
 					pointer-events: auto;
@@ -431,6 +417,14 @@
 					--slice-strokeColor: var(--highlight-color);
 					--slice-strokeWidth: var(--highlight-strokeWidth);
 					--slice-filter: var(--slice-hover-filter);
+
+					filter:
+						brightness(var(--slice-brightness))
+						drop-shadow(var(--slice-strokeWidth) 0 var(--slice-strokeColor))
+						drop-shadow(0 calc(-1 * var(--slice-strokeWidth)) var(--slice-strokeColor))
+						drop-shadow(calc(-1 * var(--slice-strokeWidth)) 0 var(--slice-strokeColor))
+						drop-shadow(0 var(--slice-strokeWidth) var(--slice-strokeColor))
+					;
 				}
 
 				&:focus-within {

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -278,11 +278,9 @@
 			style:--slice-opacity={slice.opacity ?? 1}
 			data-slice-id={slice.id}
 			class:highlighted={highlightedSliceId === slice.id}
-			data-stack
 		>
 			<div
 				class="slice-shape"
-				data-stack
 			>
 				<span class="label" aria-hidden="true">{slice.arcLabel}</span>
 			</div>
@@ -293,6 +291,7 @@
 		<a
 			class="slice-link"
 			href={slice.href}
+			data-link="contents"
 		>
 			{@render SliceContent(slice)}
 		</a>
@@ -383,14 +382,6 @@
 			display: grid;
 			max-width: 100%;
 
-			.slice-link {
-				display: contents;
-
-				:is([data-stack] > &) > * {
-					grid-area: inherit;
-				}
-			}
-
 			.slice {
 				--slice-brightness: 1;
 				--slice-scale: 1;
@@ -403,10 +394,6 @@
 
 				> * {
 					pointer-events: auto;
-				}
-
-				:is([data-stack] > &) > * {
-					grid-area: inherit;
 				}
 
 				&:hover,

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -247,7 +247,9 @@
 
 {#snippet Slice(slice: ComputedSlice)}
 	{#snippet SliceContent(slice: ComputedSlice)}
-		<div
+		<svelte:element
+			this={slice.href ? 'a' : 'div'}
+			href={slice.href}
 			class="slice"
 			role="button"
 			tabindex="0"
@@ -284,20 +286,10 @@
 			>
 				<span class="label" aria-hidden="true">{slice.arcLabel}</span>
 			</div>
-		</div>
+		</svelte:element>
 	{/snippet}
 
-	{#if slice.href}
-		<a
-			class="slice-link"
-			href={slice.href}
-			data-link="contents"
-		>
-			{@render SliceContent(slice)}
-		</a>
-	{:else}
-		{@render SliceContent(slice)}
-	{/if}
+	{@render SliceContent(slice)}
 
 	{#if slice.children?.length}
 		{#each slice.children as childSlice (childSlice.id)}

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -245,8 +245,8 @@
 </script>
 
 
-{#snippet sliceSnippet(slice: ComputedSlice)}
-	{#snippet slicePathSnippet(slice: ComputedSlice)}
+{#snippet Slice(slice: ComputedSlice)}
+	{#snippet SliceContent(slice: ComputedSlice)}
 		<div
 			class="slice"
 			role="button"
@@ -294,15 +294,15 @@
 			class="slice-link"
 			href={slice.href}
 		>
-			{@render slicePathSnippet(slice)}
+			{@render SliceContent(slice)}
 		</a>
 	{:else}
-		{@render slicePathSnippet(slice)}
+		{@render SliceContent(slice)}
 	{/if}
 
 	{#if slice.children?.length}
 		{#each slice.children as childSlice (childSlice.id)}
-			{@render sliceSnippet(childSlice)}
+			{@render Slice(childSlice)}
 		{/each}
 	{/if}
 {/snippet}
@@ -325,7 +325,7 @@
 	>
 		<div class="slices" data-stack>
 			{#each computedSlices as slice (slice.id)}
-				{@render sliceSnippet(slice)}
+				{@render Slice(slice)}
 			{/each}
 		</div>
 		<div class="center" data-stack>

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -276,11 +276,16 @@
 			style:--slice-innerSweep={slice.computed.innerSweep}
 			style:--slice-fill={slice.color}
 			style:--slice-opacity={slice.opacity ?? 1}
-			class:highlighted={highlightedSliceId === slice.id}
 			data-slice-id={slice.id}
+			class:highlighted={highlightedSliceId === slice.id}
 			data-stack
 		>
-			<span class="label" aria-hidden="true">{slice.arcLabel}</span>
+			<div
+				class="slice-shape"
+				data-stack
+			>
+				<span class="label" aria-hidden="true">{slice.arcLabel}</span>
+			</div>
 		</div>
 	{/snippet}
 
@@ -351,7 +356,7 @@
 
 	.container {
 		--highlight-color: rgba(255, 255, 255, 1);
-		--highlight-stroke-width: 2;
+		--highlight-strokeWidth: 2;
 		--hover-brightness: 1.1;
 		--hover-scale: 1.05;
 
@@ -371,6 +376,9 @@
 		transition-duration: 0.4s;
 
 		.pie {
+			--pie-originX: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
+			--pie-originY: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
+
 			position: relative;
 			display: grid;
 			max-width: 100%;
@@ -384,114 +392,136 @@
 			}
 
 			.slice {
+				--slice-brightness: 1;
 				--slice-scale: 1;
-				--slice-offset: 0;
+				--slice-strokeColor: transparent;
+				--slice-strokeWidth: 0px;
 
-				--slice-labelRadius: calc(var(--pie-labelSize) / 2);
-				--slice-labelR: clamp(
-					/* Geometric mean of the inner and outer radii (with label radius carved out) */
-					pow(
-						(
-							(var(--slice-outerR) - var(--slice-labelRadius))
-							* (var(--slice-innerR) + var(--slice-labelRadius))
-						),
-						0.5
-					),
+				display: grid;
 
-					/* Centroid of the trimmed annular sector (with inner radius adjusted by label radius) */
-					(
-						2 / 3
-						* (
-							(
-								pow(var(--slice-outerR), 3)
-								- pow(var(--slice-innerR), 3)
-							)
-							/ (
-								pow(var(--slice-outerR), 2)
-								- pow(var(--slice-innerR), 2)
-							)
-						)
-						* (
-							sin(var(--slice-totalAngle) * 1deg / 2)
-							/ (var(--slice-totalAngle) * pi/180 / 2)
-						)
-					),
+				filter: brightness(var(--slice-brightness));
 
-					/* Outer radius minus label radius */
-					var(--slice-outerR) - var(--slice-labelRadius)
-				);
+				pointer-events: none;
+				transition-property: filter;
+				will-change: filter;
 
-				background-color: var(--slice-fill);
-				clip-path: shape(
-					from
-						calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
-						calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px)),
-					arc to
-						calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
-						calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
-						of calc(var(--slice-outerR) * 1px) var(--slice-outerSweep) var(--slice-arcSize),
-					line to
-						calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
-						calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px)),
-					arc to
-						calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
-						calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
-						of calc(var(--slice-innerR) * 1px) var(--slice-innerSweep) var(--slice-arcSize),
-					close
-				);
-
-				transform-origin: var(--pie-originX) var(--pie-originY);
-				transform:
-					rotate(calc(var(--pie-rotate) + var(--slice-midAngle) * 1deg))
-					scale(var(--slice-scale))
-					translateY(calc(var(--slice-offset) * -1px))
-				;
-				opacity: var(--slice-opacity);
-
-				will-change: transform;
-				transition-property:
-					clip-path,
-					transform,
-					opacity
-				;
-
-				&:hover,
-				&:focus-within {
-					filter: brightness(var(--hover-brightness));
-					--slice-scale: var(--hover-scale);
-					opacity: 1;
+				> * {
+					pointer-events: auto;
 				}
 
+				:is([data-stack] > &) > * {
+					grid-area: inherit;
+				}
+
+				&:hover,
 				&:focus-within,
 				&.highlighted {
-					z-index: 2;
-					opacity: 1;
+					--slice-brightness: var(--hover-brightness);
+					--slice-scale: var(--hover-scale);
+					--slice-strokeColor: var(--highlight-color);
+					--slice-strokeWidth: var(--highlight-strokeWidth);
 				}
 
 				&:focus-within {
 					outline: none;
 				}
 
-				> .label {
-					position: absolute;
-					left: var(--pie-originX);
-					top: var(--pie-originY);
-					display: inline-block;
-					white-space: nowrap;
-					text-align: center;
-					line-height: 1;
-					color: currentColor;
-					font-size: calc(var(--pie-labelSize) * 1px);
-					translate: -50% calc(-50% + (var(--slice-labelR) * -1px));
-					rotate: calc(-1 * (var(--pie-rotate) + var(--slice-midAngle) * 1deg));
-					transition-property: translate, rotate, filter;
-				}
-				&:not(:hover, :focus) > .label {
-					filter: contrast(0.5) brightness(3) opacity(0.5) drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.15));
+				.slice-shape {
+					--slice-offset: 0;
+
+					--slice-labelRadius: calc(var(--pie-labelSize) / 2);
+					--slice-labelR: clamp(
+						/* Geometric mean of the inner and outer radii (with label radius carved out) */
+						pow(
+							(
+								(var(--slice-outerR) - var(--slice-labelRadius))
+								* (var(--slice-innerR) + var(--slice-labelRadius))
+							),
+							0.5
+						),
+
+						/* Centroid of the trimmed annular sector (with inner radius adjusted by label radius) */
+						(
+							2 / 3
+							* (
+								(
+									pow(var(--slice-outerR), 3)
+									- pow(var(--slice-innerR), 3)
+								)
+								/ (
+									pow(var(--slice-outerR), 2)
+									- pow(var(--slice-innerR), 2)
+								)
+							)
+							* (
+								sin(var(--slice-totalAngle) * 1deg / 2)
+								/ (var(--slice-totalAngle) * pi/180 / 2)
+							)
+						),
+
+						/* Outer radius minus label radius */
+						var(--slice-outerR) - var(--slice-labelRadius)
+					);
+
+					background-color: var(--slice-fill);
+					clip-path: shape(
+						from
+							calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+							calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px)),
+						arc to
+							calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+							calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+							of calc(var(--slice-outerR) * 1px) var(--slice-outerSweep) var(--slice-arcSize),
+						line to
+							calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+							calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px)),
+						arc to
+							calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+							calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+							of calc(var(--slice-innerR) * 1px) var(--slice-innerSweep) var(--slice-arcSize),
+						close
+					);
+
+					transform-origin: var(--pie-originX) var(--pie-originY);
+					transform:
+						rotate(calc(var(--pie-rotate) + var(--slice-midAngle) * 1deg))
+						scale(var(--slice-scale))
+						translateY(calc(var(--slice-offset) * -1px))
+					;
+					opacity: var(--slice-opacity);
+
+					will-change: transform;
+					transition-property:
+						clip-path,
+						transform,
+						opacity
+					;
+
+					&:hover,
+					&:focus-within,
+					.slice.highlighted & {
+						opacity: 1;
+					}
+
+					> .label {
+						position: absolute;
+						left: var(--pie-originX);
+						top: var(--pie-originY);
+						display: inline-block;
+						white-space: nowrap;
+						text-align: center;
+						line-height: 1;
+						color: currentColor;
+						font-size: calc(var(--pie-labelSize) * 1px);
+						translate: -50% calc(-50% + (var(--slice-labelR) * -1px));
+						rotate: calc(-1 * (var(--pie-rotate) + var(--slice-midAngle) * 1deg));
+						transition-property: translate, rotate, filter;
+					}
 				}
 
-				--pie-originX: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
-				--pie-originY: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
+				&:not(:hover, :focus-within) > .slice-shape > .label {
+					filter: contrast(0.5) brightness(3) opacity(0.5) drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.15));
+				}
 			}
 
 			> .center {

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -271,10 +271,6 @@
 			style:--slice-innerR={slice.computed.innerR}
 			style:--slice-totalAngle={slice.computed.totalAngle}
 			style:--slice-orientation={slice.computed.orientation}
-			style:--slice-gapPx={`${slice.computed.gap}px`}
-			style:--slice-outerRPx={`${slice.computed.outerR}px`}
-			style:--slice-innerRPx={`${slice.computed.innerR}px`}
-			style:--slice-totalAngleDeg={`${slice.computed.totalAngle}deg`}
 			style:--slice-arcSize={slice.computed.arcSize}
 			style:--slice-outerSweep={slice.computed.outerSweep}
 			style:--slice-innerSweep={slice.computed.innerSweep}
@@ -428,19 +424,19 @@
 				background-color: var(--slice-fill);
 				clip-path: shape(
 					from
-						calc(var(--slice-cx) + sin(var(--slice-outerStartAngle)) * var(--slice-outerRPx))
-						calc(var(--slice-cy) - cos(var(--slice-outerStartAngle)) * var(--slice-outerRPx)),
+						calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+						calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px)),
 					arc to
-						calc(var(--slice-cx) + sin(var(--slice-outerEndAngle)) * var(--slice-outerRPx))
-						calc(var(--slice-cy) - cos(var(--slice-outerEndAngle)) * var(--slice-outerRPx))
-						of var(--slice-outerRPx) var(--slice-outerSweep) var(--slice-arcSize),
+						calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+						calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-outerR)))) * var(--slice-orientation)))) * (var(--slice-outerR) * 1px))
+						of calc(var(--slice-outerR) * 1px) var(--slice-outerSweep) var(--slice-arcSize),
 					line to
-						calc(var(--slice-cx) + sin(var(--slice-innerEndAngle)) * var(--slice-innerRPx))
-						calc(var(--slice-cy) - cos(var(--slice-innerEndAngle)) * var(--slice-innerRPx)),
+						calc(var(--pie-originX) + sin(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+						calc(var(--pie-originY) - cos(calc((var(--slice-totalAngle) * 1deg / 2) - (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px)),
 					arc to
-						calc(var(--slice-cx) + sin(var(--slice-innerStartAngle)) * var(--slice-innerRPx))
-						calc(var(--slice-cy) - cos(var(--slice-innerStartAngle)) * var(--slice-innerRPx))
-						of var(--slice-innerRPx) var(--slice-innerSweep) var(--slice-arcSize),
+						calc(var(--pie-originX) + sin(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+						calc(var(--pie-originY) - cos(calc((-1 * var(--slice-totalAngle) * 1deg / 2) + (asin((var(--slice-gap) / (2 * var(--slice-innerR)))) * var(--slice-orientation)))) * (var(--slice-innerR) * 1px))
+						of calc(var(--slice-innerR) * 1px) var(--slice-innerSweep) var(--slice-arcSize),
 					close
 				);
 
@@ -496,26 +492,6 @@
 
 				--pie-originX: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
 				--pie-originY: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
-				--slice-cx: var(--pie-originX);
-				--slice-cy: var(--pie-originY);
-				--slice-outerInsetAngle: asin((var(--slice-gapPx) / 2) / var(--slice-outerRPx));
-				--slice-innerInsetAngle: asin((var(--slice-gapPx) / 2) / var(--slice-innerRPx));
-				--slice-outerStartAngle: calc(
-					(-1 * var(--slice-totalAngleDeg) / 2)
-					+ (var(--slice-outerInsetAngle) * var(--slice-orientation))
-				);
-				--slice-outerEndAngle: calc(
-					(var(--slice-totalAngleDeg) / 2)
-					- (var(--slice-outerInsetAngle) * var(--slice-orientation))
-				);
-				--slice-innerStartAngle: calc(
-					(-1 * var(--slice-totalAngleDeg) / 2)
-					+ (var(--slice-innerInsetAngle) * var(--slice-orientation))
-				);
-				--slice-innerEndAngle: calc(
-					(var(--slice-totalAngleDeg) / 2)
-					- (var(--slice-innerInsetAngle) * var(--slice-orientation))
-				);
 			}
 
 			> .center {

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -309,7 +309,7 @@
 
 <div
 	{...restProps}
-	class="container {'class' in restProps ? restProps.class : ''}"
+	class="pie-container {'class' in restProps ? restProps.class : ''}"
 	data-layout={layout}
 	style:--pie-radius={radius}
 	style:--pie-padding={padding}
@@ -354,7 +354,7 @@
 		initial-value: 0;
 	}
 
-	.container {
+	.pie-container {
 		--highlight-color: rgba(255, 255, 255, 1);
 		--highlight-strokeWidth: 1.5px;
 		--hover-brightness: 1.1;

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -7,7 +7,6 @@
 		arcLabel: string
 		titleText: string
 		href?: string
-		opacity?: number
 		children?: Slice[]
 	}
 
@@ -277,7 +276,6 @@
 			style:--slice-outerSweep={slice.computed.outerSweep}
 			style:--slice-innerSweep={slice.computed.innerSweep}
 			style:--slice-fill={slice.color}
-			style:--slice-opacity={slice.opacity ?? 1}
 			data-slice-id={slice.id}
 			class:highlighted={highlightedSliceId === slice.id}
 		>

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -28,14 +28,17 @@
 	// (Internal)
 	type ComputedSlice = Slice & {
 		computed: {
-			path: string
 			totalAngle: number
+			orientation: -1 | 1
 			midAngle: number
 			outerR: number
 			innerR: number
 			gap: number
 			level: number
 			offset: number
+			arcSize: 'small' | 'large'
+			outerSweep: 'cw' | 'ccw'
+			innerSweep: 'cw' | 'ccw'
 		}
 		children?: ComputedSlice[]
 	}
@@ -119,84 +122,6 @@
 	// Functions
 	const getLevelConfig = (level: number): LevelConfig => levels[Math.min(level, levels.length - 1)]
 
-	const polarToCartesian = (
-		centerX: number,
-		centerY: number,
-		radius: number,
-		angleInDegrees: number,
-	) => {
-		const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180.0
-
-		return {
-			x: centerX + radius * Math.cos(angleInRadians),
-			y: centerY + radius * Math.sin(angleInRadians),
-		}
-	}
-
-	const getSlicePath = ({
-		cx = 0,
-		cy = 0,
-		gap,
-		outerR,
-		innerR,
-		startAngle,
-		endAngle,
-	}: {
-		cx: number
-		cy: number
-		gap: number
-		outerR: number
-		innerR: number
-		startAngle: number
-		endAngle: number
-	}) => {
-		const angleDiff = Math.abs(endAngle - startAngle)
-		const orientation = Math.sign(endAngle - startAngle)
-
-		// Handle full circles (or nearly full circles)
-		if (angleDiff >= 359.99) {
-			return [
-				`M ${cx + outerR} ${cy}`,
-				`A ${outerR} ${outerR} 0 1 0 ${cx - outerR} ${cy}`,
-				`A ${outerR} ${outerR} 0 1 0 ${cx + outerR} ${cy}`,
-				`M ${cx + innerR} ${cy}`,
-				`A ${innerR} ${innerR} 0 1 1 ${cx - innerR} ${cy}`,
-				`A ${innerR} ${innerR} 0 1 1 ${cx + innerR} ${cy}`,
-			].join(' ')
-		}
-
-		const outerAngleStart = startAngle + Math.asin((gap / 2) / outerR) * 180 / Math.PI * orientation
-		const outerStart = polarToCartesian(cx, cy, outerR, outerAngleStart)
-
-		const outerAngleEnd = endAngle - Math.asin((gap / 2) / outerR) * 180 / Math.PI * orientation
-		const outerEnd = polarToCartesian(cx, cy, outerR, outerAngleEnd)
-
-		const innerAngleEnd = endAngle - Math.asin((gap / 2) / innerR) * 180 / Math.PI * orientation
-		const innerEnd = polarToCartesian(cx, cy, innerR, innerAngleEnd)
-
-		const innerAngleStart = startAngle + Math.asin((gap / 2) / innerR) * 180 / Math.PI * orientation
-		const innerStart = polarToCartesian(cx, cy, innerR, innerAngleStart)
-
-		const largeArcFlag = angleDiff > 180 ? 1 : 0
-		const sweepFlag = orientation === 1 ? 1 : 0
-
-		// For equiangular pie slices with n slices (each with angle θ = 360°/n),
-		// the distance d they need to be moved from the origin to create gaps of width x is:
-		// d = x / (2 * sin(θ / 2))
-		// const offset = Math.abs(gap / (2 * Math.sin(Math.abs(endAngle - startAngle) / 2)))
-
-		return (
-			[
-				`M ${outerStart.x} ${outerStart.y}`,
-				`A ${outerR} ${outerR} 0 ${largeArcFlag} ${sweepFlag} ${outerEnd.x} ${outerEnd.y}`,
-				`L ${innerEnd.x} ${innerEnd.y}`,
-				`A ${innerR} ${innerR} 0 ${largeArcFlag} ${1 - sweepFlag} ${innerStart.x} ${innerStart.y}`,
-				`L ${outerStart.x} ${outerStart.y}`,
-			]
-				.join(' ')
-		)
-	}
-
 	const computeSlices = (
 		{
 			slices,
@@ -243,22 +168,17 @@
 			return {
 				...slice,
 				computed: {
-					path: getSlicePath({
-						cx: 0,
-						cy,
-						gap: levelConfig.gap,
-						outerR,
-						innerR,
-						startAngle: -totalAngle / 2,
-						endAngle: totalAngle / 2,
-					}),
 					totalAngle,
+					orientation: totalAngle >= 0 ? 1 : -1,
 					midAngle,
 					outerR,
 					innerR,
 					level,
 					offset: levelConfig.offset ?? 0,
 					gap: levelConfig.gap,
+					arcSize: Math.abs(totalAngle) > 180 ? 'large' : 'small',
+					outerSweep: totalAngle >= 0 ? 'cw' : 'ccw',
+					innerSweep: totalAngle >= 0 ? 'ccw' : 'cw',
 				},
 				...children && {
 					children: (
@@ -304,7 +224,7 @@
 		),
 	)
 
-	const svgAttributes = $derived.by(() => {
+	const pieMetrics = $derived.by(() => {
 		const maxRadiusMultiplier = Math.max(...levels.map(level => level.outerRadiusFraction))
 		const maxOffset = Math.max(...levels.map(level => level.offset ?? 0))
 		const maxRadius = radius * maxRadiusMultiplier + maxOffset
@@ -315,81 +235,75 @@
 		const viewBoxY = -(padding + maxRadius)
 
 		return {
+			maxRadius,
 			width,
 			height,
 			viewBox: `${viewBoxX} ${viewBoxY} ${width} ${height}`,
 		}
 	})
+
 </script>
 
 
 {#snippet sliceSnippet(slice: ComputedSlice)}
-	<g
-		class="slice"
-		style:--slice-midAngle={slice.computed.midAngle}
-		style:--slice-offset={slice.computed.offset}
-		style:--slice-gap={slice.computed.gap}
-		style:--slice-outerR={slice.computed.outerR}
-		style:--slice-innerR={slice.computed.innerR}
-		style:--slice-totalAngle={slice.computed.totalAngle}
-		style:--slice-path={`path("${slice.computed.path}")`}
-		style:--slice-fill={slice.color}
-		style:--slice-opacity={slice.opacity ?? 1}
-		class:highlighted={highlightedSliceId === slice.id}
-		data-slice-id={slice.id}
-		role={slice.href ? 'link' : 'button'}
-		tabIndex="0"
-		onmouseenter={() => { onSliceMouseEnter?.(slice.id) }}
-		onmouseleave={() => { onSliceMouseLeave?.(slice.id) }}
-		onfocus={() => { onSliceFocus?.(slice.id) }}
-		onblur={() => { onSliceBlur?.(slice.id) }}
-		onclick={e => {
-			e.stopPropagation()
-			onSliceClick?.(slice.id)
-		}}
-		onkeydown={e => {
-			if (e.code === 'Enter' || e.code === 'Space')
+	{#snippet slicePathSnippet(slice: ComputedSlice)}
+		<div
+			class="slice"
+			role="button"
+			tabindex="0"
+			aria-label={slice.titleText}
+			onmouseenter={() => { onSliceMouseEnter?.(slice.id) }}
+			onmouseleave={() => { onSliceMouseLeave?.(slice.id) }}
+			onfocus={() => { onSliceFocus?.(slice.id) }}
+			onblur={() => { onSliceBlur?.(slice.id) }}
+			onclick={e => {
+				e.stopPropagation()
 				onSliceClick?.(slice.id)
-		}}
-	>
-		<line
-			class="label-line"
-			x1="0"
-			y1={slice.computed.gap}
-			x2="0"
-			y2={-slice.computed.innerR}
-		/>
+			}}
+			onkeydown={e => {
+				if (e.code === 'Enter' || e.code === 'Space')
+					onSliceClick?.(slice.id)
+			}}
+			style:--slice-midAngle={slice.computed.midAngle}
+			style:--slice-offset={slice.computed.offset}
+			style:--slice-gap={slice.computed.gap}
+			style:--slice-outerR={slice.computed.outerR}
+			style:--slice-innerR={slice.computed.innerR}
+			style:--slice-totalAngle={slice.computed.totalAngle}
+			style:--slice-orientation={slice.computed.orientation}
+			style:--slice-gapPx={`${slice.computed.gap}px`}
+			style:--slice-outerRPx={`${slice.computed.outerR}px`}
+			style:--slice-innerRPx={`${slice.computed.innerR}px`}
+			style:--slice-totalAngleDeg={`${slice.computed.totalAngle}deg`}
+			style:--slice-arcSize={slice.computed.arcSize}
+			style:--slice-outerSweep={slice.computed.outerSweep}
+			style:--slice-innerSweep={slice.computed.innerSweep}
+			style:--slice-fill={slice.color}
+			style:--slice-opacity={slice.opacity ?? 1}
+			class:highlighted={highlightedSliceId === slice.id}
+			data-slice-id={slice.id}
+			data-stack
+		>
+			<span class="label" aria-hidden="true">{slice.arcLabel}</span>
+		</div>
+	{/snippet}
 
-		{#snippet slicePathSnippet(slice: ComputedSlice)}
-			<!-- Safari: set path directly with `d` attribute -->
-			<path
-				d={slice.computed.path}
-				class="slice-path"
-			>
-				<title>{slice.titleText}</title>
-			</path>
-		{/snippet}
-
-		{#if slice.href}
-			<a href={slice.href}>
-				{@render slicePathSnippet(slice)}
-			</a>
-		{:else}
+	{#if slice.href}
+		<a
+			class="slice-link"
+			href={slice.href}
+		>
 			{@render slicePathSnippet(slice)}
-		{/if}
+		</a>
+	{:else}
+		{@render slicePathSnippet(slice)}
+	{/if}
 
-		<text class="label" aria-hidden="true">
-			{slice.arcLabel}
-		</text>
-
-		{#if slice.children?.length}
-			<g class="slices">
-				{#each slice.children as childSlice (childSlice.id)}
-					{@render sliceSnippet(childSlice)}
-				{/each}
-			</g>
-		{/if}
-	</g>
+	{#if slice.children?.length}
+		{#each slice.children as childSlice (childSlice.id)}
+			{@render sliceSnippet(childSlice)}
+		{/each}
+	{/if}
 {/snippet}
 
 <div
@@ -397,29 +311,32 @@
 	class="container {'class' in restProps ? restProps.class : ''}"
 	data-layout={layout}
 	style:--pie-radius={radius}
+	style:--pie-padding={padding}
 	style:--pie-labelSize={labelSize}
+	style:--pie-maxR={pieMetrics.maxRadius}
 >
-	<svg {...svgAttributes}>
-		{#if title}
-			<title>{title}</title>
-		{/if}
-
-		<g class="slices">
+	<div
+		class="pie"
+		aria-label={title}
+		style:width={`${pieMetrics.width}px`}
+		style:height={`${pieMetrics.height}px`}
+		data-stack
+	>
+		<div class="slices" data-stack>
 			{#each computedSlices as slice (slice.id)}
 				{@render sliceSnippet(slice)}
 			{/each}
-		</g>
-
-		<g class="center">
+		</div>
+		<div class="center" data-stack>
 			{#if centerContentSnippet}
 				{@render centerContentSnippet()}
 			{:else}
-				<text>
+				<span>
 					{centerLabel}
-				</text>
+				</span>
 			{/if}
-		</g>
-	</svg>
+		</div>
+	</div>
 </div>
 
 
@@ -457,9 +374,18 @@
 		backface-visibility: hidden;
 		transition-duration: 0.4s;
 
-		svg {
+		.pie {
+			position: relative;
 			display: grid;
 			max-width: 100%;
+
+			.slice-link {
+				display: contents;
+
+				:is([data-stack] > &) > * {
+					grid-area: inherit;
+				}
+			}
 
 			.slice {
 				--slice-scale: 1;
@@ -499,59 +425,68 @@
 					var(--slice-outerR) - var(--slice-labelRadius)
 				);
 
-				transform-origin: 0 0;
-				cursor: pointer;
-				will-change: transform;
+				background-color: var(--slice-fill);
+				clip-path: shape(
+					from
+						calc(var(--slice-cx) + sin(var(--slice-outerStartAngle)) * var(--slice-outerRPx))
+						calc(var(--slice-cy) - cos(var(--slice-outerStartAngle)) * var(--slice-outerRPx)),
+					arc to
+						calc(var(--slice-cx) + sin(var(--slice-outerEndAngle)) * var(--slice-outerRPx))
+						calc(var(--slice-cy) - cos(var(--slice-outerEndAngle)) * var(--slice-outerRPx))
+						of var(--slice-outerRPx) var(--slice-outerSweep) var(--slice-arcSize),
+					line to
+						calc(var(--slice-cx) + sin(var(--slice-innerEndAngle)) * var(--slice-innerRPx))
+						calc(var(--slice-cy) - cos(var(--slice-innerEndAngle)) * var(--slice-innerRPx)),
+					arc to
+						calc(var(--slice-cx) + sin(var(--slice-innerStartAngle)) * var(--slice-innerRPx))
+						calc(var(--slice-cy) - cos(var(--slice-innerStartAngle)) * var(--slice-innerRPx))
+						of var(--slice-innerRPx) var(--slice-innerSweep) var(--slice-arcSize),
+					close
+				);
 
+				transform-origin: var(--pie-originX) var(--pie-originY);
 				transform:
 					rotate(calc(var(--pie-rotate) + var(--slice-midAngle) * 1deg))
 					scale(var(--slice-scale))
 					translateY(calc(var(--slice-offset) * -1px))
 				;
 				opacity: var(--slice-opacity);
-				transition-property: transform, opacity;
+
+				will-change: transform;
+				transition-property:
+					clip-path,
+					transform,
+					opacity
+				;
 
 				&:hover,
-				&:focus {
+				&:focus-within {
 					filter: brightness(var(--hover-brightness));
 					--slice-scale: var(--hover-scale);
 					opacity: 1;
 				}
 
-				&:focus,
+				&:focus-within,
 				&.highlighted {
-					stroke: var(--highlight-color);
-					stroke-width: calc(var(--highlight-stroke-width) * 1px);
 					z-index: 2;
 					opacity: 1;
 				}
 
-				&:focus {
+				&:focus-within {
 					outline: none;
 				}
 
-				> .label-line {
-					opacity: 0;
-					stroke: currentColor;
-					stroke-width: 1;
-					stroke-dasharray: 1 2;
-					pointer-events: none;
-				}
-
-				.slice-path {
-					d: var(--slice-path);
-					fill: var(--slice-fill);
-					stroke-linecap: square;
-				}
-
 				> .label {
-					text-anchor: middle;
-					dominant-baseline: central;
-					fill: currentColor;
-					stroke: none;
+					position: absolute;
+					left: var(--pie-originX);
+					top: var(--pie-originY);
+					display: inline-block;
+					white-space: nowrap;
+					text-align: center;
+					line-height: 1;
+					color: currentColor;
 					font-size: calc(var(--pie-labelSize) * 1px);
-					pointer-events: none;
-					translate: 0 calc(var(--slice-labelR) * -1px);
+					translate: -50% calc(-50% + (var(--slice-labelR) * -1px));
 					rotate: calc(-1 * (var(--pie-rotate) + var(--slice-midAngle) * 1deg));
 					transition-property: translate, rotate, filter;
 				}
@@ -559,24 +494,57 @@
 					filter: contrast(0.5) brightness(3) opacity(0.5) drop-shadow(1px 2px 3px rgba(0, 0, 0, 0.15));
 				}
 
-				> .slices {
-					transform: rotate(calc(var(--pie-rotate) + var(--slice-midAngle) * -1deg));
-					transform-origin: 0 0;
-					will-change: transform;
-				}
+				--pie-originX: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
+				--pie-originY: calc((var(--pie-maxR) + var(--pie-padding)) * 1px);
+				--slice-cx: var(--pie-originX);
+				--slice-cy: var(--pie-originY);
+				--slice-outerInsetAngle: asin((var(--slice-gapPx) / 2) / var(--slice-outerRPx));
+				--slice-innerInsetAngle: asin((var(--slice-gapPx) / 2) / var(--slice-innerRPx));
+				--slice-outerStartAngle: calc(
+					(-1 * var(--slice-totalAngleDeg) / 2)
+					+ (var(--slice-outerInsetAngle) * var(--slice-orientation))
+				);
+				--slice-outerEndAngle: calc(
+					(var(--slice-totalAngleDeg) / 2)
+					- (var(--slice-outerInsetAngle) * var(--slice-orientation))
+				);
+				--slice-innerStartAngle: calc(
+					(-1 * var(--slice-totalAngleDeg) / 2)
+					+ (var(--slice-innerInsetAngle) * var(--slice-orientation))
+				);
+				--slice-innerEndAngle: calc(
+					(var(--slice-totalAngleDeg) / 2)
+					- (var(--slice-innerInsetAngle) * var(--slice-orientation))
+				);
 			}
 
 			> .center {
-				:global(text) {
-					font-size: 0.8em;
-					fill: currentColor;
+				position: absolute;
+				inset: 0;
+				display: grid;
+				justify-items: center;
+				pointer-events: none;
 
-					text-anchor: middle;
-					dominant-baseline: var(--center-label-baseline);
+				:global {
+					> * {
+						pointer-events: auto;
 
-					pointer-events: none;
+						font-size: 0.8em;
+						color: currentColor;
+						translate: 0 calc((var(--center-align-offset, 0)) * 1px);
+					}
 				}
 			}
+		}
+
+		&[data-layout="TopHalf"] > .pie > .center {
+			align-items: end;
+			--center-align-offset: calc(-1 * var(--pie-padding));
+		}
+
+		&[data-layout="FullLeft"] > .pie > .center,
+		&[data-layout="FullTop"] > .pie > .center {
+			align-items: center;
 		}
 	}
 </style>

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -356,7 +356,7 @@
 
 	.container {
 		--highlight-color: rgba(255, 255, 255, 1);
-		--highlight-strokeWidth: 2;
+		--highlight-strokeWidth: 1.5px;
 		--hover-brightness: 1.1;
 		--hover-scale: 1.05;
 
@@ -396,10 +396,20 @@
 				--slice-scale: 1;
 				--slice-strokeColor: transparent;
 				--slice-strokeWidth: 0px;
+				--slice-filter:
+					brightness(var(--slice-brightness))
+				;
+				--slice-hover-filter:
+					brightness(var(--slice-brightness))
+					drop-shadow(var(--slice-strokeWidth) 0 var(--slice-strokeColor))
+					drop-shadow(0 calc(-1 * var(--slice-strokeWidth)) var(--slice-strokeColor))
+					drop-shadow(calc(-1 * var(--slice-strokeWidth)) 0 var(--slice-strokeColor))
+					drop-shadow(0 var(--slice-strokeWidth) var(--slice-strokeColor))
+				;
 
 				display: grid;
 
-				filter: brightness(var(--slice-brightness));
+				filter: var(--slice-filter);
 
 				pointer-events: none;
 				transition-property: filter;
@@ -420,6 +430,7 @@
 					--slice-scale: var(--hover-scale);
 					--slice-strokeColor: var(--highlight-color);
 					--slice-strokeWidth: var(--highlight-strokeWidth);
+					--slice-filter: var(--slice-hover-filter);
 				}
 
 				&:focus-within {

--- a/src/global.css
+++ b/src/global.css
@@ -186,6 +186,14 @@ a {
 			text-decoration: none;
 		}
 	}
+
+	&[data-link='contents'] {
+		display: contents;
+
+		> * {
+			grid-area: inherit;
+		}
+	}
 }
 
 hr {

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -1655,18 +1655,17 @@
 				}
 			}
 
-			> :global(.pie-container) {
-				transition-property: translate, scale, opacity;
-				transition-duration: 0.5s;
-				translate: var(--translate);
-				scale: var(--scale);
-				opacity: var(--opacity);
-			}
-
 			:global {
-				.slice {
-					transition-property: transform, opacity !important;
-					opacity: calc(1 - clamp(0, abs(var(--pie-slice-highlightIndex) - var(--i)), 1) * 0.5 * var(--isTransformed));
+				> .pie-container {
+					transition-property: translate, scale, opacity;
+					transition-duration: 0.5s;
+					translate: var(--translate);
+					scale: var(--scale);
+					opacity: var(--opacity);
+
+					.slice {
+						--slice-opacity: calc(1 - clamp(0, abs(var(--pie-slice-highlightIndex) - var(--i)), 1) * 0.5 * var(--isTransformed));
+					}
 				}
 			}
 		}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -1655,7 +1655,7 @@
 				}
 			}
 
-			> :global(*) {
+			> :global(.pie-container) {
 				transition-property: translate, scale, opacity;
 				transition-duration: 0.5s;
 				translate: var(--translate);

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -630,16 +630,11 @@
 								}}
 							>
 								{#snippet centerContentSnippet()}
-									<circle
-										r="8"
-										fill={scoreColor}
-									>
-										{#if showScores && score?.hasUnratedComponent}
-											<title>
-												*contains unrated components
-											</title>
-										{/if}
-									</circle>
+									<span
+										class="pie-center-dot pie-center-dot-large"
+										style:--pie-center-color={scoreColor}
+										title={showScores && score?.hasUnratedComponent ? '*contains unrated components' : undefined}
+									></span>
 								{/snippet}
 							</Pie>
 						</div>
@@ -1607,6 +1602,14 @@
 				padding: 2rem 0;
 			}
 		}
+	}
+
+	.pie-center-dot {
+		display: inline-block;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background-color: var(--pie-center-color);
 	}
 
 	@container (min-width: 1140px) {

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -1049,42 +1049,36 @@
 							>
 								{#snippet centerContentSnippet()}
 									{#if summaryVisualization === SummaryVisualization.Icon}
-										<image
-											href={`/images/wallets/${wallet.metadata.id}.${wallet.metadata.iconExtension}`}
+										<img
+											src={`/images/wallets/${wallet.metadata.id}.${wallet.metadata.iconExtension}`}
 											width="40"
 											height="40"
-											x="-20"
-											y="-20"
+											alt=""
 										/>
 									{:else if summaryVisualization === SummaryVisualization.Stage}
 										{#if stage && stage !== 'NOT_APPLICABLE' && stage !== 'QUALIFIED_FOR_NO_STAGES' && ladderEvaluation}
 											{@const stageIndex = ladderEvaluation.ladder.stages.findIndex(s => s.id === stage.id)}
 											{@const maxStages = ladderEvaluation.ladder.stages.length}
 											{#if stageIndex >= 0}
-												<text fill={stageToColor(stageIndex, maxStages)}>
+												<span class="pie-center-stage-label" style:--pie-center-color={stageToColor(stageIndex, maxStages)}>
 													{stage.label}
-												</text>
+												</span>
 											{:else}
-												<text>❔</text>
+												<span>❔</span>
 											{/if}
 										{:else}
-											<text>❔</text>
+											<span>❔</span>
 										{/if}
 									{:else if summaryVisualization === SummaryVisualization.Score}
-										<text>
+										<span>
 											{formatScore(score)}
-										</text>
+										</span>
 									{:else if summaryVisualization === SummaryVisualization.ScoreDot}
-										<circle
-											r="4"
-											fill={scoreToColor(score === null ? null : score.score)}
-										>
-											{#if score !== null && score.hasUnratedComponent}
-												<title>
-													*contains unrated components
-												</title>
-											{/if}
-										</circle>
+										<span
+											class="pie-center-dot"
+											style:--pie-center-color={scoreToColor(score === null ? null : score.score)}
+											title={score !== null && score.hasUnratedComponent ? '*contains unrated components' : undefined}
+										></span>
 									{/if}
 								{/snippet}
 							</Pie>
@@ -1281,28 +1275,19 @@
 							>
 								{#snippet centerContentSnippet()}
 									{#if summaryVisualization === SummaryVisualization.Icon}
-										<text
-											font-size="24"
-											text-anchor="middle"
-											dominant-baseline="central"
-										>
+										<span class="pie-center-icon">
 											{attrGroup.icon}
-										</text>
+										</span>
 									{:else if summaryVisualization === SummaryVisualization.Score}
-										<text>
+										<span>
 											{formatScore(groupScore)}
-										</text>
+										</span>
 									{:else if summaryVisualization === SummaryVisualization.ScoreDot}
-										<circle
-											r="4"
-											fill={scoreToColor(groupScore === null ? null : groupScore.score)}
-										>
-											{#if groupScore !== null && groupScore.hasUnratedComponent}
-												<title>
-													*contains unrated components
-												</title>
-											{/if}
-										</circle>
+										<span
+											class="pie-center-dot"
+											style:--pie-center-color={scoreToColor(groupScore === null ? null : groupScore.score)}
+											title={groupScore !== null && groupScore.hasUnratedComponent ? '*contains unrated components' : undefined}
+										></span>
 									{/if}
 								{/snippet}
 							</Pie>
@@ -1582,6 +1567,23 @@
 
 	.eip-tooltip-content {
 		width: 34rem;
+	}
+
+	.pie-center-stage-label {
+		color: var(--pie-center-color);
+	}
+
+	.pie-center-dot {
+		display: inline-block;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		background-color: var(--pie-center-color);
+	}
+
+	.pie-center-icon {
+		font-size: 24px;
+		line-height: 1;
 	}
 
 	button:has([data-badge]) {


### PR DESCRIPTION
## Components

* `<Pie>`
  * Render pie slices dynamically with HTML/CSS using CSS variables, `calc()`, `clip-path` and the newly Baseline Available [`shape()` CSS function](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/shape), replacing SVG + JavaScript calculations
  * Benefits:
    * smaller server-side rendering footprint; absolute SVG path coordinates with excessive decimal places no longer have to be baked into the initial HTML payload
    * allows for future HTML/CSS-native `popover` placement on individual pie slices that doesn't rely on JavaScript event listeners