### PR TITLE
fix: increase connect event timeout to prevent false negative

### DIFF
--- a/src/lib/eip-test-runners.ts
+++ b/src/lib/eip-test-runners.ts
@@ -325,7 +325,7 @@ export async function runStep2Connect(step: TestStep, ctx: EIPTestContext): Prom
 	}
 
 	// Give a brief moment for connect event to fire (some wallets emit asynchronously)
-	await new Promise(resolve => setTimeout(resolve, 100))
+	await new Promise(resolve => setTimeout(resolve, 500))
 
 	// Clean up listeners
 	try {


### PR DESCRIPTION
# Fix: increase connect event timeout to prevent false negative

The EIP-1193 `connect` event check in Step 2 was _mostly_ reporting wallets as failed. It seems 100ms is not enough for wallets that emit the event asynchronously after the request resolves.

Verified the event does fire correctly via console:

```ts
window.ethereum.on('connect', (info) => {
  console.log('CONNECT EVENT FIRED:', info)
})

await window.ethereum.request({ method: 'eth_requestAccounts' })
// → CONNECT EVENT FIRED: { chainId: '0x1' }
```

Fix is bumping the wait from 100ms to 500ms.