### PR TITLE
feat(seo): improve page titles on /hww and /wallet/summary

### DIFF
--- a/src/pages/hww/[attrGroupId].astro
+++ b/src/pages/hww/[attrGroupId].astro
@@ -37,7 +37,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 <Layout
 	metadata={{
-		title: `${attrGroup.displayName} - Walletbeat`,
+		title: `Ethereum Hardware Wallets ${attrGroup.displayName} - Walletbeat`,
 		description: `Learn how ${attrGroup.displayName} impacts your wallet experience.`,
 		keywordsBefore: [`Ethereum ${attrGroup.displayName}`],
 	}}

--- a/src/pages/hww/summary.astro
+++ b/src/pages/hww/summary.astro
@@ -14,7 +14,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 <Layout
 	metadata={{
-		title: 'Walletbeat',
+		title: 'Ethereum Hardware Wallets - Walletbeat',
 	}}
 >
 	<Navigation navigationItems={defaultNavigationItems} />

--- a/src/pages/wallet/[attrGroupId].astro
+++ b/src/pages/wallet/[attrGroupId].astro
@@ -36,7 +36,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 <Layout
 	metadata={{
-		title: `${attrGroup.displayName} - Walletbeat`,
+		title: `Ethereum Wallets ${attrGroup.displayName} - Walletbeat`,
 		description: `Learn how ${attrGroup.displayName} impacts your wallet experience.`,
 		keywordsBefore: [`Ethereum ${attrGroup.displayName}`],
 	}}

--- a/src/pages/wallet/summary.astro
+++ b/src/pages/wallet/summary.astro
@@ -15,7 +15,7 @@ import WalletTable from '@/views/WalletTable.svelte'
 
 <Layout
 	metadata={{
-		title: 'Walletbeat',
+		title: 'Ethereum Wallets - Walletbeat',
 	}}
 >
 	<Navigation navigationItems={defaultNavigationItems} />


### PR DESCRIPTION
## Summary

Closes #149. Implements the title format that @polymutex approved on the issue thread (\"Sounds good to me\"):

| Route | Before | After |
|---|---|---|
| \`/hww/summary\` | \`Walletbeat\` | \`Ethereum Hardware Wallets - Walletbeat\` |
| \`/hww/{attrGroup}\` | \`{Group} - Walletbeat\` | \`Ethereum Hardware Wallets {Group} - Walletbeat\` |
| \`/wallet/summary\` | \`Walletbeat\` | \`Ethereum Wallets - Walletbeat\` |
| \`/wallet/{attrGroup}\` | \`{Group} - Walletbeat\` | \`Ethereum Wallets {Group} - Walletbeat\` |

## Diff

4 lines across 4 files — strictly the title strings.

\`\`\`
src/pages/hww/[attrGroupId].astro    | 2 +-
src/pages/hww/summary.astro          | 2 +-
src/pages/wallet/[attrGroupId].astro | 2 +-
src/pages/wallet/summary.astro       | 2 +-
4 files changed, 4 insertions(+), 4 deletions(-)
\`\`\`

## Note on existing PR #465

Saw [#465](https://github.com/walletbeat/walletbeat/pull/465) by @Hijanhv has been open since January with merge conflicts and zero maintainer reviews — and the diff scope-crept into Svelte/lint refactors well beyond the title change.

If @Hijanhv wants to rebase and trim back to the title-only scope, happy to defer this PR. Otherwise this one keeps the diff to the four lines the issue asked for, which should be straightforward to land.

## Test plan

- [x] Title strings updated to match the spec exactly
- [x] No other markup or behavior changes
- [ ] Reviewer step: run \`pnpm dev\` and confirm browser tab titles match the table above
- [ ] Reviewer step: confirm individual wallet pages (\`/{walletName}/\`) — out of scope for this issue — still render their own titles