### PR TITLE
Astro: bundle size optimizations

### DIFF
--- a/src/pages/[walletName]/index.astro
+++ b/src/pages/[walletName]/index.astro
@@ -44,6 +44,6 @@ import WalletPage from '@/views/WalletPage.svelte'
 	<Navigation navigationItems={defaultNavigationItems} />
 
 	<main data-sticky-container>
-		<WalletPage {walletName} client:load />
+		<WalletPage {walletName} client:idle />
 	</main>
 </Layout>

--- a/src/pages/embedded/[attrGroupId].astro
+++ b/src/pages/embedded/[attrGroupId].astro
@@ -45,7 +45,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Embedded Wallets'
 			wallets={Object.values(allRatedWallets).filter(wallet => wallet.types[WalletType.EMBEDDED])}
 			attributeGroups={[attrGroup]}

--- a/src/pages/embedded/summary.astro
+++ b/src/pages/embedded/summary.astro
@@ -22,7 +22,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Embedded Wallets'
 			wallets={Object.values(allRatedWallets).filter(wallet => wallet.types[WalletType.EMBEDDED])}
 			{attributeGroups}

--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -295,7 +295,7 @@ import HelpOutlineIcon from '@material-icons/svg/svg/help_outline/baseline.svg?r
 						</header>
 
 						<div data-column='gap-5' data-scroll-item='inline-detached'>
-							<Typography client:load content={entry.answer} />
+							<Typography client:visible content={entry.answer} />
 						</div>
 					</section>
 				</>

--- a/src/pages/hww/[attrGroupId].astro
+++ b/src/pages/hww/[attrGroupId].astro
@@ -46,7 +46,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Hardware Wallets'
 			wallets={Object.values(ratedHardwareWallets)}
 			attributeGroups={[attrGroup]}

--- a/src/pages/hww/summary.astro
+++ b/src/pages/hww/summary.astro
@@ -21,7 +21,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Hardware Wallets'
 			wallets={Object.values(ratedHardwareWallets)}
 			{attributeGroups}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,14 +42,14 @@ import WalletTable from '@/views/WalletTable.svelte'
 		</header>
 
 		<WalletTable
-			client:load
+			client:visible
 			title='Software Wallets'
 			wallets={Object.values(ratedSoftwareWallets)}
 			{attributeGroups}
 		/>
 
 		<WalletTable
-			client:load
+			client:visible
 			title='Hardware Wallets'
 			wallets={Object.values(ratedHardwareWallets)}
 			{attributeGroups}

--- a/src/pages/wallet/7702.astro
+++ b/src/pages/wallet/7702.astro
@@ -34,7 +34,7 @@ import GitHubIcon from 'lucide-static/icons/github.svg?raw'
 			/>
 		</header>
 
-		<Eip7702Table title='Software Wallets by EIP-7702 Support' client:load />
+		<Eip7702Table title='Software Wallets by EIP-7702 Support' client:visible />
 
 		<footer data-scroll-item='inline-detached padding-match-end' data-row='center'>
 			<p>

--- a/src/pages/wallet/[attrGroupId].astro
+++ b/src/pages/wallet/[attrGroupId].astro
@@ -45,7 +45,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Software Wallets'
 			wallets={Object.values(allRatedWallets).filter(wallet => wallet.types[WalletType.SOFTWARE])}
 			attributeGroups={[attrGroup]}

--- a/src/pages/wallet/summary.astro
+++ b/src/pages/wallet/summary.astro
@@ -22,7 +22,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 	<main data-sticky-container>
 		<WalletTable
-			client:load
+			client:visible
 			title='Software Wallets'
 			wallets={Object.values(allRatedWallets).filter(wallet => wallet.types[WalletType.SOFTWARE])}
 			{attributeGroups}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,7 @@
-@import '@fontsource/space-grotesk/latin.css';
+@import '@fontsource/space-grotesk/latin-400.css';
+@import '@fontsource/space-grotesk/latin-500.css';
+@import '@fontsource/space-grotesk/latin-600.css';
+@import '@fontsource/space-grotesk/latin-700.css';
 
 :root {
 	--transition-easeInExpo: cubic-bezier(0.7, 0, 0.84, 0);

--- a/src/views/Navigation.astro
+++ b/src/views/Navigation.astro
@@ -19,7 +19,7 @@ const currentPathname = Astro.url.pathname
 >
 	<div id='nav-menu' data-sticky-container>
 		<NavigationItems
-			client:load
+			client:idle
 			transition:persist
 			items={navigationItems}
 			currentPathname={currentPathname}


### PR DESCRIPTION
## Views

* Defer JavaScript island hydration with `client:visible` to reduce initial payload size

## Fonts

* Load only font weights that are used on the site