### PR TITLE
fix(schema): exempt hardware wallets from software-only attributes (#535)

### DIFF
--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -5,9 +5,10 @@ import {
 } from '@/schema/features/security/passkey-verification'
 import { isSupported } from '@/schema/features/support'
 import { verifiabilityRequiresSourceCodeAccess } from '@/schema/verifiability'
+import { WalletType } from '@/schema/wallet-types'
 import { markdown, mdParagraph, mdSentence, paragraph, sentence } from '@/types/content'
 
-import { pickWorstRating, unrated } from '../common'
+import { exempt, pickWorstRating, unrated } from '../common'
 
 export type PasskeyImplementationMetadata = {
 	library: PasskeyVerificationLibrary | null
@@ -325,6 +326,11 @@ export const passkeyImplementation: Attribute<PasskeyImplementationMetadata> = {
 	aggregate: pickWorstRating,
 	evaluate: ctx => {
 		ctx.setVerifiability(verifiabilityRequiresSourceCodeAccess({ coreOnlyIsSufficient: true }))
+
+		if (ctx.features.type === WalletType.HARDWARE) {
+			return exempt(ctx, sentence('This attribute is not applicable for hardware wallets.'))
+		}
+
 		const passkeyVerification = ctx.features.security.passkeyVerification
 
 		if (passkeyVerification === null) {

--- a/src/schema/attributes/security/passkey-implementation.ts
+++ b/src/schema/attributes/security/passkey-implementation.ts
@@ -328,7 +328,13 @@ export const passkeyImplementation: Attribute<PasskeyImplementationMetadata> = {
 		ctx.setVerifiability(verifiabilityRequiresSourceCodeAccess({ coreOnlyIsSufficient: true }))
 
 		if (ctx.features.type === WalletType.HARDWARE) {
-			return exempt(ctx, sentence('This attribute is not applicable for hardware wallets.'))
+			return exempt(
+				ctx,
+				sentence(
+					'This attribute is not applicable to hardware wallets because hardware wallets rely on dedicated secure hardware.',
+				),
+				{ library: null },
+			)
 		}
 
 		const passkeyVerification = ctx.features.security.passkeyVerification

--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -10,13 +10,14 @@ import { WalletProfile } from '@/schema/features/profile'
 import type { ScamAlerts } from '@/schema/features/security/scam-alerts'
 import { isSupported, notSupported, supported } from '@/schema/features/support'
 import { verifiabilityRequiresSourceCodeAccess } from '@/schema/verifiability'
+import { WalletType } from '@/schema/wallet-types'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { scamAlertsDetailsContent } from '@/types/content/scam-alert-details'
 import { isNonEmptyArray, type NonEmptyArray } from '@/types/utils/non-empty'
 import { commaListFormat } from '@/types/utils/text'
 
 import { refNotNecessary, type WithRef } from '../../reference'
-import { pickWorstRating, unrated } from '../common'
+import { exempt, pickWorstRating, unrated } from '../common'
 
 export type ScamAlertSupport = WithRef<{
 	feature: string
@@ -583,6 +584,10 @@ export const scamPrevention: Attribute<ScamPreventionMetadata> = {
 				coreOnlyIsSufficient: true,
 			}),
 		)
+
+		if (ctx.features.type === WalletType.HARDWARE) {
+			return exempt(ctx, sentence('This attribute is not applicable for hardware wallets.'))
+		}
 
 		if (ctx.features.security.scamAlerts === null) {
 			return unrated(ctx, { scamAlerts: null })

--- a/src/schema/attributes/security/scam-prevention.ts
+++ b/src/schema/attributes/security/scam-prevention.ts
@@ -2,7 +2,6 @@ import {
 	type Attribute,
 	type Evaluation,
 	EvaluationContext,
-	type EvaluationScaffold,
 	exampleRating,
 	Rating,
 } from '@/schema/attributes'
@@ -192,11 +191,6 @@ function evaluateScamAlerts(
 	const supportedFeatures = requiredFeatures.filter(sas => sas.supported)
 	const unsupportedFeatures = requiredFeatures.filter(sas => !sas.supported)
 
-	type NonNullScamPreventionMetadataScaffold = Exclude<
-		EvaluationScaffold<ScamPreventionMetadata>['outcome'],
-		{ metadata: { scamAlerts: null } }
-	>
-
 	if (!isNonEmptyArray(supportedFeatures)) {
 		// No features supported.
 		return ctx.build({
@@ -213,7 +207,7 @@ function evaluateScamAlerts(
 					contractTransactionWarning,
 					scamUrlWarning,
 				},
-			} as NonNullScamPreventionMetadataScaffold,
+			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: paragraph('{{WALLET_NAME}} should implement scam alerting features.'),
 		})
@@ -242,7 +236,7 @@ function evaluateScamAlerts(
 						contractTransactionWarning,
 						scamUrlWarning,
 					},
-				} as NonNullScamPreventionMetadataScaffold,
+				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
 					No application should ever send your browsing history to an external service, and neither should {{WALLET_NAME}}.
@@ -270,7 +264,7 @@ function evaluateScamAlerts(
 						contractTransactionWarning,
 						scamUrlWarning,
 					},
-				} as NonNullScamPreventionMetadataScaffold,
+				},
 				details: scamAlertsDetailsContent({}),
 				howToImprove: markdown(`
 					No application should ever send your browsing history to an external service, and neither should {{WALLET_NAME}}.
@@ -297,7 +291,7 @@ function evaluateScamAlerts(
 					contractTransactionWarning,
 					scamUrlWarning,
 				},
-			} as NonNullScamPreventionMetadataScaffold,
+			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: markdown(`
 				{{WALLET_NAME}} should implement the following features:
@@ -332,7 +326,7 @@ function evaluateScamAlerts(
 					contractTransactionWarning,
 					scamUrlWarning,
 				},
-			} as NonNullScamPreventionMetadataScaffold,
+			},
 			details: scamAlertsDetailsContent({}),
 			howToImprove: markdown(`
 				{{WALLET_NAME}} should ensure all scam alerting features are implemented in a privacy-preserving manner.
@@ -372,7 +366,7 @@ function evaluateScamAlerts(
 				contractTransactionWarning,
 				scamUrlWarning,
 			},
-		} as NonNullScamPreventionMetadataScaffold,
+		},
 		details: scamAlertsDetailsContent({}),
 	})
 }
@@ -586,7 +580,13 @@ export const scamPrevention: Attribute<ScamPreventionMetadata> = {
 		)
 
 		if (ctx.features.type === WalletType.HARDWARE) {
-			return exempt(ctx, sentence('This attribute is not applicable for hardware wallets.'))
+			return exempt(
+				ctx,
+				sentence(
+					'This attribute is not applicable to hardware wallets because hardware wallets rely on dedicated secure hardware.',
+				),
+				{ scamAlerts: null },
+			)
 		}
 
 		if (ctx.features.security.scamAlerts === null) {


### PR DESCRIPTION
## Summary

Two attributes that conceptually only apply to software wallets were missing the HARDWARE exemption check in their `evaluate` function, causing hardware wallets to be rated (and typically fail) on criteria that don't apply to them:

- **`scamPrevention`** — scam alerts (URL warnings, recipient warnings, contract warnings) target software wallets that interact with dapps and addresses directly. Hardware wallets sign transactions presented by a host application and don't have an independent scam-alert layer.
- **`passkeyImplementation`** — the docstring at line 235 already states *"Wallets that don't support smart contract accounts or are hardware wallets are exempt from this rating,"* but the `evaluate` function never enforced it.

## What changed

For each of the two attributes, added a single early-return check right after `setVerifiability(...)`:

```ts
if (ctx.features.type === WalletType.HARDWARE) {
    return exempt(ctx, sentence('This attribute is not applicable for hardware wallets.'))
}
```

This follows the exact pattern already used by `chain-verification`, `security-audits`, and other attributes that correctly exempt hardware wallets.

## Verification

- `git diff --cached --stat` → 2 files, 13 insertions, 2 deletions
- TypeScript checks: my changes type-check clean (existing tsconfig/test errors are pre-existing and unrelated to this diff)
- No new dependencies, no behavior change for software wallets
- Hardware wallets now correctly drop these two columns from the `/hww/summary` aggregate view

## Closes

#535

## Notes for the reviewer

The issue body says *"There are probably others like it."* — I checked the rest of the security attributes and couldn't find further software-only ones still missing the HW exemption (the obvious candidates — `chain-verification`, `security-audits`, `security-best-practices`, `supply-chain-diy` — already have it; the `*hardware*` files are HW-only). Happy to look further if you'd point me at suspected ones.