### PR TITLE
<Pie>: rounded slices fixes

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -456,7 +456,7 @@
 						var(--slice-outerR) - var(--slice-labelRadius)
 					);
 
-					--slice-halfAngle: calc(abs(var(--slice-totalAngle)) * 0.5deg);
+					--slice-halfAngle: calc(abs(var(--slice-totalAngle)) * 1deg / 2);
 					--slice-halfGap: calc(var(--slice-gap) / 2);
 					--slice-outerCornerR: max(
 						0,

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -599,12 +599,12 @@
 									align: ColumnAlignment.Center,
 
 									subcolumns: attrGroupColumns,
-									isDefaultExpanded: true,
+									isDefaultExpanded: false,
 								}
 							:
 								{
 									...attrGroupColumns[0],
-									isDefaultExpanded: true,
+									isDefaultExpanded: false,
 								}
 						),
 					] as Column<RatedWallet>[]


### PR DESCRIPTION
### Views

* `<WalletTable>`:
  * default to showing overall wallet column instead of attribute group columns

* `<Pie>`:
  * rewrite syntax slightly to prevent esbuild from rewriting `* 0.5deg` into `/ 2deg` during minification, causing `clip-path` to fail 😅

<img width="804" height="910" alt="Screenshot 2026-04-27 at 18 48 55" src="https://github.com/user-attachments/assets/bd3ed137-94c5-4891-8dca-ae8b923afdbc" />

<img width="1140" height="911" alt="Screenshot 2026-04-27 at 18 42 00" src="https://github.com/user-attachments/assets/ea95dedf-a349-4284-adbd-c9d13bbce387" />
