### PR TITLE
fix: l1-lying-rpc-proxy URL parsing, add video demos and Helios PR link

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -105,6 +105,7 @@
 		"EIP",
 		"EIPs",
 		"Elytro",
+		"Enkrypt",
 		"EOA",
 		"EOAs",
 		"ERC",

--- a/resources/docs/wallet-testing/chain-verification/chain-verification.md
+++ b/resources/docs/wallet-testing/chain-verification/chain-verification.md
@@ -135,3 +135,18 @@ Navigate to the token balance screen for the ERC-20 token. Compare what the wall
 ### Step 7: Attempt an ERC-20 token send
 
 Try to send a small amount of the ERC-20 token to a different address you own. Observe whether the wallet uses the inflated proxy balance to calculate available funds, and whether it shows any indication that it is suspicious of the balance. Record the observed behavior in the same field as the previous step.
+
+## Video demonstrations
+
+### Video 1 — Wallet tricked by lying proxy (fake USDC balance)
+
+https://www.loom.com/share/cb1f9af969424f9b8d45c238cff463d1
+
+### Video 2 — Helios light client detecting the lie (warning banner)
+
+https://www.loom.com/share/f461dca60e32429db81b19fc2dc28897
+
+## Helios integration PR
+
+Proof-of-concept Helios light client integration for Enkrypt wallet:
+https://github.com/enkryptcom/enKrypt/pull/792

--- a/src/tools/l1-lying-rpc-proxy/index.ts
+++ b/src/tools/l1-lying-rpc-proxy/index.ts
@@ -105,7 +105,8 @@ function forwardToUpstream(
 	body: Buffer,
 ): Promise<{ statusCode: number; body: Buffer }> {
 	return new Promise((resolve, reject) => {
-		const isHttps = upstreamUrl.startsWith('https:')
+		const parsed = new URL(upstreamUrl)
+		const isHttps = parsed.protocol === 'https:'
 
 		const options = {
 			method: 'POST',
@@ -129,8 +130,24 @@ function forwardToUpstream(
 		}
 
 		const req = isHttps
-			? https.request(upstreamUrl, options, callback)
-			: http.request(upstreamUrl, options, callback)
+			? https.request(
+					{
+						...options,
+						hostname: parsed.hostname,
+						port: parsed.port || 443,
+						path: parsed.pathname + parsed.search,
+					},
+					callback,
+				)
+			: http.request(
+					{
+						...options,
+						hostname: parsed.hostname,
+						port: parsed.port || 80,
+						path: parsed.pathname + parsed.search,
+					},
+					callback,
+				)
 
 		req.on('error', reject)
 		req.write(body)


### PR DESCRIPTION
finish fixing #505
Added the following
- Fixes a bug in #562  
- Video 1 — Wallet tricked by lying proxy (fake USDC balance)
https://www.loom.com/share/cb1f9af969424f9b8d45c238cff463d1

- Video 2 — Helios light client detecting the lie (warning banner)
https://www.loom.com/share/f461dca60e32429db81b19fc2dc28897

- Helios integration PR
Proof-of-concept Helios light client integration for Enkrypt wallet:
https://github.com/enkryptcom/enKrypt/pull/792