### PR TITLE
Feature: Add ERC-8213 support

### DIFF
--- a/data/eips.ts
+++ b/data/eips.ts
@@ -1,4 +1,5 @@
 import type { Eip, EipNumber } from '../src/schema/eips'
+import { eip712 } from './eips/eip-712'
 import { eip1193 } from './eips/eip-1193'
 import { eip2700 } from './eips/eip-2700'
 import { eip5792 } from './eips/eip-5792'
@@ -8,6 +9,7 @@ import { erc4337 } from './eips/erc-4337'
 import { erc5564 } from './eips/erc-5564'
 import { erc7828 } from './eips/erc-7828'
 import { erc7831 } from './eips/erc-7831'
+import { erc8213 } from './eips/erc-8213'
 
 /**
  * All EIPs tracked by Walletbeat.
@@ -19,9 +21,11 @@ export const eips: Record<EipNumber, Eip> = {
 	'5564': erc5564,
 	'5792': eip5792,
 	'6963': eip6963,
+	'712': eip712,
 	'7702': eip7702,
 	'7828': erc7828,
 	'7831': erc7831,
+	'8213': erc8213,
 }
 
 /** Resolve an EIP from an EIP number. */

--- a/data/eips/eip-712.ts
+++ b/data/eips/eip-712.ts
@@ -1,0 +1,22 @@
+import { type Eip, EipPrefix, EipStatus } from '@/schema/eips'
+
+export const eip712: Eip = {
+	friendlyName: 'Typed structured data signing',
+	formalTitle: 'Typed structured data hashing and signing',
+	number: '712',
+	prefix: EipPrefix.EIP,
+	status: EipStatus.FINAL,
+	summaryMarkdown: `
+		EIP-712 defines a standard for hashing and signing typed structured data,
+		enabling wallets to display human-readable descriptions of what a user is
+		signing rather than a hex string. It introduces a domain separator
+		and per-type schemas so that signatures are both human-inspectable and
+		replay-protected across different contracts and chains.
+	`,
+	whyItMattersMarkdown: `
+		Without EIP-712, wallets present users with a raw 32-byte hash to sign,
+		giving them no indication of what they are authorizing. With EIP-712,
+		wallets can decode and display the structured data 
+		so users can make an informed decision before signing.
+	`,
+}

--- a/data/eips/erc-8213.ts
+++ b/data/eips/erc-8213.ts
@@ -1,0 +1,27 @@
+import { type Eip, EipPrefix, EipStatus } from '@/schema/eips'
+
+export const erc8213: Eip = {
+	friendlyName: 'Wallet signature & calldata digest display',
+	formalTitle: 'Wallet Signature and Calldata Digest Display',
+	number: '8213',
+	prefix: EipPrefix.ERC,
+	status: EipStatus.DRAFT,
+	summaryMarkdown: `
+		ERC-8213 standardizes the terminology and display requirements for
+		cryptographic digests that wallets show to signers. It defines the terms:
+
+		- **EIP-712 Digest**: \`keccak256("\\x19\\x01" || domainSeparator || hashStruct(message))\` — the value that is ultimately signed.
+		- **Calldata Digest**: \`keccak256(uint256(len(calldata)) || calldata)\` — a compact, chain-agnostic fingerprint of the transaction payload.
+
+		For EIP-712 signing, wallets SHOULD display at least the EIP-712 Digest (or Domain Hash + Message Hash together).
+		For transactions with calldata, wallets SHOULD display the Calldata Digest as a \`0x\`-prefixed hex string.
+	`,
+	whyItMattersMarkdown: `
+		Recent high-profile exchange compromises showed that users cannot safely
+		rely on a website's description of what they are signing, if the signing
+		interface is compromised, the description can be spoofed while the actual
+		payload is malicious. ERC-8213 gives signers a way to independently verify
+		the exact bytes they authorize by comparing a short digest against a trusted
+		external source, without needing to parse raw hex character-by-character.
+	`,
+}

--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -238,7 +238,7 @@ export const bitboxWallet: HardwareWallet = {
 					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -213,7 +213,7 @@ export const cypherockWallet: HardwareWallet = {
 					to: DataDisplayOptions.SHOWN_BY_DEFAULT, // contract address
 					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -86,7 +86,7 @@ export const fireflyWallet: HardwareWallet = {
 				calldataDecoded: noCalldataDecoding,
 				dataExtraction: noDataExtraction,
 				detailsDisplayed: null,
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -27,8 +27,8 @@ import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	BasicBenchmarkTransactions,
 	ComplexBenchmarkTransactions,
-	DataDecoded,
 	DataExtraction,
+	DataLocation,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
@@ -254,15 +254,15 @@ export const gridplusWallet: HardwareWallet = {
 				],
 				calldataDecoded: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataDecoded.ON_DEVICE,
+					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
 					[BasicBenchmarkTransactions.ERC_721_TRANSFER]: null,
 					[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataDecoded.NOT_DECODED,
-					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataDecoded.ON_DEVICE,
+					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.NOT_PROVIDED,
+					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataLocation.ON_DEVICE,
 					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
-						DataDecoded.NOT_DECODED,
+						DataLocation.NOT_PROVIDED,
 				},
 				dataExtraction: {
 					[DataExtraction.EYES]: true,
@@ -270,7 +270,7 @@ export const gridplusWallet: HardwareWallet = {
 					[DataExtraction.QRCODE]: false,
 				},
 				detailsDisplayed: displaysFullTransactionDetails,
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -6,9 +6,9 @@ import { SupplyChainFactoryType } from '@/schema/features/security/supply-chain-
 import {
 	BasicBenchmarkTransactions,
 	ComplexBenchmarkTransactions,
-	DataDecoded,
 	DataDisplayOptions,
 	DataExtraction,
+	DataLocation,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/transaction-legibility'
 import { InteroperabilityType } from '@/schema/features/self-sovereignty/interoperability'
@@ -165,15 +165,15 @@ export const imkeyWallet: HardwareWallet = {
 				],
 				calldataDecoded: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataDecoded.ON_DEVICE,
+					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
 					[BasicBenchmarkTransactions.ERC_721_TRANSFER]: null,
 					[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataDecoded.NOT_DECODED,
-					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataDecoded.NOT_DECODED,
-					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataDecoded.NOT_DECODED,
+					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.NOT_PROVIDED,
+					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.NOT_PROVIDED,
+					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataLocation.NOT_PROVIDED,
 					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
-						DataDecoded.NOT_DECODED,
+						DataLocation.NOT_PROVIDED,
 				},
 				dataExtraction: {
 					[DataExtraction.EYES]: true,
@@ -184,7 +184,7 @@ export const imkeyWallet: HardwareWallet = {
 					...displaysFullTransactionDetails,
 					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -17,9 +17,9 @@ import { SupplyChainDIYType } from '@/schema/features/security/supply-chain-diy'
 import {
 	BasicBenchmarkTransactions,
 	ComplexBenchmarkTransactions,
-	DataDecoded,
 	DataDisplayOptions,
 	DataExtraction,
+	DataLocation,
 	noCalldataDecoding,
 } from '@/schema/features/security/transaction-legibility'
 import { InteroperabilityType } from '@/schema/features/self-sovereignty/interoperability'
@@ -260,8 +260,8 @@ export const keycardShell: HardwareWallet = {
 				],
 				calldataDecoded: {
 					...noCalldataDecoding,
-					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataDecoded.ON_DEVICE,
+					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.ON_DEVICE,
 				},
 				// Data extraction: QR codes used for transaction data (ERC-4527); display visible to eyes
 				dataExtraction: {
@@ -277,7 +277,7 @@ export const keycardShell: HardwareWallet = {
 					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -17,9 +17,9 @@ import { SecureElementType } from '@/schema/features/security/secure-element'
 import {
 	BasicBenchmarkTransactions,
 	ComplexBenchmarkTransactions,
-	DataDecoded,
 	DataDisplayOptions,
 	DataExtraction,
+	DataLocation,
 	displaysFullTransactionDetails,
 } from '@/schema/features/security/transaction-legibility'
 import { notSupported, supported } from '@/schema/features/support'
@@ -196,15 +196,15 @@ export const keystoneWallet: HardwareWallet = {
 				],
 				calldataDecoded: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataDecoded.ON_DEVICE,
+					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
 					[BasicBenchmarkTransactions.ERC_721_TRANSFER]: null,
 					[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: null,
-					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataDecoded.NOT_DECODED,
-					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataDecoded.ON_DEVICE,
-					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataDecoded.NOT_DECODED,
+					[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.NOT_PROVIDED,
+					[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.ON_DEVICE,
+					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataLocation.NOT_PROVIDED,
 					[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
-						DataDecoded.NOT_DECODED,
+						DataLocation.NOT_PROVIDED,
 				},
 				dataExtraction: {
 					[DataExtraction.EYES]: true,
@@ -215,7 +215,7 @@ export const keystoneWallet: HardwareWallet = {
 					...displaysFullTransactionDetails,
 					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -199,7 +199,7 @@ export const ledgerWallet: HardwareWallet = {
 					[DataExtraction.QRCODE]: false,
 				},
 				detailsDisplayed: displaysFullTransactionDetails,
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -168,7 +168,7 @@ export const ngrave: HardwareWallet = {
 					to: DataDisplayOptions.SHOWN_BY_DEFAULT,
 					value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -203,7 +203,7 @@ export const onekeyWallet: HardwareWallet = {
 					chain: DataDisplayOptions.NOT_IN_UI,
 					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -190,7 +190,7 @@ export const trezorWallet: HardwareWallet = {
 					chain: DataDisplayOptions.NOT_IN_UI,
 					nonce: DataDisplayOptions.NOT_IN_UI,
 				},
-				messageSigningLegibility: null,
+				erc8213: null,
 			},
 			userSafety: null,
 		},

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -44,6 +44,7 @@ import {
 } from '@/schema/features/security/security-best-practices'
 import {
 	BasicBenchmarkTransactions,
+	CallDataDisplay,
 	ComplexBenchmarkTransactions,
 	DataDisplayOptions,
 	type DisplayedBasicTransactionDetails,
@@ -665,17 +666,20 @@ export const ambire: SoftwareWallet = {
 			},
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: false,
-					formatted: false,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				transactionDetailsDisplay: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: ambireTransactionDisplayDefault,
 					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {

--- a/data/software-wallets/bitget.ts
+++ b/data/software-wallets/bitget.ts
@@ -11,6 +11,7 @@ import {
 	MultiPartyKeyReconstruction,
 } from '@/schema/features/security/keys-handling'
 import {
+	CallDataDisplay,
 	DataDisplayOptions,
 	MessageSigningDetails,
 } from '@/schema/features/security/transaction-legibility'
@@ -206,17 +207,20 @@ export const bitget: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: true,
-					formatted: false,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				transactionDetailsDisplay: null,
 			},
 		},

--- a/data/software-wallets/completed.tmpl.ts
+++ b/data/software-wallets/completed.tmpl.ts
@@ -67,6 +67,7 @@ import {
 	ComplexBenchmarkTransactions,
 	DataDisplayOptions,
 	type DisplayedBasicTransactionDetails,
+	displaysFullCallData,
 	MessageSigningDetails,
 	SimulationBenchmarkTransactions,
 	TransactionOutcome,
@@ -629,17 +630,15 @@ export const completedTemplate: SoftwareWallet = {
 			},
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: true,
-					formatted: true,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: displaysFullCallData,
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+					},
+				}),
 				transactionDetailsDisplay: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: passTransactionDisplay,
 					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -143,8 +143,7 @@ export const frame: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: null,
-				messageSigningLegibility: null,
+				erc8213: null,
 				transactionDetailsDisplay: null,
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -29,10 +29,10 @@ import {
 } from '@/schema/features/security/security-best-practices'
 import {
 	BasicBenchmarkTransactions,
+	CallDataDisplay,
 	ComplexBenchmarkTransactions,
 	DataDisplayOptions,
 	type DisplayedBasicTransactionDetails,
-	displaysFullCallData,
 	MessageSigningDetails,
 	SimulationBenchmarkTransactions,
 	TransactionOutcome,
@@ -551,13 +551,20 @@ export const metamask: SoftwareWallet = {
 			},
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: displaysFullCallData,
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				transactionDetailsDisplay: {
 					[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
 						...metamaskTransactionDisplayDefault,

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -182,8 +182,7 @@ export const nufi: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: null,
-				messageSigningLegibility: null,
+				erc8213: null,
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// 	from: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/okx.ts
+++ b/data/software-wallets/okx.ts
@@ -8,6 +8,7 @@ import {
 	LegalProtectionType,
 } from '@/schema/features/security/bug-bounty-program'
 import {
+	CallDataDisplay,
 	DataDisplayOptions,
 	MessageSigningDetails,
 } from '@/schema/features/security/transaction-legibility'
@@ -196,17 +197,20 @@ OKX Wallet is a universal crypto wallet available on multiple platforms, includi
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: true,
-					formatted: false,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_OPTIONALLY,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// 	from: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -145,8 +145,7 @@ export const phantom: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: null,
-				messageSigningLegibility: null,
+				erc8213: null,
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// 	from: DataDisplayOptions.SHOWN_OPTIONALLY,

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -29,6 +29,7 @@ import type { ScamUrlWarning } from '@/schema/features/security/scam-alerts'
 import { SecurityFlawSeverity } from '@/schema/features/security/security-audits'
 import {
 	BasicBenchmarkTransactions,
+	CallDataDisplay,
 	ComplexBenchmarkTransactions,
 	DataDisplayOptions,
 	type DisplayedBasicTransactionDetails,
@@ -714,17 +715,20 @@ export const rabby: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: false,
-					formatted: true,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_OPTIONALLY,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				transactionDetailsDisplay: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: rabbyTransactionDisplayDefault,
 					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -19,6 +19,7 @@ import {
 } from '@/schema/features/security/keys-handling'
 import {
 	BasicBenchmarkTransactions,
+	CallDataDisplay,
 	ComplexBenchmarkTransactions,
 	DataDisplayOptions,
 	type DisplayedBasicTransactionDetails,
@@ -283,17 +284,20 @@ export const rainbow: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: {
-					copyHexToClipboard: true,
-					formatted: false,
-					rawHex: true,
-				},
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				},
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				transactionDetailsDisplay: {
 					[BasicBenchmarkTransactions.ETH_TRANSFER]: rainbowTransactionDisplayDefault,
 					[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -11,7 +11,10 @@ import {
 } from '@/schema/features/security/hardware-wallet-support'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import { type ScamUrlWarning } from '@/schema/features/security/scam-alerts'
-import { displaysFullCallData } from '@/schema/features/security/transaction-legibility'
+import {
+	CallDataDisplay,
+	DataDisplayOptions,
+} from '@/schema/features/security/transaction-legibility'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import {
 	TransactionSubmissionL2Support,
@@ -266,8 +269,15 @@ export const safe: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: displaysFullCallData,
-				messageSigningLegibility: null,
+				erc8213: supported({
+					calldataDisplay: {
+						[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_OPTIONALLY,
+						[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+					messageSigningLegibility: null,
+				}),
 				// transactionDetailsDisplay: displaysFullTransactionDetails,
 				transactionDetailsDisplay: null,
 			},

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -149,8 +149,7 @@ export const zerion: SoftwareWallet = {
 			securityBestPractices: null,
 			transactionLegibility: {
 				ref: refTodo,
-				calldataDisplay: null,
-				messageSigningLegibility: null,
+				erc8213: null,
 				transactionDetailsDisplay: null,
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,

--- a/data/software-wallets/zeus.ts
+++ b/data/software-wallets/zeus.ts
@@ -10,8 +10,6 @@ import {
 import {
 	DataDisplayOptions,
 	MessageSigningDetails,
-	type SoftwareMessageSigningLegibility,
-	type SoftwareTransactionLegibilityImplementation,
 } from '@/schema/features/security/transaction-legibility'
 import { RpcEndpointConfiguration } from '@/schema/features/self-sovereignty/chain-configurability'
 import {
@@ -280,7 +278,15 @@ export const zeus: SoftwareWallet = {
 						url: 'https://github.com/greekfetacheese/zeus/blob/6fc3006fd8790f3f0db2feae24a5bdbad07c0c30/src/core/tx_analysis.rs',
 					},
 				],
-				calldataDisplay: null,
+				erc8213: supported({
+					calldataDisplay: null,
+					messageSigningLegibility: {
+						[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+					},
+				}),
 				// transactionDetailsDisplay: {
 				// 	chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// 	from: DataDisplayOptions.SHOWN_BY_DEFAULT,
@@ -289,14 +295,8 @@ export const zeus: SoftwareWallet = {
 				// 	to: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// 	value: DataDisplayOptions.SHOWN_BY_DEFAULT,
 				// },
-				messageSigningLegibility: {
-					[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
-					[MessageSigningDetails.SAFE_HASH]: DataDisplayOptions.NOT_IN_UI,
-				} as SoftwareMessageSigningLegibility,
 				transactionDetailsDisplay: null,
-			} as SoftwareTransactionLegibilityImplementation),
+			}),
 		},
 		selfSovereignty: {
 			permissionsManagement: null,

--- a/resources/docs/features.md
+++ b/resources/docs/features.md
@@ -3081,18 +3081,18 @@ type SoftwareTransactionDetailsDisplay =
 Types of transactions that a wallet can decode the calldata of.
 
 ```typescript
-type CalldataDecodingTypes = Record<HardwareBenchmarkTransactions, DataDecoded | null>
+type CalldataDecodingTypes = Record<HardwareBenchmarkTransactions, DataLocation | null>
 ```
 
 ---
 
-### Enum: `DataDecoded`
+### Enum: `DataLocation`
 
 Where does the calldata decoding actually happen? To identify: initiate a contract transaction and observe whether the decoded output appears on the hardware wallet's own screen, or only in the companion app / browser extension on the computer.
 
 - `ON_DEVICE` = `'ON_DEVICE'`: Decoding happens on the hardware wallet device itself. The decoded function name and parameters are shown on the device screen, independently of any software running on the connected computer.
 - `OFF_DEVICE` = `'OFF_DEVICE'`: Decoding happens off-device — in a companion app, browser extension, or desktop software. The hardware wallet's own screen does not show decoded data.
-- `NOT_DECODED` = `'NOT_DECODED'`: No decoding occurs; raw hex calldata is shown (or nothing at all).
+- `NOT_PROVIDED` = `'NOT_PROVIDED'`: No decoding occurs; raw hex calldata is shown (or nothing at all).
 
 ---
 
@@ -3105,7 +3105,7 @@ Users can test on https://beta.walletbeat.eth.limo/test and test a EIP-712 messa
 - `EIP712_STRUCT` = `'EIP712_STRUCT'`: The wallet shows the full decoded EIP-712 struct — domain fields and message fields rendered as human-readable key-value pairs.
 - `DOMAIN_HASH` = `'DOMAIN_HASH'`: The wallet shows the EIP-712 domain separator hash.
 - `MESSAGE_HASH` = `'MESSAGE_HASH'`: The wallet shows the EIP-712 message hash.
-- `SAFE_HASH` = `'SAFE_HASH'`: The wallet shows the Safe-specific transaction hash (used in Safe signing flows).
+- `EIP712_DIGEST` = `'EIP712_DIGEST'`: The wallet shows the EIP-712 digest: the final hash that gets signed: `"\x19\x01" || domainSeparator || hashStruct(message)`.
 
 ---
 
@@ -3116,15 +3116,6 @@ For software wallets: track which message signing data types are available
 ```typescript
 type SoftwareMessageSigningLegibility = Record<MessageSigningDetails, DataDisplayOptions> | null
 ```
-
----
-
-### Interface: `HardwareMessageSigningLegibility`
-
-For hardware wallets: track which message signing data types are available and where they are displayed
-
-- `messageSigningDetails` (`Record<MessageSigningDetails, DataDisplayOptions>`): Which message signing data types does the wallet provide?
-- `decoded` (`DataDecoded`): Where does the message signing data display happen?
 
 ---
 
@@ -3152,26 +3143,41 @@ type DataExtractionMethods = Record<DataExtraction, boolean | null>
 
 ---
 
+### Interface: `HardwareWalletErc8213`
+
+- `calldataDisplay` (`Record<CallDataDisplay, DisplayCapability> | null`)
+- `messageSigningLegibility` (`Record<MessageSigningDetails, DisplayCapability> | null`)
+
+---
+
 ### Interface: `HardwareTransactionLegibilitySupport`
 
 A record of transaction legibility support (both message and transaction)
 
+- `erc8213` (`Support<HardwareWalletErc8213> | null`)
 - `calldataDecoded` (`CalldataDecodingTypes | null`): Does the wallet decode basic and complex transaction calldata to show function names and parameters?
 - `detailsDisplayed` (`DisplayedBasicTransactionDetails | null`): Does a wallet display transaction details clearly?
 - `dataExtraction` (`DataExtractionMethods | null`): Does a wallet allow for data extraction?
-- `messageSigningLegibility` (`HardwareMessageSigningLegibility | null`): What message signing data does the hardware wallet provide and where is it displayed?
 
 ---
 
-### Interface: `CallDataDisplay`
+### Enum: `CallDataDisplay`
 
 What can the user do with the calldata on the approval screen? To test: initiate a contract transaction (e.g. USDC_APPROVAL) and check what calldata options the wallet provides.
 
 Users can test on https://beta.walletbeat.eth.limo/test and test a USDC approval transaction under `Transactions` tab.
 
-- `rawHex` (`boolean`): The raw `0x...` hex calldata is visible somewhere on the approval screen. To test: look for a hex string starting with `0x` on the approval screen or in an expandable section.
-- `copyHexToClipboard` (`boolean`): A dedicated button copies the raw hex calldata to the clipboard. For batched transactions, the full hex including the multicall wrapper is expected. To test: look for a copy icon or "Copy" button next to the calldata.
-- `formatted` (`boolean`): The calldata is decoded into a human-readable function name and arguments (e.g. JSON or structured text), not just raw hex. For batched transactions, each inner call should be decoded individually. To test: check if the wallet shows the function name (e.g. `approve`) and parameters (e.g. spender address, amount) in a readable format.
+- `RAW_HEX` = `'RAW_HEX'`: The raw `0x...` hex calldata is visible somewhere on the approval screen. To test: look for a hex string starting with `0x` on the approval screen or in an expandable section.
+- `COPY_HEX_TO_CLIPBOARD` = `'COPY_HEX_TO_CLIPBOARD'`: A dedicated button copies the raw hex calldata to the clipboard. For batched transactions, the full hex including the multicall wrapper is expected. To test: look for a copy icon or "Copy" button next to the calldata.
+- `FORMATTED` = `'FORMATTED'`: The calldata is decoded into a human-readable function name and arguments (e.g. JSON or structured text), not just raw hex. For batched transactions, each inner call should be decoded individually. To test: check if the wallet shows the function name (e.g. `approve`) and parameters (e.g. spender address, amount) in a readable format.
+- `CALLDATA_DIGEST` = `'CALLDATA_DIGEST'`: The wallet shows the calldata digest: keccak256(uint256(len) || calldata)
+
+---
+
+### Interface: `SoftwareWalletErc8213`
+
+- `calldataDisplay` (`Record<CallDataDisplay, DataDisplayOptions> | null`)
+- `messageSigningLegibility` (`SoftwareMessageSigningLegibility | null`)
 
 ---
 
@@ -3179,9 +3185,14 @@ Users can test on https://beta.walletbeat.eth.limo/test and test a USDC approval
 
 A record of transaction legibility support (both message and transaction)
 
-- `calldataDisplay` (`CallDataDisplay | null`): Does the software wallet support displaying the calldata in different formats?
+- `erc8213` (`Support<SoftwareWalletErc8213> | null`)
 - `transactionDetailsDisplay` (`SoftwareTransactionDetailsDisplay | null`): Does the software wallet support displaying the transaction details? Evaluated per benchmark transaction type.
-- `messageSigningLegibility` (`SoftwareMessageSigningLegibility | null`): What message signing data does the software wallet provide?
+
+---
+
+### Interface: `BaseTransactionLegibilitySupport`
+
+- `erc8213` (`Support | null`)
 
 ---
 

--- a/resources/docs/features.md
+++ b/resources/docs/features.md
@@ -3170,7 +3170,7 @@ Users can test on https://beta.walletbeat.eth.limo/test and test a USDC approval
 - `RAW_HEX` = `'RAW_HEX'`: The raw `0x...` hex calldata is visible somewhere on the approval screen. To test: look for a hex string starting with `0x` on the approval screen or in an expandable section.
 - `COPY_HEX_TO_CLIPBOARD` = `'COPY_HEX_TO_CLIPBOARD'`: A dedicated button copies the raw hex calldata to the clipboard. For batched transactions, the full hex including the multicall wrapper is expected. To test: look for a copy icon or "Copy" button next to the calldata.
 - `FORMATTED` = `'FORMATTED'`: The calldata is decoded into a human-readable function name and arguments (e.g. JSON or structured text), not just raw hex. For batched transactions, each inner call should be decoded individually. To test: check if the wallet shows the function name (e.g. `approve`) and parameters (e.g. spender address, amount) in a readable format.
-- `CALLDATA_DIGEST` = `'CALLDATA_DIGEST'`: The wallet shows the calldata digest: keccak256(uint256(len) || calldata)
+- `CALLDATA_DIGEST` = `'CALLDATA_DIGEST'`: The wallet shows the Calldata digest: keccak256(uint256(len) || calldata)
 
 ---
 

--- a/resources/docs/features.md
+++ b/resources/docs/features.md
@@ -3150,6 +3150,12 @@ type DataExtractionMethods = Record<DataExtraction, boolean | null>
 
 ---
 
+### Interface: `BaseTransactionLegibilitySupport`
+
+- `erc8213` (`Support | null`)
+
+---
+
 ### Interface: `HardwareTransactionLegibilitySupport`
 
 A record of transaction legibility support (both message and transaction)
@@ -3176,8 +3182,10 @@ Users can test on https://beta.walletbeat.eth.limo/test and test a USDC approval
 
 ### Interface: `SoftwareWalletErc8213`
 
-- `calldataDisplay` (`Record<CallDataDisplay, DataDisplayOptions> | null`)
-- `messageSigningLegibility` (`SoftwareMessageSigningLegibility | null`)
+ERC-8213 (Transaction Legibility) support for software wallets. Tracks which calldata display formats and message signing data types the wallet exposes to the user.
+
+- `calldataDisplay` (`Record<CallDataDisplay, DataDisplayOptions> | null`): Which calldata display formats are available and how they are shown.
+- `messageSigningLegibility` (`SoftwareMessageSigningLegibility | null`): Which message signing data types are available and how they are shown.
 
 ---
 
@@ -3187,12 +3195,6 @@ A record of transaction legibility support (both message and transaction)
 
 - `erc8213` (`Support<SoftwareWalletErc8213> | null`)
 - `transactionDetailsDisplay` (`SoftwareTransactionDetailsDisplay | null`): Does the software wallet support displaying the transaction details? Evaluated per benchmark transaction type.
-
----
-
-### Interface: `BaseTransactionLegibilitySupport`
-
-- `erc8213` (`Support | null`)
 
 ---
 

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -1,3 +1,5 @@
+import { eip712 } from '@/data/eips/eip-712'
+import { erc8213 } from '@/data/eips/erc-8213'
 import {
 	type Attribute,
 	type Evaluation,
@@ -6,6 +8,7 @@ import {
 	Rating,
 	Verifiability,
 } from '@/schema/attributes'
+import { eipMarkdownLink, eipMarkdownShortLink } from '@/schema/eips'
 import {
 	BasicBenchmarkTransactions,
 	benchmarkTransactionLabel,
@@ -1389,7 +1392,7 @@ export const transactionLegibility: Attribute = {
 		- Copy to clipboard: Users can copy the calldata directly for verification
 		- Calldata digest (ERC-8213): Users can verify the calldata hash independently
 
-		Software wallets must also support calldata decoding for various transaction types, from basic token transfers to complex nested transactions, and must display the EIP-712 digest for typed message signing (ERC-8213).
+		Software wallets must also support calldata decoding for various transaction types, from basic token transfers to complex nested transactions, and must display the ${eipMarkdownShortLink(eip712)} digest for typed message signing (${eipMarkdownLink(erc8213)}).
 
 		**Hardware Wallet Specific Requirements:**
 		For hardware wallets, the signature/transaction information *must* be visible on the hardware wallet device itself. Any data shown only in a companion app or browser extension is ignored for hardware wallet ratings.
@@ -1399,24 +1402,24 @@ export const transactionLegibility: Attribute = {
 		- QR code: Users can scan a QR code displayed on the device to extract data
 		- Hashes: Users can compare hashes displayed on the device to verify data
 
-		The Calldata digest and EIP-712 digest (ERC-8213) must be shown on the device itself.
+		The Calldata digest and ${eipMarkdownShortLink(eip712)} digest (${eipMarkdownLink(erc8213)}) must be shown on the device itself.
 
-		**ERC-8213 Compliance:**
-		A wallet fully implements ERC-8213 when it displays both:
+		**${eipMarkdownLink(erc8213)} Compliance:**
+		A wallet fully implements ${eipMarkdownShortLink(erc8213)} when it displays both:
 		- The **Calldata digest** for transactions with calldata
-		- The **EIP-712 digest** for typed structured data signatures
+		- The **${eipMarkdownShortLink(eip712)} digest** for typed structured data signatures
 
 		For hardware wallets, both must be shown on the device screen (not just in companion software).
 
 		**Rating Criteria:**
 
 		For software wallets:
-		- A wallet receives a passing rating if it displays calldata in all formats (raw hex, formatted, copyable, digest), displays all essential transaction details, supports complex calldata decoding, and shows the EIP-712 digest for message signing (full ERC-8213 compliance).
+		- A wallet receives a passing rating if it displays calldata in all formats (raw hex, formatted, copyable, digest), displays all essential transaction details, supports complex calldata decoding, and shows the ${eipMarkdownShortLink(eip712)} digest for message signing (full ${eipMarkdownShortLink(erc8213)} compliance).
 		- A wallet receives a partial rating if it has some combination of these features but not all.
 		- A wallet receives a failing rating if it lacks calldata display capabilities or does not display essential transaction details.
 
 		For hardware wallets:
-		- A wallet receives a passing rating if it supports decoding of complex nested transactions, displays all essential transaction details on the device, and provides comprehensive data extraction methods (QR codes and hashes). It must also implement ERC-8213 (Calldata digest and EIP-712 digest on-device).
+		- A wallet receives a passing rating if it supports decoding of complex nested transactions, displays all essential transaction details on the device, and provides comprehensive data extraction methods (QR codes and hashes). It must also implement ${eipMarkdownLink(erc8213)} (Calldata digest and ${eipMarkdownShortLink(eip712)} digest on-device).
 		- A wallet receives a partial rating if it has some combination of these features but not all at the full level.
 		- A wallet receives a failing rating if it lacks calldata decoding support, does not display essential transaction details on the device, and provides no effective data extraction methods.
 	`),

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -955,10 +955,11 @@ function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string 
 	}
 
 	if (features.transactions.failing.length > 0) {
-		          improvements.push(                                                                                                                              
-           `**Transaction Information:** Add the required fields or calldata decoding for:\n${features.transactions.failing.map(t => `- ${t}`).join('\n')
-          }`,                                                                                                                                                 
-          )  
+		improvements.push(
+			`**Transaction Information:** Add the required fields or calldata decoding for:\n${features.transactions.failing
+				.map(t => `- ${t}`)
+				.join('\n')}`,
+		)
 	}
 
 	if (features.transactions.partial.length > 0) {

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -559,10 +559,10 @@ function analyzeSoftwareFeatures({
 	erc8213,
 	transactionDetailsDisplay,
 }: SoftwareTransactionLegibilityImplementation): SoftwareFeatureDetails {
-	const erc8213Data = erc8213 !== null && isSupported(erc8213) ? erc8213 : null
-	const calldataDisplay = erc8213Data !== null ? erc8213Data.calldataDisplay : null
-	const messageSigningLegibility =
-		erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
+	const { calldataDisplay, messageSigningLegibility } =
+		erc8213 !== null && isSupported(erc8213)
+			? erc8213
+			: { calldataDisplay: null, messageSigningLegibility: null }
 
 	const isDisplayed = (opt: DataDisplayOptions): boolean =>
 		opt === DataDisplayOptions.SHOWN_BY_DEFAULT || opt === DataDisplayOptions.SHOWN_OPTIONALLY

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -1098,19 +1098,17 @@ function evaluateHardwareWalletTransactionLegibility(
 			return Rating.UNRATED
 		}
 
-		const erc8213Data = isSupported(erc8213) ? erc8213 : null
-
-		if (erc8213Data === null) {
-			return Rating.UNRATED
+		if (!isSupported(erc8213)) {
+			return Rating.FAIL
 		}
 
 		let calldataDigestLocation: DataLocation | null = null
 
-		if (erc8213Data.calldataDisplay !== null) {
-			calldataDigestLocation = erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
+		if (erc8213.calldataDisplay !== null) {
+			calldataDigestLocation = erc8213.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
 		}
 
-		const messageSigningLegibility = erc8213Data.messageSigningLegibility
+		const messageSigningLegibility = erc8213.messageSigningLegibility
 
 		// Evaluate message signing (PASS/FAIL only)
 		const messageSigningPasses =
@@ -1225,18 +1223,16 @@ function evaluateSoftwareWalletTransactionLegibility(
 		return unrated(ctx)
 	}
 
-	const erc8213Data = isSupported(erc8213) ? erc8213 : null
+	if (!isSupported(erc8213)) {
+		return softwareNoTransactionLegibility(ctx, softwareTransactionLegibility)
+	}
 
-	if (
-		erc8213Data === null ||
-		erc8213Data.calldataDisplay === null ||
-		erc8213Data.messageSigningLegibility === null
-	) {
+	if (erc8213.calldataDisplay === null || erc8213.messageSigningLegibility === null) {
 		return unrated(ctx)
 	}
 
-	const calldataDisplay = erc8213Data.calldataDisplay
-	const messageSigningLegibility = erc8213Data.messageSigningLegibility
+	const calldataDisplay = erc8213.calldataDisplay
+	const messageSigningLegibility = erc8213.messageSigningLegibility
 
 	const isShown = (field: DataDisplayOptions): boolean =>
 		field === DataDisplayOptions.SHOWN_BY_DEFAULT || field === DataDisplayOptions.SHOWN_OPTIONALLY

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -10,23 +10,25 @@ import {
 	BasicBenchmarkTransactions,
 	benchmarkTransactionLabel,
 	benchmarkTransactions,
+	CallDataDisplay,
 	ComplexBenchmarkTransactions,
-	DataDecoded,
 	DataDisplayOptions,
 	DataExtraction,
-	type HardwareMessageSigningLegibility,
+	DataLocation,
 	type HardwareTransactionLegibilityImplementation,
+	type HardwareWalletErc8213,
 	isFullBasicTransactionDetails,
 	isHardwareTransactionLegibility,
 	isSupportedOnDevice,
 	MessageSigningDetails,
 	SimulationBenchmarkTransactions,
-	type SoftwareMessageSigningLegibility,
 	type SoftwareTransactionLegibilityImplementation,
+	type SoftwareWalletErc8213,
 	supportsAnyCalldataDecoding,
 	supportsAnyDataExtraction,
 	TransactionOutcome,
 } from '@/schema/features/security/transaction-legibility'
+import { isSupported, type Support } from '@/schema/features/support'
 import { refNotNecessary } from '@/schema/reference'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { commaListFormat } from '@/types/utils/text'

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -15,12 +15,16 @@ import {
 	DataDisplayOptions,
 	DataExtraction,
 	DataLocation,
+	displaysFullTransactionDetails,
+	displaysNoTransactionDetails,
 	type HardwareTransactionLegibilityImplementation,
 	type HardwareWalletErc8213,
 	isFullBasicTransactionDetails,
 	isHardwareTransactionLegibility,
 	isSupportedOnDevice,
 	MessageSigningDetails,
+	noCalldataDecoding,
+	noDataExtraction,
 	SimulationBenchmarkTransactions,
 	type SoftwareTransactionLegibilityImplementation,
 	type SoftwareWalletErc8213,
@@ -28,7 +32,7 @@ import {
 	supportsAnyDataExtraction,
 	TransactionOutcome,
 } from '@/schema/features/security/transaction-legibility'
-import { isSupported } from '@/schema/features/support'
+import { isSupported, supported } from '@/schema/features/support'
 import { refNotNecessary } from '@/schema/reference'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { commaListFormat } from '@/types/utils/text'
@@ -1433,6 +1437,74 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
+						calldataDecoded: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.ON_DEVICE,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.ON_DEVICE,
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.ON_DEVICE,
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataLocation.ON_DEVICE,
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								DataLocation.ON_DEVICE,
+						},
+						detailsDisplayed: displaysFullTransactionDetails,
+						dataExtraction: {
+							[DataExtraction.EYES]: true,
+							[DataExtraction.QRCODE]: true,
+							[DataExtraction.HASHES]: true,
+						},
+						ref: refNotNecessary,
+					},
+				),
+			),
+			exampleRating(
+				paragraph(`
+					The hardware wallet implements full transaction legibility with complete ERC-8213
+					compliance: calldata digest and EIP-712 digest are both shown on-device.
+				`),
+				hardwareFullTransactionLegibility(
+					EvaluationContext.forTest(() => transactionLegibility),
+					{
+						erc8213: supported({
+							calldataDisplay: {
+								[CallDataDisplay.RAW_HEX]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[CallDataDisplay.FORMATTED]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[CallDataDisplay.CALLDATA_DIGEST]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+							},
+							messageSigningLegibility: {
+								[MessageSigningDetails.EIP712_STRUCT]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[MessageSigningDetails.DOMAIN_HASH]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[MessageSigningDetails.MESSAGE_HASH]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[MessageSigningDetails.EIP712_DIGEST]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+							},
+						}),
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
@@ -1449,7 +1521,124 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
-						transactionDetailsDisplay: null,
+						transactionDetailsDisplay: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: displaysFullTransactionDetails,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: displaysFullTransactionDetails,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								{
+									...displaysFullTransactionDetails,
+									calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									transactionOutcome: TransactionOutcome.EXPLAINED,
+								},
+							[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
+								...displaysFullTransactionDetails,
+								failure: 'DETECTED',
+							},
+							[SimulationBenchmarkTransactions.NONDETERMINISTIC_TRANSACTION]: {
+								...displaysFullTransactionDetails,
+								nondeterminism: 'RESIMULATES_WITH_WARNING',
+							},
+						},
+						ref: refNotNecessary,
+					},
+				),
+			),
+			exampleRating(
+				paragraph(`
+					The software wallet implements full ERC-8213 compliance: calldata digest and
+					EIP-712 digest shown for message signing. Alongside full transaction details,
+					all outcomes explained, and simulation detection for failing and nondeterministic
+					transactions.
+				`),
+				softwareFullTransactionLegibility(
+					EvaluationContext.forTest(() => transactionLegibility),
+					{
+						erc8213: supported({
+							calldataDisplay: {
+								[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							},
+							messageSigningLegibility: {
+								[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							},
+						}),
+						transactionDetailsDisplay: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: displaysFullTransactionDetails,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
+								...displaysFullTransactionDetails,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: displaysFullTransactionDetails,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: {
+								...displaysFullTransactionDetails,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								{
+									...displaysFullTransactionDetails,
+									calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									transactionOutcome: TransactionOutcome.EXPLAINED,
+								},
+							[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
+								...displaysFullTransactionDetails,
+								failure: 'DETECTED',
+							},
+							[SimulationBenchmarkTransactions.NONDETERMINISTIC_TRANSACTION]: {
+								...displaysFullTransactionDetails,
+								nondeterminism: 'RESIMULATES_WITH_WARNING',
+							},
+						},
 						ref: refNotNecessary,
 					},
 				),
@@ -1466,7 +1655,14 @@ export const transactionLegibility: Attribute = {
 					{
 						erc8213: null,
 						calldataDecoded: null,
-						detailsDisplayed: null,
+						detailsDisplayed: {
+							gas: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							nonce: DataDisplayOptions.NOT_IN_UI,
+							from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							chain: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+						},
 						dataExtraction: null,
 						ref: refNotNecessary,
 					},
@@ -1481,6 +1677,76 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
+						calldataDecoded: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.ON_DEVICE,
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: DataLocation.NOT_PROVIDED,
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: DataLocation.NOT_PROVIDED,
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.NOT_PROVIDED,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.NOT_PROVIDED,
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.NOT_PROVIDED,
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]:
+								DataLocation.NOT_PROVIDED,
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								DataLocation.NOT_PROVIDED,
+						},
+						detailsDisplayed: displaysFullTransactionDetails,
+						dataExtraction: {
+							[DataExtraction.EYES]: true,
+							[DataExtraction.QRCODE]: false,
+							[DataExtraction.HASHES]: false,
+						},
+						ref: refNotNecessary,
+					},
+				),
+			),
+			exampleRating(
+				paragraph(`
+					The hardware wallet decodes basic transactions on-device and shows the EIP-712 digest for
+					message signing, but the calldata digest is only available off-device via the companion app,
+					and complex nested transactions are not decoded.
+				`),
+				hardwareBasicTransactionLegibility(
+					EvaluationContext.forTest(() => transactionLegibility),
+					{
+						erc8213: supported({
+							calldataDisplay: {
+								[CallDataDisplay.RAW_HEX]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+								[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.OFF_DEVICE,
+								},
+								[CallDataDisplay.FORMATTED]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.OFF_DEVICE,
+								},
+								[CallDataDisplay.CALLDATA_DIGEST]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.OFF_DEVICE,
+								},
+							},
+							messageSigningLegibility: {
+								[MessageSigningDetails.EIP712_STRUCT]: {
+									display: DataDisplayOptions.NOT_IN_UI,
+									location: DataLocation.NOT_PROVIDED,
+								},
+								[MessageSigningDetails.DOMAIN_HASH]: {
+									display: DataDisplayOptions.NOT_IN_UI,
+									location: DataLocation.NOT_PROVIDED,
+								},
+								[MessageSigningDetails.MESSAGE_HASH]: {
+									display: DataDisplayOptions.NOT_IN_UI,
+									location: DataLocation.NOT_PROVIDED,
+								},
+								[MessageSigningDetails.EIP712_DIGEST]: {
+									display: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									location: DataLocation.ON_DEVICE,
+								},
+							},
+						}),
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
@@ -1497,6 +1763,137 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
+						transactionDetailsDisplay: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							},
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							},
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								transactionOutcome: TransactionOutcome.EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								{
+									gas: DataDisplayOptions.NOT_IN_UI,
+									nonce: DataDisplayOptions.NOT_IN_UI,
+									from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									chain: DataDisplayOptions.NOT_IN_UI,
+									value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									calldataDecoded: DataDisplayOptions.SHOWN_BY_DEFAULT,
+									transactionOutcome: TransactionOutcome.EXPLAINED,
+								},
+							[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								failure: 'DETECTED',
+							},
+							[SimulationBenchmarkTransactions.NONDETERMINISTIC_TRANSACTION]: {
+								gas: DataDisplayOptions.NOT_IN_UI,
+								nonce: DataDisplayOptions.NOT_IN_UI,
+								from: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								to: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								chain: DataDisplayOptions.NOT_IN_UI,
+								value: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								nondeterminism: 'RESIMULATES_WITH_WARNING',
+							},
+						},
+						ref: refNotNecessary,
+					},
+				),
+			),
+			exampleRating(
+				paragraph(`
+					The software wallet shows raw hex and formatted calldata and supports EIP-712 message
+					signing, but does not show the calldata digest required for full ERC-8213 compliance,
+					and not all transaction outcomes are explained.
+				`),
+				softwarePartialTransactionLegibility(
+					EvaluationContext.forTest(() => transactionLegibility),
+					{
+						erc8213: supported({
+							calldataDisplay: {
+								[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+							},
+							messageSigningLegibility: {
+								[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+								[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+							},
+						}),
 						transactionDetailsDisplay: null,
 						ref: refNotNecessary,
 					},
@@ -1512,9 +1909,9 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
-						calldataDecoded: null,
-						detailsDisplayed: null,
-						dataExtraction: null,
+						calldataDecoded: noCalldataDecoding,
+						detailsDisplayed: displaysNoTransactionDetails,
+						dataExtraction: noDataExtraction,
 						ref: refNotNecessary,
 					},
 				),
@@ -1527,7 +1924,122 @@ export const transactionLegibility: Attribute = {
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
 						erc8213: null,
-						transactionDetailsDisplay: null,
+						transactionDetailsDisplay: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: displaysNoTransactionDetails,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: displaysNoTransactionDetails,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								{
+									...displaysNoTransactionDetails,
+									calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+									transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+								},
+							[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
+								...displaysNoTransactionDetails,
+								failure: 'NOT_DETECTED',
+							},
+							[SimulationBenchmarkTransactions.NONDETERMINISTIC_TRANSACTION]: {
+								...displaysNoTransactionDetails,
+								nondeterminism: 'NO_OUTCOME_SHOWN',
+							},
+						},
+						ref: refNotNecessary,
+					},
+				),
+			),
+			exampleRating(
+				paragraph(`
+					The software wallet claims ERC-8213 support but does not show raw hex calldata,
+					failing the basic transparency requirement.
+				`),
+				softwareNoTransactionLegibility(
+					EvaluationContext.forTest(() => transactionLegibility),
+					{
+						erc8213: supported({
+							calldataDisplay: {
+								[CallDataDisplay.RAW_HEX]: DataDisplayOptions.NOT_IN_UI,
+								[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.NOT_IN_UI,
+								[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
+								[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+							},
+							messageSigningLegibility: {
+								[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.NOT_IN_UI,
+								[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
+								[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
+								[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
+							},
+						}),
+						transactionDetailsDisplay: {
+							[BasicBenchmarkTransactions.ETH_TRANSFER]: displaysNoTransactionDetails,
+							[BasicBenchmarkTransactions.ERC_20_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_721_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: {
+								...displaysNoTransactionDetails,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: displaysNoTransactionDetails,
+							[ComplexBenchmarkTransactions.USDC_APPROVAL]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.AAVE_SUPPLY]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: {
+								...displaysNoTransactionDetails,
+								calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+								transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+							},
+							[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
+								{
+									...displaysNoTransactionDetails,
+									calldataDecoded: DataDisplayOptions.NOT_IN_UI,
+									transactionOutcome: TransactionOutcome.NOT_EXPLAINED,
+								},
+							[SimulationBenchmarkTransactions.FAILED_TRANSACTION]: {
+								...displaysNoTransactionDetails,
+								failure: 'NOT_DETECTED',
+							},
+							[SimulationBenchmarkTransactions.NONDETERMINISTIC_TRANSACTION]: {
+								...displaysNoTransactionDetails,
+								nondeterminism: 'NO_OUTCOME_SHOWN',
+							},
+						},
 						ref: refNotNecessary,
 					},
 				),

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -197,9 +197,11 @@ function analyzeHardwareFeatures(
 		]
 
 		// Determine if any are on-device
-		const anyOnDevice = Object.values(provides).some(cap => cap.location === DataLocation.ON_DEVICE)
+		const allOnDevice = Object.values(provides).every(
+			cap => cap.location === DataLocation.ON_DEVICE,
+		)
 
-		details.messageSigning.decodedLocation = anyOnDevice
+		details.messageSigning.decodedLocation = allOnDevice
 			? DataLocation.ON_DEVICE
 			: DataLocation.OFF_DEVICE
 
@@ -303,7 +305,7 @@ function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): stri
 	return sections.join('\n')
 }
 
-function generateHardwareHowToImprove(features: HardwareFeatureDetails): string {
+function generateHardwareHowToImprove(features: HardwareFeatureDetails): string | undefined {
 	const improvements: string[] = []
 
 	if (features.calldataDecoding.missing.length > 0) {
@@ -371,7 +373,7 @@ function generateHardwareHowToImprove(features: HardwareFeatureDetails): string 
 	}
 
 	if (improvements.length === 0) {
-		return 'No improvements needed: The wallet implements full transaction legibility including ERC-8213.'
+		return undefined
 	}
 
 	return improvements.join('\n\n')
@@ -421,9 +423,12 @@ function hardwareNoTransactionLegibility(
 		details: markdown(
 			`{{WALLET_NAME}} implements either zero or very little transaction legibility on the hardware device itself. Transaction legibility is important for security as it allows users to verify transaction details directly on their hardware wallet screen before signing, without relying on potentially compromised software.\n\n${featureDetailsMarkdown}`,
 		),
-		howToImprove: markdown(
-			`{{WALLET_NAME}} should implement the following improvements to provide comprehensive transaction legibility on the hardware device:\n\n${improvementsMarkdown}`,
-		),
+		howToImprove:
+			improvementsMarkdown === undefined
+				? undefined
+				: markdown(
+						`{{WALLET_NAME}} should implement the following improvements to provide comprehensive transaction legibility on the hardware device:\n\n${improvementsMarkdown}`,
+					),
 	})
 }
 
@@ -452,9 +457,12 @@ function hardwareBasicTransactionLegibility(
 		details: markdown(
 			`{{WALLET_NAME}} supports basic transaction legibility on the hardware device, but the implementation does not provide full transparency. The device may display some transaction details or support basic calldata decoding, but lacks comprehensive support for complex transactions, all essential details, or advanced data extraction methods.\n\n${featureDetailsMarkdown}`,
 		),
-		howToImprove: markdown(
-			`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
-		),
+		howToImprove:
+			improvementsMarkdown === undefined
+				? undefined
+				: markdown(
+						`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
+					),
 	})
 }
 
@@ -483,9 +491,12 @@ function hardwarePartialTransactionLegibility(
 		details: markdown(
 			`{{WALLET_NAME}} supports partial transaction legibility on the hardware device. The device displays most transaction details and may support calldata decoding for some transaction types, but may not fully decode complex nested transactions or provide all data extraction methods. Showing transaction details directly on the hardware device is crucial for security as it allows users to verify transaction details independently of potentially compromised software.\n\n${featureDetailsMarkdown}`,
 		),
-		howToImprove: markdown(
-			`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
-		),
+		howToImprove:
+			improvementsMarkdown === undefined
+				? undefined
+				: markdown(
+						`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
+					),
 	})
 }
 
@@ -930,7 +941,7 @@ function generateSoftwareDetailsMarkdown(features: SoftwareFeatureDetails): stri
 	return sections.join('\n')
 }
 
-function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string {
+function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string | undefined {
 	const improvements: string[] = []
 
 	if (features.calldataDisplay.missing.length > 0) {
@@ -982,7 +993,7 @@ function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string 
 	}
 
 	if (improvements.length === 0) {
-		return 'No improvements needed: The wallet implements full transaction legibility including ERC-8213.'
+		return undefined
 	}
 
 	return improvements.join('\n\n')
@@ -1009,9 +1020,12 @@ function softwareNoTransactionLegibility(
 		details: markdown(
 			`{{WALLET_NAME}} implements either zero or very little transaction legibility. The wallet does not adequately display calldata (raw hex, formatted, copyable) or essential transaction details for all benchmark transaction types. Transaction legibility is important for security as it allows users to verify transaction details on their wallet screen before signing.\n\n${featureDetailsMarkdown}`,
 		),
-		howToImprove: markdown(
-			`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
-		),
+		howToImprove:
+			improvementsMarkdown === undefined
+				? undefined
+				: markdown(
+						`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
+					),
 	})
 }
 
@@ -1033,9 +1047,12 @@ function softwarePartialTransactionLegibility(
 		details: markdown(
 			`{{WALLET_NAME}} supports some transaction legibility features, but not all. The wallet displays basic transaction details but may be missing calldata display formats, clear transaction outcome explanations for complex interactions, or simulation capabilities. Showing full transaction details is crucial for security.\n\n${featureDetailsMarkdown}`,
 		),
-		howToImprove: markdown(
-			`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
-		),
+		howToImprove:
+			improvementsMarkdown === undefined
+				? undefined
+				: markdown(
+						`{{WALLET_NAME}} should implement the following improvements:\n\n${improvementsMarkdown}`,
+					),
 	})
 }
 

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -955,15 +955,10 @@ function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string 
 	}
 
 	if (features.transactions.failing.length > 0) {
-		if (features.transactions.failing.length > 4) {
-			improvements.push(
-				`**Transaction Information:** Add the required fields or calldata decoding for:\n${features.transactions.failing.map(t => `- ${t}`).join('\n')}`,
-			)
-		} else {
-			improvements.push(
-				`**Transaction Information:** Add the required fields or calldata decoding for ${commaListFormat(features.transactions.failing)}`,
-			)
-		}
+		          improvements.push(                                                                                                                              
+           `**Transaction Information:** Add the required fields or calldata decoding for:\n${features.transactions.failing.map(t => `- ${t}`).join('\n')
+          }`,                                                                                                                                                 
+          )  
 	}
 
 	if (features.transactions.partial.length > 0) {

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -39,71 +39,32 @@ import { pickWorstRating, unrated } from '../common'
 
 /**
  * Evaluates if software wallet message signing meets PASS criteria.
- * PASS if showing: EIP-712 struct OR (domainHash & messageHash) OR safeHash
+ * PASS requires: EIP-712 digest shown (per ERC-8213).
  */
 function evaluateSoftwareMessageSigning(
-	messageSigningLegibility: SoftwareMessageSigningLegibility,
+	msgSigning: NonNullable<SoftwareWalletErc8213['messageSigningLegibility']>,
 ): boolean {
-	if (messageSigningLegibility === null) {
-		return false
-	}
-
-	const hasEip712Struct =
-		messageSigningLegibility[MessageSigningDetails.EIP712_STRUCT] ===
-			DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		messageSigningLegibility[MessageSigningDetails.EIP712_STRUCT] ===
-			DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasDomainHash =
-		messageSigningLegibility[MessageSigningDetails.DOMAIN_HASH] ===
-			DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		messageSigningLegibility[MessageSigningDetails.DOMAIN_HASH] ===
-			DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasMessageHash =
-		messageSigningLegibility[MessageSigningDetails.MESSAGE_HASH] ===
-			DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		messageSigningLegibility[MessageSigningDetails.MESSAGE_HASH] ===
-			DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasSafeHash =
-		messageSigningLegibility[MessageSigningDetails.SAFE_HASH] ===
-			DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		messageSigningLegibility[MessageSigningDetails.SAFE_HASH] ===
-			DataDisplayOptions.SHOWN_OPTIONALLY
-
-	// PASS if: EIP-712 struct OR (domainHash AND messageHash) OR safeHash
-	return hasEip712Struct || (hasDomainHash && hasMessageHash) || hasSafeHash
+	return (
+		msgSigning[MessageSigningDetails.EIP712_DIGEST] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
+		msgSigning[MessageSigningDetails.EIP712_DIGEST] === DataDisplayOptions.SHOWN_OPTIONALLY
+	)
 }
 
 /**
  * Evaluates if hardware wallet message signing meets PASS criteria.
- * PASS if showing: (EIP-712 struct OR (domainHash & messageHash) OR safeHash) AND on-device
+ * PASS requires: EIP-712 digest shown ON_DEVICE (per ERC-8213).
  */
 function evaluateHardwareMessageSigning(
-	messageSigningLegibility: HardwareMessageSigningLegibility,
+	msgSigning: NonNullable<HardwareWalletErc8213['messageSigningLegibility']>,
 ): boolean {
-	if (messageSigningLegibility === null) {
-		return false
-	}
+	const digestCapability = msgSigning[MessageSigningDetails.EIP712_DIGEST]
 
-	if (messageSigningLegibility.decoded !== DataDecoded.ON_DEVICE) {
-		return false
-	}
-
-	const provides = messageSigningLegibility.messageSigningDetails
-	const hasEip712Struct =
-		provides[MessageSigningDetails.EIP712_STRUCT] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		provides[MessageSigningDetails.EIP712_STRUCT] === DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasDomainHash =
-		provides[MessageSigningDetails.DOMAIN_HASH] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		provides[MessageSigningDetails.DOMAIN_HASH] === DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasMessageHash =
-		provides[MessageSigningDetails.MESSAGE_HASH] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		provides[MessageSigningDetails.MESSAGE_HASH] === DataDisplayOptions.SHOWN_OPTIONALLY
-	const hasSafeHash =
-		provides[MessageSigningDetails.SAFE_HASH] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
-		provides[MessageSigningDetails.SAFE_HASH] === DataDisplayOptions.SHOWN_OPTIONALLY
-
-	// PASS if: EIP-712 struct OR (domainHash AND messageHash) OR safeHash
-	return hasEip712Struct || (hasDomainHash && hasMessageHash) || hasSafeHash
+	return (
+		digestCapability !== undefined &&
+		digestCapability.location === DataLocation.ON_DEVICE &&
+		(digestCapability.display === DataDisplayOptions.SHOWN_BY_DEFAULT ||
+			digestCapability.display === DataDisplayOptions.SHOWN_OPTIONALLY)
+	)
 }
 
 // Hardware wallet detail generation helpers
@@ -111,7 +72,7 @@ interface HardwareFeatureDetails {
 	calldataDecoding: {
 		supported: string[]
 		missing: string[]
-		decodedLocation: DataDecoded | null
+		decodedLocation: DataLocation | null
 	}
 	transactionDetails: {
 		supported: string[]
@@ -124,21 +85,22 @@ interface HardwareFeatureDetails {
 	messageSigning: {
 		supported: string[]
 		missing: string[]
-		decodedLocation: DataDecoded | null
+		decodedLocation: DataLocation | null
 	}
+	calldataDigest: DataLocation | null
 }
 
-function analyzeHardwareFeatures({
-	calldataDecoded,
-	detailsDisplayed,
-	dataExtraction,
-	messageSigningLegibility,
-}: HardwareTransactionLegibilityImplementation): HardwareFeatureDetails {
+function analyzeHardwareFeatures(
+	{ calldataDecoded, detailsDisplayed, dataExtraction }: HardwareTransactionLegibilityImplementation,
+	calldataDigestLocation: DataLocation | null,
+	messageSigningLegibility: HardwareWalletErc8213['messageSigningLegibility'] | null,
+): HardwareFeatureDetails {
 	const details: HardwareFeatureDetails = {
 		calldataDecoding: { supported: [], missing: [], decodedLocation: null },
 		transactionDetails: { supported: [], missing: [] },
 		dataExtraction: { supported: [], missing: [] },
 		messageSigning: { supported: [], missing: [], decodedLocation: null },
+		calldataDigest: calldataDigestLocation,
 	}
 
 	// Analyze calldata decoding
@@ -147,7 +109,7 @@ function analyzeHardwareFeatures({
 
 		// Track decoded location for calldata decoding
 		// If any supported decoding is ON_DEVICE, show ON_DEVICE; otherwise show OFF_DEVICE if any are supported
-		let calldataDecodedLocation: DataDecoded | null = null
+		let calldataDecodedLocation: DataLocation | null = null
 		let hasOnDeviceDecoding = false
 		let hasOffDeviceDecoding = false
 
@@ -155,8 +117,8 @@ function analyzeHardwareFeatures({
 			const label = benchmarkTransactionLabel(key)
 			const decodedLocation = calldataDecoded[key]
 
-			if (decodedLocation !== DataDecoded.NOT_DECODED) {
-				if (decodedLocation === DataDecoded.ON_DEVICE) {
+			if (decodedLocation !== DataLocation.NOT_PROVIDED) {
+				if (decodedLocation === DataLocation.ON_DEVICE) {
 					hasOnDeviceDecoding = true
 				} else {
 					hasOffDeviceDecoding = true
@@ -174,9 +136,9 @@ function analyzeHardwareFeatures({
 
 		// Prefer ON_DEVICE if any decoding is ON_DEVICE, otherwise use OFF_DEVICE if any are supported
 		if (hasOnDeviceDecoding) {
-			calldataDecodedLocation = DataDecoded.ON_DEVICE
+			calldataDecodedLocation = DataLocation.ON_DEVICE
 		} else if (hasOffDeviceDecoding) {
-			calldataDecodedLocation = DataDecoded.OFF_DEVICE
+			calldataDecodedLocation = DataLocation.OFF_DEVICE
 		}
 
 		details.calldataDecoding.decodedLocation = calldataDecodedLocation
@@ -221,33 +183,35 @@ function analyzeHardwareFeatures({
 
 	// Analyze message signing
 	if (messageSigningLegibility !== null) {
-		const provides = messageSigningLegibility.messageSigningDetails
-		const decodedLocation = messageSigningLegibility.decoded
-		const onDevice = decodedLocation === DataDecoded.ON_DEVICE
-
-		details.messageSigning.decodedLocation = decodedLocation
+		const provides = messageSigningLegibility
 
 		const signingChecks = [
 			{ key: MessageSigningDetails.EIP712_STRUCT, label: 'EIP-712 structured data' },
 			{ key: MessageSigningDetails.DOMAIN_HASH, label: 'Domain hash' },
 			{ key: MessageSigningDetails.MESSAGE_HASH, label: 'Message hash' },
-			{ key: MessageSigningDetails.SAFE_HASH, label: 'Safe hash' },
+			{ key: MessageSigningDetails.EIP712_DIGEST, label: 'EIP-712 digest' },
 		]
 
-		if (onDevice) {
-			signingChecks.forEach(({ key, label }) => {
-				if (
-					provides[key] === DataDisplayOptions.SHOWN_BY_DEFAULT ||
-					provides[key] === DataDisplayOptions.SHOWN_OPTIONALLY
-				) {
-					details.messageSigning.supported.push(label)
-				} else {
-					details.messageSigning.missing.push(label)
-				}
-			})
-		} else {
-			details.messageSigning.missing.push('On-device message signing display')
-		}
+		// Determine if any are on-device
+		const anyOnDevice = Object.values(provides).some(cap => cap.location === DataLocation.ON_DEVICE)
+
+		details.messageSigning.decodedLocation = anyOnDevice
+			? DataLocation.ON_DEVICE
+			: DataLocation.OFF_DEVICE
+
+		signingChecks.forEach(({ key, label }) => {
+			const cap = provides[key]
+
+			if (
+				cap.location === DataLocation.ON_DEVICE &&
+				(cap.display === DataDisplayOptions.SHOWN_BY_DEFAULT ||
+					cap.display === DataDisplayOptions.SHOWN_OPTIONALLY)
+			) {
+				details.messageSigning.supported.push(label)
+			} else {
+				details.messageSigning.missing.push(label)
+			}
+		})
 	}
 
 	return details
@@ -263,9 +227,9 @@ function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): stri
 	) {
 		sections.push('**Calldata Decoding**\n')
 
-		if (features.calldataDecoding.decodedLocation === DataDecoded.ON_DEVICE) {
+		if (features.calldataDecoding.decodedLocation === DataLocation.ON_DEVICE) {
 			sections.push('Decoded on-device.\n')
-		} else if (features.calldataDecoding.decodedLocation === DataDecoded.OFF_DEVICE) {
+		} else if (features.calldataDecoding.decodedLocation === DataLocation.OFF_DEVICE) {
 			sections.push('Decoded off-device.\n')
 		}
 
@@ -278,13 +242,26 @@ function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): stri
 		}
 	}
 
+	// Calldata digest section (ERC-8213)
+	if (features.calldataDigest !== null) {
+		sections.push('\n**Calldata digest (ERC-8213)**\n')
+
+		if (features.calldataDigest === DataLocation.ON_DEVICE) {
+			sections.push('✓ Calldata digest displayed on-device.\n')
+		} else if (features.calldataDigest === DataLocation.OFF_DEVICE) {
+			sections.push('⚠ Calldata digest displayed off-device only.\n')
+		} else {
+			sections.push('✗ Calldata digest not shown.\n')
+		}
+	}
+
 	// Message Signing section
 	if (features.messageSigning.supported.length > 0 || features.messageSigning.missing.length > 0) {
 		sections.push('\n**Message Signing**\n')
 
-		if (features.messageSigning.decodedLocation === DataDecoded.ON_DEVICE) {
+		if (features.messageSigning.decodedLocation === DataLocation.ON_DEVICE) {
 			sections.push('Displayed on-device.\n')
-		} else if (features.messageSigning.decodedLocation === DataDecoded.OFF_DEVICE) {
+		} else if (features.messageSigning.decodedLocation === DataLocation.OFF_DEVICE) {
 			sections.push('Displayed off-device.\n')
 		}
 
@@ -295,6 +272,28 @@ function generateHardwareDetailsMarkdown(features: HardwareFeatureDetails): stri
 		if (features.messageSigning.missing.length > 0) {
 			sections.push(`✗ Missing: ${commaListFormat(features.messageSigning.missing)}\n`)
 		}
+	}
+
+	// ERC-8213 compliance summary
+	const calldataDigestOnDevice = features.calldataDigest === DataLocation.ON_DEVICE
+	const eip712DigestOnDevice = features.messageSigning.supported.includes('EIP-712 digest')
+	const erc8213Full = calldataDigestOnDevice && eip712DigestOnDevice
+	const erc8213Partial = calldataDigestOnDevice || eip712DigestOnDevice
+
+	sections.push('\n**ERC-8213 Compliance**\n')
+
+	if (erc8213Full) {
+		sections.push(
+			'✓ Fully implemented on-device: Calldata digest and EIP-712 digest are both shown.\n',
+		)
+	} else if (erc8213Partial) {
+		sections.push(
+			`⚠ Partial: ${calldataDigestOnDevice ? '✓ Calldata digest (on-device)' : '✗ Calldata digest'}, ${eip712DigestOnDevice ? '✓ EIP-712 digest (on-device)' : '✗ EIP-712 digest'}.\n`,
+		)
+	} else {
+		sections.push(
+			'✗ Not implemented: Neither Calldata digest nor EIP-712 digest is shown on-device.\n',
+		)
 	}
 
 	return sections.join('\n')
@@ -315,7 +314,7 @@ function generateHardwareHowToImprove(features: HardwareFeatureDetails): string 
 		}
 	}
 
-	if (features.calldataDecoding.decodedLocation === DataDecoded.OFF_DEVICE) {
+	if (features.calldataDecoding.decodedLocation === DataLocation.OFF_DEVICE) {
 		improvements.push(
 			"**Calldata Decoding:** Move decoding on-device so users don't have to trust a potentially compromised companion app.",
 		)
@@ -327,7 +326,7 @@ function generateHardwareHowToImprove(features: HardwareFeatureDetails): string 
 		)
 	}
 
-	if (features.messageSigning.decodedLocation === DataDecoded.OFF_DEVICE) {
+	if (features.messageSigning.decodedLocation === DataLocation.OFF_DEVICE) {
 		improvements.push(
 			'**Message Signing:** Display message signing details on-device to prevent host software from altering what the user thinks they are approving.',
 		)
@@ -345,19 +344,58 @@ function generateHardwareHowToImprove(features: HardwareFeatureDetails): string 
 		)
 	}
 
+	const erc8213Missing: string[] = []
+
+	if (features.calldataDigest !== DataLocation.ON_DEVICE) {
+		erc8213Missing.push(
+			features.calldataDigest === DataLocation.OFF_DEVICE
+				? '**Calldata digest:** Move on-device, the digest must appear on the hardware screen, not only in companion software.'
+				: '**Calldata digest:** Show `keccak256(len(calldata) || calldata)` on the device screen so users can independently verify the calldata.',
+		)
+	}
+
+	if (!features.messageSigning.supported.includes('EIP-712 digest')) {
+		erc8213Missing.push(
+			'**EIP-712 digest:** Show the final `"\\x19\\x01" || domainSeparator || hashStruct(message)` hash on the device screen during typed message signing.',
+		)
+	}
+
+	if (erc8213Missing.length > 0) {
+		improvements.push(
+			`**ERC-8213 Implementation:** Implement the following on-device to fully comply with ERC-8213:\n${erc8213Missing.map(m => `- ${m}`).join('\n')}`,
+		)
+	}
+
 	if (improvements.length === 0) {
-		return 'No improvements needed - the wallet implements full transaction legibility.'
+		return 'No improvements needed: The wallet implements full transaction legibility including ERC-8213.'
 	}
 
 	return improvements.join('\n\n')
 }
 
 // Hardware wallet evaluation helpers
+function unwrapHardwareErc8213(support: HardwareTransactionLegibilityImplementation): {
+	calldataDigestLocation: DataLocation | null
+	messageSigningLegibility: HardwareWalletErc8213['messageSigningLegibility'] | null
+} {
+	const erc8213Data =
+		support.erc8213 !== null && isSupported(support.erc8213) ? support.erc8213 : null
+	let calldataDigestLocation: DataLocation | null = null
+	if (erc8213Data !== null && erc8213Data.calldataDisplay !== null) {
+		calldataDigestLocation =
+			erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
+	}
+	const messageSigningLegibility =
+		erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
+	return { calldataDigestLocation, messageSigningLegibility }
+}
+
 function hardwareNoTransactionLegibility(
 	ctx: EvaluationContext,
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
-	const features = analyzeHardwareFeatures(support)
+	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
+	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -383,7 +421,8 @@ function hardwareBasicTransactionLegibility(
 	ctx: EvaluationContext,
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
-	const features = analyzeHardwareFeatures(support)
+	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
+	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -409,7 +448,8 @@ function hardwarePartialTransactionLegibility(
 	ctx: EvaluationContext,
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
-	const features = analyzeHardwareFeatures(support)
+	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
+	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -435,7 +475,8 @@ function hardwareFullTransactionLegibility(
 	ctx: EvaluationContext,
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
-	const features = analyzeHardwareFeatures(support)
+	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
+	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 
 	return ctx.build({
@@ -468,34 +509,55 @@ interface SoftwareFeatureDetails {
 		supported: string[]
 		missing: string[]
 	}
+	erc8213: {
+		calldataDigest: boolean
+		eip712Digest: boolean
+	}
 }
 
 function analyzeSoftwareFeatures({
-	calldataDisplay,
+	erc8213,
 	transactionDetailsDisplay,
-	messageSigningLegibility,
 }: SoftwareTransactionLegibilityImplementation): SoftwareFeatureDetails {
+	const erc8213Data = erc8213 !== null && isSupported(erc8213) ? erc8213 : null
+	const calldataDisplay = erc8213Data !== null ? erc8213Data.calldataDisplay : null
+	const messageSigningLegibility = erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
+
+	const isDisplayed = (opt: DataDisplayOptions): boolean =>
+		opt === DataDisplayOptions.SHOWN_BY_DEFAULT || opt === DataDisplayOptions.SHOWN_OPTIONALLY
+
+	const erc8213CalldataDigest =
+		calldataDisplay !== null && isDisplayed(calldataDisplay[CallDataDisplay.CALLDATA_DIGEST])
+
+	const erc8213Eip712Digest =
+		messageSigningLegibility !== null &&
+		isDisplayed(messageSigningLegibility[MessageSigningDetails.EIP712_DIGEST])
+
 	const details: SoftwareFeatureDetails = {
 		calldataDisplay: { supported: [], missing: [] },
 		transactions: { passing: [], partial: [], failing: [] },
 		messageSigning: { supported: [], missing: [] },
+		erc8213: {
+			calldataDigest: erc8213CalldataDigest,
+			eip712Digest: erc8213Eip712Digest,
+		},
 	}
 
 	// Analyze calldata display
 	if (calldataDisplay !== null) {
-		if (calldataDisplay.rawHex) {
+		if (isDisplayed(calldataDisplay[CallDataDisplay.RAW_HEX])) {
 			details.calldataDisplay.supported.push('Raw hex display')
 		} else {
 			details.calldataDisplay.missing.push('Raw hex display')
 		}
 
-		if (calldataDisplay.formatted) {
+		if (isDisplayed(calldataDisplay[CallDataDisplay.FORMATTED])) {
 			details.calldataDisplay.supported.push('Formatted output')
 		} else {
 			details.calldataDisplay.missing.push('Formatted output')
 		}
 
-		if (calldataDisplay.copyHexToClipboard) {
+		if (isDisplayed(calldataDisplay[CallDataDisplay.COPY_HEX_TO_CLIPBOARD])) {
 			details.calldataDisplay.supported.push('Copy to clipboard')
 		} else {
 			details.calldataDisplay.missing.push('Copy to clipboard')
@@ -671,7 +733,7 @@ function analyzeSoftwareFeatures({
 			}
 		}
 
-		// Safe nested multisend (hardest benchmark — requires calldataDecoded and explained outcome to PASS)
+		// Safe nested multisend (hardest benchmark: requires calldataDecoded and explained outcome to PASS)
 		{
 			const tx =
 				transactionDetailsDisplay[
@@ -742,7 +804,7 @@ function analyzeSoftwareFeatures({
 			{ key: MessageSigningDetails.EIP712_STRUCT, label: 'EIP-712 structured data' },
 			{ key: MessageSigningDetails.DOMAIN_HASH, label: 'Domain hash' },
 			{ key: MessageSigningDetails.MESSAGE_HASH, label: 'Message hash' },
-			{ key: MessageSigningDetails.SAFE_HASH, label: 'Safe hash' },
+			{ key: MessageSigningDetails.EIP712_DIGEST, label: 'EIP-712 digest' },
 		]
 
 		signingChecks.forEach(({ key, label }) => {
@@ -826,6 +888,22 @@ function generateSoftwareDetailsMarkdown(features: SoftwareFeatureDetails): stri
 		}
 	}
 
+	// ERC-8213 compliance section
+	const erc8213Full = features.erc8213.calldataDigest && features.erc8213.eip712Digest
+	const erc8213Partial = features.erc8213.calldataDigest || features.erc8213.eip712Digest
+
+	sections.push('\n**ERC-8213 Compliance**\n')
+
+	if (erc8213Full) {
+		sections.push('✓ Fully implemented: Calldata digest and EIP-712 digest are both shown.\n')
+	} else if (erc8213Partial) {
+		sections.push(
+			`⚠ Partial: ${features.erc8213.calldataDigest ? '✓ Calldata digest' : '✗ Calldata digest'}, ${features.erc8213.eip712Digest ? '✓ EIP-712 digest' : '✗ EIP-712 digest'}.\n`,
+		)
+	} else {
+		sections.push('✗ Not implemented: Neither Calldata digest nor EIP-712 digest is shown.\n')
+	}
+
 	return sections.join('\n')
 }
 
@@ -860,8 +938,28 @@ function generateSoftwareHowToImprove(features: SoftwareFeatureDetails): string 
 		)
 	}
 
+	const erc8213Missing: string[] = []
+
+	if (!features.erc8213.calldataDigest) {
+		erc8213Missing.push(
+			'**Calldata digest:** Show `keccak256(len(calldata) || calldata)` on the signing screen so users can independently verify the calldata.',
+		)
+	}
+
+	if (!features.erc8213.eip712Digest) {
+		erc8213Missing.push(
+			'**EIP-712 digest:** Show the final `"\\x19\\x01" || domainSeparator || hashStruct(message)` hash during typed message signing.',
+		)
+	}
+
+	if (erc8213Missing.length > 0) {
+		improvements.push(
+			`**ERC-8213 Implementation:** Implement the following to fully comply with ERC-8213:\n${erc8213Missing.map(m => `- ${m}`).join('\n')}`,
+		)
+	}
+
 	if (improvements.length === 0) {
-		return 'No improvements needed - the wallet implements full transaction legibility.'
+		return 'No improvements needed: The wallet implements full transaction legibility including ERC-8213.'
 	}
 
 	return improvements.join('\n\n')
@@ -944,17 +1042,32 @@ function evaluateHardwareWalletTransactionLegibility(
 ): Evaluation {
 	ctx.addRef(hardwareTransactionLegibility)
 
-	const { calldataDecoded, detailsDisplayed, dataExtraction, messageSigningLegibility } =
+	const { calldataDecoded, detailsDisplayed, dataExtraction, erc8213 } =
 		hardwareTransactionLegibility
 
 	const getOverallRating = (): Rating => {
-		if (calldataDecoded === null || detailsDisplayed === null || dataExtraction === null) {
+		if (calldataDecoded === null || detailsDisplayed === null || dataExtraction === null || erc8213 === null) {
 			return Rating.UNRATED
 		}
 
+		const erc8213Data = isSupported(erc8213) ? erc8213 : null
+
+		if (erc8213Data === null) {
+			return Rating.UNRATED
+		}
+
+		let calldataDigestLocation: DataLocation | null = null
+
+		if (erc8213Data.calldataDisplay !== null) {
+			calldataDigestLocation =
+				erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
+		}
+
+		const messageSigningLegibility = erc8213Data.messageSigningLegibility
+
 		// Evaluate message signing (PASS/FAIL only)
 		const messageSigningPasses =
-			messageSigningLegibility && evaluateHardwareMessageSigning(messageSigningLegibility)
+			messageSigningLegibility !== null && evaluateHardwareMessageSigning(messageSigningLegibility)
 
 		// Check if wallet supports calldata decoding for complex transactions (ON_DEVICE)
 		const supportsComplexDecoding: boolean =
@@ -988,12 +1101,16 @@ function evaluateHardwareWalletTransactionLegibility(
 			dataExtraction[DataExtraction.QRCODE] === true &&
 			dataExtraction[DataExtraction.HASHES] === true
 
-		// PASS: Full support - complex decoding AND all details displayed AND advanced data extraction AND message signing passes
+		// Check if Calldata digest is displayed on-device (ERC-8213)
+		const hasCalldataDigestOnDevice = calldataDigestLocation === DataLocation.ON_DEVICE
+
+		// PASS: Full support - complex decoding AND all details displayed AND advanced data extraction AND message signing passes AND Calldata digest on-device
 		if (
 			supportsComplexDecoding &&
 			displaysAllDetails &&
 			hasAdvancedDataExtraction &&
-			messageSigningPasses
+			messageSigningPasses &&
+			hasCalldataDigestOnDevice
 		) {
 			return Rating.PASS
 		}
@@ -1003,7 +1120,7 @@ function evaluateHardwareWalletTransactionLegibility(
 			(!supportsAnyCalldataDecoding(calldataDecoded) &&
 				!displaysAllDetails &&
 				!hasDataExtraction) ||
-			(messageSigningLegibility !== null && !messageSigningPasses)
+			!messageSigningPasses
 		) {
 			return Rating.FAIL
 		}
@@ -1055,12 +1172,20 @@ function evaluateSoftwareWalletTransactionLegibility(
 ): Evaluation {
 	const transactionLegibilitySupport = ctx.popRefs(softwareTransactionLegibility)
 
-	const { calldataDisplay, transactionDetailsDisplay, messageSigningLegibility } =
-		transactionLegibilitySupport
+	const { erc8213, transactionDetailsDisplay } = transactionLegibilitySupport
 
-	if (calldataDisplay === null || transactionDetailsDisplay === null) {
+	if (transactionDetailsDisplay === null || erc8213 === null) {
 		return unrated(ctx)
 	}
+
+	const erc8213Data = isSupported(erc8213) ? erc8213 : null
+
+	if (erc8213Data === null || erc8213Data.calldataDisplay === null || erc8213Data.messageSigningLegibility === null) {
+		return unrated(ctx)
+	}
+
+	const calldataDisplay = erc8213Data.calldataDisplay
+	const messageSigningLegibility = erc8213Data.messageSigningLegibility
 
 	const isShown = (field: DataDisplayOptions): boolean =>
 		field === DataDisplayOptions.SHOWN_BY_DEFAULT || field === DataDisplayOptions.SHOWN_OPTIONALLY
@@ -1115,20 +1240,20 @@ function evaluateSoftwareWalletTransactionLegibility(
 	let rating: Rating
 
 	if (
-		!calldataDisplay.rawHex ||
-		(messageSigningLegibility !== null &&
-			!evaluateSoftwareMessageSigning(messageSigningLegibility)) ||
+		calldataDisplay[CallDataDisplay.RAW_HEX] === DataDisplayOptions.NOT_IN_UI ||
+		!evaluateSoftwareMessageSigning(messageSigningLegibility) ||
 		allTransactions.some(tx => !allBasicFieldsShown(tx)) ||
 		!isShown(usdcApproval.calldataDecoded) ||
 		!isShown(aaveSupply.calldataDecoded)
 	) {
 		rating = Rating.FAIL
 	} else {
-		// PASS requires: formatted + copyable calldata display, all transaction outcomes explained,
-		// complex nested transactions fully decoded, and simulation benchmarks detected.
+		// PASS requires: formatted + copyable + digest calldata display, all transaction outcomes explained,
+		// complex nested transactions fully decoded, simulation benchmarks detected, and ERC-8213 Calldata digest.
 		const isPartial =
-			!calldataDisplay.formatted ||
-			!calldataDisplay.copyHexToClipboard ||
+			calldataDisplay[CallDataDisplay.FORMATTED] === DataDisplayOptions.NOT_IN_UI ||
+			calldataDisplay[CallDataDisplay.COPY_HEX_TO_CLIPBOARD] === DataDisplayOptions.NOT_IN_UI ||
+			calldataDisplay[CallDataDisplay.CALLDATA_DIGEST] === DataDisplayOptions.NOT_IN_UI ||
 			erc20.transactionOutcome !== TransactionOutcome.EXPLAINED ||
 			erc721.transactionOutcome !== TransactionOutcome.EXPLAINED ||
 			erc1155.transactionOutcome !== TransactionOutcome.EXPLAINED ||
@@ -1140,7 +1265,6 @@ function evaluateSoftwareWalletTransactionLegibility(
 			safeMultisend.transactionOutcome !== TransactionOutcome.EXPLAINED ||
 			failedTx.failure !== 'DETECTED' ||
 			nondeterminismTx.nondeterminism !== 'RESIMULATES_WITH_WARNING' ||
-			messageSigningLegibility === null ||
 			!evaluateSoftwareMessageSigning(messageSigningLegibility)
 
 		rating = isPartial ? Rating.PARTIAL : Rating.PASS
@@ -1179,11 +1303,20 @@ export const transactionLegibility: Attribute = {
 		step is crucial for preventing attacks where malicious software might attempt to trick users
 		into signing transactions with different parameters than what they intended.
 
-		Without this, users are at the mercy of the app they are interacting with sending them a bad transactions, either because they have a bug, were hacked, or are malicious. Without a signer being able to verify if their transaction is correct, user should not send such a transaction.
+		Without this, users are at the mercy of the app they are interacting with sending them bad transactions, whether due to a bug, a hack, or malicious intent. Without being able to verify what they are signing, users should not send such transactions.
 
 		Full transaction legibility implementations ensure that all relevant transaction details (recipient
-		address, amount, fees, etc.) are clearly displayed on the wallet screen, EIP-712 message hashes,
-		and decoded calldata, allowing users to make informed decisions before authorizing transactions.
+		address, amount, fees, etc.) are clearly displayed on the wallet screen alongside decoded calldata,
+		allowing users to make informed decisions before authorizing transactions.
+
+		**ERC-8213: Standardizing What Users Sign**
+		[ERC-8213](https://erc8213.eth.limo) introduces two cryptographic digests that give users a
+		machine-verifiable way to confirm exactly what they are approving:
+
+		- **Calldata digest**, \`keccak256(len(calldata) || calldata)\`: a hash of the raw transaction calldata. Users can compute this independently to verify the calldata hasn't been tampered with.
+		- **EIP-712 digest**, \`"\\x19\\x01" || domainSeparator || hashStruct(message)\`: the final hash that gets signed for typed structured data.
+
+		A full ERC-8213 implementation means the wallet shows both digests, enabling users to independently verify every transaction and signature: not just trust what the UI displays.
 	`),
 	methodology: markdown(`
 		Wallets are evaluated based on key aspects of transaction legibility, with different criteria for software and hardware wallets:
@@ -1206,27 +1339,37 @@ export const transactionLegibility: Attribute = {
 		- Raw hex format: Users can view the raw hexadecimal calldata
 		- Formatted output: Users can view decoded, human-readable calldata
 		- Copy to clipboard: Users can copy the calldata directly for verification
+		- Calldata digest (ERC-8213): Users can verify the calldata hash independently
 
-		Software wallets must also support calldata decoding for various transaction types, from basic token transfers to complex nested transactions.
+		Software wallets must also support calldata decoding for various transaction types, from basic token transfers to complex nested transactions, and must display the EIP-712 digest for typed message signing (ERC-8213).
 
 		**Hardware Wallet Specific Requirements:**
-		For hardware wallets, the signature/transaction information *must* be visible on the hardware wallet device itself. Any data shown on a software wallet component is ignored for hardware wallet ratings.
+		For hardware wallets, the signature/transaction information *must* be visible on the hardware wallet device itself. Any data shown only in a companion app or browser extension is ignored for hardware wallet ratings.
 
 		Hardware wallets must also provide data extraction methods to allow users to independently verify transaction data:
 		- Visual display: Users can view the data on the hardware wallet screen
 		- QR code: Users can scan a QR code displayed on the device to extract data
 		- Hashes: Users can compare hashes displayed on the device to verify data
 
+		The Calldata digest and EIP-712 digest (ERC-8213) must be shown on the device itself.
+
+		**ERC-8213 Compliance:**
+		A wallet fully implements ERC-8213 when it displays both:
+		- The **Calldata digest** for transactions with calldata
+		- The **EIP-712 digest** for typed structured data signatures
+
+		For hardware wallets, both must be shown on the device screen (not just in companion software).
+
 		**Rating Criteria:**
 
 		For software wallets:
-		- A wallet receives a passing rating if it displays calldata in all three formats (raw hex, formatted, copyable), displays all essential transaction details, and supports complex calldata decoding (including nested transactions).
-		- A wallet receives a partial rating if it has some combination of these features but not all, or if calldata decoding data has not been provided.
+		- A wallet receives a passing rating if it displays calldata in all formats (raw hex, formatted, copyable, digest), displays all essential transaction details, supports complex calldata decoding, and shows the EIP-712 digest for message signing (full ERC-8213 compliance).
+		- A wallet receives a partial rating if it has some combination of these features but not all.
 		- A wallet receives a failing rating if it lacks calldata display capabilities or does not display essential transaction details.
 
 		For hardware wallets:
-		- A wallet receives a passing rating if it supports decoding of complex nested transactions, displays all essential transaction details on the device, and provides comprehensive data extraction methods (QR codes and hashes, in addition to visual display).
-		- A wallet receives a partial rating if it has some combination of these features (decoding support, transaction details display, or data extraction methods), but not all at the full level.
+		- A wallet receives a passing rating if it supports decoding of complex nested transactions, displays all essential transaction details on the device, and provides comprehensive data extraction methods (QR codes and hashes). It must also implement ERC-8213 (Calldata digest and EIP-712 digest on-device).
+		- A wallet receives a partial rating if it has some combination of these features but not all at the full level.
 		- A wallet receives a failing rating if it lacks calldata decoding support, does not display essential transaction details on the device, and provides no effective data extraction methods.
 	`),
 	ratingScale: {
@@ -1241,10 +1384,10 @@ export const transactionLegibility: Attribute = {
 				hardwareFullTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
+						erc8213: null,
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1257,9 +1400,8 @@ export const transactionLegibility: Attribute = {
 				softwareFullTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
-						calldataDisplay: null,
+						erc8213: null,
 						transactionDetailsDisplay: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1274,10 +1416,10 @@ export const transactionLegibility: Attribute = {
 				hardwarePartialTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
+						erc8213: null,
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1290,10 +1432,10 @@ export const transactionLegibility: Attribute = {
 				hardwareBasicTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
+						erc8213: null,
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1306,9 +1448,8 @@ export const transactionLegibility: Attribute = {
 				softwarePartialTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
-						calldataDisplay: null,
+						erc8213: null,
 						transactionDetailsDisplay: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1322,10 +1463,10 @@ export const transactionLegibility: Attribute = {
 				hardwareNoTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
+						erc8213: null,
 						calldataDecoded: null,
 						detailsDisplayed: null,
 						dataExtraction: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),
@@ -1337,9 +1478,8 @@ export const transactionLegibility: Attribute = {
 				softwareNoTransactionLegibility(
 					EvaluationContext.forTest(() => transactionLegibility),
 					{
-						calldataDisplay: null,
+						erc8213: null,
 						transactionDetailsDisplay: null,
-						messageSigningLegibility: null,
 						ref: refNotNecessary,
 					},
 				),

--- a/src/schema/attributes/security/transaction-legibility.ts
+++ b/src/schema/attributes/security/transaction-legibility.ts
@@ -28,7 +28,7 @@ import {
 	supportsAnyDataExtraction,
 	TransactionOutcome,
 } from '@/schema/features/security/transaction-legibility'
-import { isSupported, type Support } from '@/schema/features/support'
+import { isSupported } from '@/schema/features/support'
 import { refNotNecessary } from '@/schema/reference'
 import { markdown, paragraph, sentence } from '@/types/content'
 import { commaListFormat } from '@/types/utils/text'
@@ -91,7 +91,11 @@ interface HardwareFeatureDetails {
 }
 
 function analyzeHardwareFeatures(
-	{ calldataDecoded, detailsDisplayed, dataExtraction }: HardwareTransactionLegibilityImplementation,
+	{
+		calldataDecoded,
+		detailsDisplayed,
+		dataExtraction,
+	}: HardwareTransactionLegibilityImplementation,
 	calldataDigestLocation: DataLocation | null,
 	messageSigningLegibility: HardwareWalletErc8213['messageSigningLegibility'] | null,
 ): HardwareFeatureDetails {
@@ -381,12 +385,14 @@ function unwrapHardwareErc8213(support: HardwareTransactionLegibilityImplementat
 	const erc8213Data =
 		support.erc8213 !== null && isSupported(support.erc8213) ? support.erc8213 : null
 	let calldataDigestLocation: DataLocation | null = null
+
 	if (erc8213Data !== null && erc8213Data.calldataDisplay !== null) {
-		calldataDigestLocation =
-			erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
+		calldataDigestLocation = erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
 	}
+
 	const messageSigningLegibility =
 		erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
+
 	return { calldataDigestLocation, messageSigningLegibility }
 }
 
@@ -395,7 +401,11 @@ function hardwareNoTransactionLegibility(
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
 	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
-	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
+	const features = analyzeHardwareFeatures(
+		support,
+		calldataDigestLocation,
+		messageSigningLegibility,
+	)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -422,7 +432,11 @@ function hardwareBasicTransactionLegibility(
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
 	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
-	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
+	const features = analyzeHardwareFeatures(
+		support,
+		calldataDigestLocation,
+		messageSigningLegibility,
+	)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -449,7 +463,11 @@ function hardwarePartialTransactionLegibility(
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
 	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
-	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
+	const features = analyzeHardwareFeatures(
+		support,
+		calldataDigestLocation,
+		messageSigningLegibility,
+	)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 	const improvementsMarkdown = generateHardwareHowToImprove(features)
 
@@ -476,7 +494,11 @@ function hardwareFullTransactionLegibility(
 	support: HardwareTransactionLegibilityImplementation,
 ): Evaluation {
 	const { calldataDigestLocation, messageSigningLegibility } = unwrapHardwareErc8213(support)
-	const features = analyzeHardwareFeatures(support, calldataDigestLocation, messageSigningLegibility)
+	const features = analyzeHardwareFeatures(
+		support,
+		calldataDigestLocation,
+		messageSigningLegibility,
+	)
 	const featureDetailsMarkdown = generateHardwareDetailsMarkdown(features)
 
 	return ctx.build({
@@ -521,7 +543,8 @@ function analyzeSoftwareFeatures({
 }: SoftwareTransactionLegibilityImplementation): SoftwareFeatureDetails {
 	const erc8213Data = erc8213 !== null && isSupported(erc8213) ? erc8213 : null
 	const calldataDisplay = erc8213Data !== null ? erc8213Data.calldataDisplay : null
-	const messageSigningLegibility = erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
+	const messageSigningLegibility =
+		erc8213Data !== null ? erc8213Data.messageSigningLegibility : null
 
 	const isDisplayed = (opt: DataDisplayOptions): boolean =>
 		opt === DataDisplayOptions.SHOWN_BY_DEFAULT || opt === DataDisplayOptions.SHOWN_OPTIONALLY
@@ -1046,7 +1069,12 @@ function evaluateHardwareWalletTransactionLegibility(
 		hardwareTransactionLegibility
 
 	const getOverallRating = (): Rating => {
-		if (calldataDecoded === null || detailsDisplayed === null || dataExtraction === null || erc8213 === null) {
+		if (
+			calldataDecoded === null ||
+			detailsDisplayed === null ||
+			dataExtraction === null ||
+			erc8213 === null
+		) {
 			return Rating.UNRATED
 		}
 
@@ -1059,8 +1087,7 @@ function evaluateHardwareWalletTransactionLegibility(
 		let calldataDigestLocation: DataLocation | null = null
 
 		if (erc8213Data.calldataDisplay !== null) {
-			calldataDigestLocation =
-				erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
+			calldataDigestLocation = erc8213Data.calldataDisplay[CallDataDisplay.CALLDATA_DIGEST].location
 		}
 
 		const messageSigningLegibility = erc8213Data.messageSigningLegibility
@@ -1180,7 +1207,11 @@ function evaluateSoftwareWalletTransactionLegibility(
 
 	const erc8213Data = isSupported(erc8213) ? erc8213 : null
 
-	if (erc8213Data === null || erc8213Data.calldataDisplay === null || erc8213Data.messageSigningLegibility === null) {
+	if (
+		erc8213Data === null ||
+		erc8213Data.calldataDisplay === null ||
+		erc8213Data.messageSigningLegibility === null
+	) {
 		return unrated(ctx)
 	}
 

--- a/src/schema/eips.ts
+++ b/src/schema/eips.ts
@@ -2,6 +2,7 @@
  * The set of all EIP numbers tracked by Walletbeat.
  */
 export type EipNumber =
+	| '712'
 	| '1193'
 	| '2700'
 	| '4337'
@@ -11,6 +12,7 @@ export type EipNumber =
 	| '7702'
 	| '7828'
 	| '7831'
+	| '8213'
 
 /**
  * The status of an Ethereum Improvement Proposal (EIP).
@@ -77,6 +79,11 @@ export function eipEthereumDotOrgUrl(eip: EipNumber | Eip): string {
 /** Return a magic URL which the Markdown parser can turn into an EIP link. */
 function markdownMagicUrl(eip: EipNumber | Eip, format: 'long' | 'short'): string {
 	return `${eipEthereumDotOrgUrl(eip)}#wb-format=${format}`
+}
+
+/** Return a markdown link for an EIP using only its short label (e.g. "EIP-712"). */
+export function eipMarkdownShortLink(eip: Eip): string {
+	return `[${eipShortLabel(eip)}](${markdownMagicUrl(eip, 'short')})`
 }
 
 /** Return a markdown link for an EIP. */

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -1,5 +1,6 @@
 import type { WithRef } from '@/schema/reference'
 import { Enum, mergeEnums } from '@/utils/enum'
+import type { Support } from '../support'
 
 /**
  * To test: initiate the relevant transaction type and observe the approval
@@ -432,7 +433,7 @@ export type SoftwareTransactionDetailsDisplay =
 /**
  * Types of transactions that a wallet can decode the calldata of.
  */
-export type CalldataDecodingTypes = Record<HardwareBenchmarkTransactions, DataDecoded | null> // Allow null for existing wallets that don't have enough data
+export type CalldataDecodingTypes = Record<HardwareBenchmarkTransactions, DataLocation | null> // Allow null for existing wallets that don't have enough data
 
 /**
  * Where does the calldata decoding actually happen?
@@ -440,7 +441,7 @@ export type CalldataDecodingTypes = Record<HardwareBenchmarkTransactions, DataDe
  * decoded output appears on the hardware wallet's own screen, or only in
  * the companion app / browser extension on the computer.
  */
-export enum DataDecoded {
+export enum DataLocation {
 	/**
 	 * Decoding happens on the hardware wallet device itself.
 	 * The decoded function name and parameters are shown on the device screen,
@@ -455,7 +456,7 @@ export enum DataDecoded {
 	OFF_DEVICE = 'OFF_DEVICE',
 
 	/** No decoding occurs; raw hex calldata is shown (or nothing at all). */
-	NOT_DECODED = 'NOT_DECODED',
+	NOT_PROVIDED = 'NOT_PROVIDED',
 }
 
 /**
@@ -480,8 +481,11 @@ export enum MessageSigningDetails {
 	/** The wallet shows the EIP-712 message hash. */
 	MESSAGE_HASH = 'MESSAGE_HASH',
 
-	/** The wallet shows the Safe-specific transaction hash (used in Safe signing flows). */
-	SAFE_HASH = 'SAFE_HASH',
+	/**
+	 * The wallet shows the EIP-712 digest: the final hash that gets signed:
+	 * `"\x19\x01" ‖ domainSeparator ‖ hashStruct(message)`.
+	 */
+	EIP712_DIGEST = 'EIP712_DIGEST',
 }
 
 /**
@@ -499,29 +503,29 @@ export interface HardwareMessageSigningLegibility {
 	/** Which message signing data types does the wallet provide? */
 	messageSigningDetails: Record<MessageSigningDetails, DataDisplayOptions>
 	/** Where does the message signing data display happen? */
-	decoded: DataDecoded
+	decoded: DataLocation
 }
 /**
  * Shorthand for a wallet that cannot do any calldata decoding.
  */
 export const noCalldataDecoding: CalldataDecodingTypes = {
-	[BasicBenchmarkTransactions.ETH_TRANSFER]: DataDecoded.NOT_DECODED,
-	[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataDecoded.NOT_DECODED,
-	[BasicBenchmarkTransactions.ERC_721_TRANSFER]: DataDecoded.NOT_DECODED,
-	[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: DataDecoded.NOT_DECODED,
-	[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataDecoded.NOT_DECODED,
-	[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataDecoded.NOT_DECODED,
-	[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataDecoded.NOT_DECODED,
-	[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataDecoded.NOT_DECODED,
+	[BasicBenchmarkTransactions.ETH_TRANSFER]: DataLocation.NOT_PROVIDED,
+	[BasicBenchmarkTransactions.ERC_20_TRANSFER]: DataLocation.NOT_PROVIDED,
+	[BasicBenchmarkTransactions.ERC_721_TRANSFER]: DataLocation.NOT_PROVIDED,
+	[BasicBenchmarkTransactions.ERC_1155_TRANSFER]: DataLocation.NOT_PROVIDED,
+	[BasicBenchmarkTransactions.ZKSYNC_USDC_TRANSFER]: DataLocation.NOT_PROVIDED,
+	[ComplexBenchmarkTransactions.USDC_APPROVAL]: DataLocation.NOT_PROVIDED,
+	[ComplexBenchmarkTransactions.AAVE_SUPPLY]: DataLocation.NOT_PROVIDED,
+	[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_SUPPLY_NESTED]: DataLocation.NOT_PROVIDED,
 	[ComplexBenchmarkTransactions.SAFEWALLET_AAVE_USDC_APPROVE_SUPPLY_BATCH_NESTED_MULTISEND]:
-		DataDecoded.NOT_DECODED,
+		DataLocation.NOT_PROVIDED,
 }
 
 /**
  * Returns whether the given calldata decoding types support any decoding at all.
  */
 export function supportsAnyCalldataDecoding(calldataDecodingTypes: CalldataDecodingTypes): boolean {
-	return Object.values(calldataDecodingTypes).some(v => v !== DataDecoded.NOT_DECODED)
+	return Object.values(calldataDecodingTypes).some(v => v !== DataLocation.NOT_PROVIDED)
 }
 
 /**
@@ -583,13 +587,32 @@ export function isSupportedOnDevice(
 	legibility: CalldataDecodingTypes,
 	decoding: HardwareBenchmarkTransactions,
 ): boolean {
-	return legibility[decoding] === DataDecoded.ON_DEVICE
+	return legibility[decoding] === DataLocation.ON_DEVICE
+}
+
+export interface HardwareWalletErc8213 {
+	calldataDisplay: Record<
+		CallDataDisplay,
+		DisplayCapability
+	> | null
+
+	messageSigningLegibility: Record<
+		MessageSigningDetails,
+		DisplayCapability
+	> | null
+}
+
+type DisplayCapability = {
+	display: DataDisplayOptions
+	location: DataLocation
 }
 
 /**
  * A record of transaction legibility support (both message and transaction)
  */
-export interface HardwareTransactionLegibilitySupport {
+export interface HardwareTransactionLegibilitySupport extends BaseTransactionLegibilitySupport {
+	erc8213: Support<HardwareWalletErc8213> | null,
+
 	/**
 	 * Does the wallet decode basic and complex transaction calldata to show function names and parameters?
 	 */
@@ -608,6 +631,13 @@ export interface HardwareTransactionLegibilitySupport {
 	 * What message signing data does the hardware wallet provide and where is it displayed?
 	 */
 	messageSigningLegibility: HardwareMessageSigningLegibility | null
+
+	/**
+	 * Does the hardware wallet display the calldata digest (`keccak256(len(calldata) ‖ calldata)`)
+	 * as defined by ERC-8213, and if so, where?
+	 * Must be ON_DEVICE for a passing rating.
+	 */
+	calldataDigest: DataLocation | null
 }
 
 /**
@@ -618,41 +648,31 @@ export interface HardwareTransactionLegibilitySupport {
  * Users can test on https://beta.walletbeat.eth.limo/test and
  * test a USDC approval transaction under `Transactions` tab.
  */
-export interface CallDataDisplay {
-	/**
-	 * The raw `0x...` hex calldata is visible somewhere on the approval screen.
-	 * To test: look for a hex string starting with `0x` on the approval screen
-	 * or in an expandable section.
-	 */
-	rawHex: boolean
-
-	/**
-	 * A dedicated button copies the raw hex calldata to the clipboard.
-	 * For batched transactions, the full hex including the multicall wrapper is expected.
-	 * To test: look for a copy icon or "Copy" button next to the calldata.
-	 */
-	copyHexToClipboard: boolean
-
-	/**
-	 * The calldata is decoded into a human-readable function name and arguments
-	 * (e.g. JSON or structured text), not just raw hex.
-	 * For batched transactions, each inner call should be decoded individually.
-	 * To test: check if the wallet shows the function name (e.g. `approve`) and
-	 * parameters (e.g. spender address, amount) in a readable format.
-	 */
-	formatted: boolean
+export enum CallDataDisplay {
+	RAW_HEX= 'RAW_HEX',
+	COPY_HEX_TO_CLIPBOARD = 'COPY_HEX_TO_CLIPBOARD',
+	FORMATTED = 'FORMATTED',
+	CALLDATA_DIGEST = 'CALLDATA_DIGEST'
 }
 
 export const displaysFullCallData: CallDataDisplay = {
 	rawHex: true,
 	copyHexToClipboard: true,
 	formatted: true,
+	calldataDigest: true,
+}
+
+export interface SoftwareWalletErc8213 {
+	calldataDisplay: Record<CallDataDisplay, DataDisplayOptions> | null
+	messageSigningLegibility: SoftwareMessageSigningLegibility | null
 }
 
 /**
  * A record of transaction legibility support (both message and transaction)
  */
-export interface SoftwareTransactionLegibilitySupport {
+export interface SoftwareTransactionLegibilitySupport extends BaseTransactionLegibilitySupport {
+	erc8213: Support<SoftwareWalletErc8213> | null,
+
 	/**
 	 * Does the software wallet support displaying the calldata in different formats?
 	 */
@@ -694,6 +714,10 @@ export function isHardwareTransactionLegibility(
 	// not on `SoftwareTransactionLegibilityImplementation`, so it is a good way to distinguish
 	// between the two types:
 	return Object.hasOwn(transactionLegibility, 'dataExtraction')
+}
+
+export interface BaseTransactionLegibilitySupport {
+	erc8213: Support | null
 }
 
 export type HardwareTransactionLegibilityImplementation =

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -644,7 +644,7 @@ export enum CallDataDisplay {
 	 */
 	FORMATTED = 'FORMATTED',
 	/**
-	 * The wallet shows the calldata digest:
+	 * The wallet shows the Calldata digest:
 	 * keccak256(uint256(len) || calldata)
 	 */
 	CALLDATA_DIGEST = 'CALLDATA_DIGEST',

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -593,6 +593,10 @@ type DisplayCapability = {
 	location: DataLocation
 }
 
+export interface BaseTransactionLegibilitySupport {
+	erc8213: Support | null
+}
+
 /**
  * A record of transaction legibility support (both message and transaction)
  */
@@ -657,8 +661,15 @@ export const displaysFullCallData: Record<CallDataDisplay, DataDisplayOptions> =
 	[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
 }
 
+/**
+ * ERC-8213 (Transaction Legibility) support for software wallets.
+ * Tracks which calldata display formats and message signing data types
+ * the wallet exposes to the user.
+ */
 export interface SoftwareWalletErc8213 {
+	/** Which calldata display formats are available and how they are shown. */
 	calldataDisplay: Record<CallDataDisplay, DataDisplayOptions> | null
+	/** Which message signing data types are available and how they are shown. */
 	messageSigningLegibility: SoftwareMessageSigningLegibility | null
 }
 
@@ -700,10 +711,6 @@ export function isHardwareTransactionLegibility(
 	// not on `SoftwareTransactionLegibilityImplementation`, so it is a good way to distinguish
 	// between the two types:
 	return Object.hasOwn(transactionLegibility, 'dataExtraction')
-}
-
-export interface BaseTransactionLegibilitySupport {
-	erc8213: Support | null
 }
 
 export type HardwareTransactionLegibilityImplementation =

--- a/src/schema/features/security/transaction-legibility.ts
+++ b/src/schema/features/security/transaction-legibility.ts
@@ -1,5 +1,6 @@
 import type { WithRef } from '@/schema/reference'
 import { Enum, mergeEnums } from '@/utils/enum'
+
 import type { Support } from '../support'
 
 /**
@@ -483,7 +484,7 @@ export enum MessageSigningDetails {
 
 	/**
 	 * The wallet shows the EIP-712 digest: the final hash that gets signed:
-	 * `"\x19\x01" ‖ domainSeparator ‖ hashStruct(message)`.
+	 * `"\x19\x01" || domainSeparator || hashStruct(message)`.
 	 */
 	EIP712_DIGEST = 'EIP712_DIGEST',
 }
@@ -496,15 +497,6 @@ export type SoftwareMessageSigningLegibility = Record<
 	DataDisplayOptions
 > | null
 
-/**
- * For hardware wallets: track which message signing data types are available and where they are displayed
- */
-export interface HardwareMessageSigningLegibility {
-	/** Which message signing data types does the wallet provide? */
-	messageSigningDetails: Record<MessageSigningDetails, DataDisplayOptions>
-	/** Where does the message signing data display happen? */
-	decoded: DataLocation
-}
 /**
  * Shorthand for a wallet that cannot do any calldata decoding.
  */
@@ -591,15 +583,9 @@ export function isSupportedOnDevice(
 }
 
 export interface HardwareWalletErc8213 {
-	calldataDisplay: Record<
-		CallDataDisplay,
-		DisplayCapability
-	> | null
+	calldataDisplay: Record<CallDataDisplay, DisplayCapability> | null
 
-	messageSigningLegibility: Record<
-		MessageSigningDetails,
-		DisplayCapability
-	> | null
+	messageSigningLegibility: Record<MessageSigningDetails, DisplayCapability> | null
 }
 
 type DisplayCapability = {
@@ -611,7 +597,7 @@ type DisplayCapability = {
  * A record of transaction legibility support (both message and transaction)
  */
 export interface HardwareTransactionLegibilitySupport extends BaseTransactionLegibilitySupport {
-	erc8213: Support<HardwareWalletErc8213> | null,
+	erc8213: Support<HardwareWalletErc8213> | null
 
 	/**
 	 * Does the wallet decode basic and complex transaction calldata to show function names and parameters?
@@ -626,18 +612,6 @@ export interface HardwareTransactionLegibilitySupport extends BaseTransactionLeg
 	 * Does a wallet allow for data extraction?
 	 */
 	dataExtraction: DataExtractionMethods | null
-
-	/**
-	 * What message signing data does the hardware wallet provide and where is it displayed?
-	 */
-	messageSigningLegibility: HardwareMessageSigningLegibility | null
-
-	/**
-	 * Does the hardware wallet display the calldata digest (`keccak256(len(calldata) ‖ calldata)`)
-	 * as defined by ERC-8213, and if so, where?
-	 * Must be ON_DEVICE for a passing rating.
-	 */
-	calldataDigest: DataLocation | null
 }
 
 /**
@@ -649,17 +623,38 @@ export interface HardwareTransactionLegibilitySupport extends BaseTransactionLeg
  * test a USDC approval transaction under `Transactions` tab.
  */
 export enum CallDataDisplay {
-	RAW_HEX= 'RAW_HEX',
+	/**
+	 * The raw `0x...` hex calldata is visible somewhere on the approval screen.
+	 * To test: look for a hex string starting with `0x` on the approval screen
+	 * or in an expandable section.
+	 */
+	RAW_HEX = 'RAW_HEX',
+	/**
+	 * A dedicated button copies the raw hex calldata to the clipboard.
+	 * For batched transactions, the full hex including the multicall wrapper is expected.
+	 * To test: look for a copy icon or "Copy" button next to the calldata.
+	 */
 	COPY_HEX_TO_CLIPBOARD = 'COPY_HEX_TO_CLIPBOARD',
+	/**
+	 * The calldata is decoded into a human-readable function name and arguments
+	 * (e.g. JSON or structured text), not just raw hex.
+	 * For batched transactions, each inner call should be decoded individually.
+	 * To test: check if the wallet shows the function name (e.g. `approve`) and
+	 * parameters (e.g. spender address, amount) in a readable format.
+	 */
 	FORMATTED = 'FORMATTED',
-	CALLDATA_DIGEST = 'CALLDATA_DIGEST'
+	/**
+	 * The wallet shows the calldata digest:
+	 * keccak256(uint256(len) || calldata)
+	 */
+	CALLDATA_DIGEST = 'CALLDATA_DIGEST',
 }
 
-export const displaysFullCallData: CallDataDisplay = {
-	rawHex: true,
-	copyHexToClipboard: true,
-	formatted: true,
-	calldataDigest: true,
+export const displaysFullCallData: Record<CallDataDisplay, DataDisplayOptions> = {
+	[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	[CallDataDisplay.FORMATTED]: DataDisplayOptions.SHOWN_BY_DEFAULT,
+	[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.SHOWN_BY_DEFAULT,
 }
 
 export interface SoftwareWalletErc8213 {
@@ -671,22 +666,13 @@ export interface SoftwareWalletErc8213 {
  * A record of transaction legibility support (both message and transaction)
  */
 export interface SoftwareTransactionLegibilitySupport extends BaseTransactionLegibilitySupport {
-	erc8213: Support<SoftwareWalletErc8213> | null,
+	erc8213: Support<SoftwareWalletErc8213> | null
 
-	/**
-	 * Does the software wallet support displaying the calldata in different formats?
-	 */
-	calldataDisplay: CallDataDisplay | null
 	/**
 	 * Does the software wallet support displaying the transaction details?
 	 * Evaluated per benchmark transaction type.
 	 */
 	transactionDetailsDisplay: SoftwareTransactionDetailsDisplay | null
-
-	/**
-	 * What message signing data does the software wallet provide?
-	 */
-	messageSigningLegibility: SoftwareMessageSigningLegibility | null
 }
 
 export const isFullBasicTransactionDetails = (

--- a/src/types/utils/text.ts
+++ b/src/types/utils/text.ts
@@ -44,8 +44,8 @@ export function slugifyCamelCase(camelCaseString: string): string {
 }
 
 /**
- * Return the prefix to use before a list item in a comma-separated list.
- * For example, ["a", "b", "c", "d"] would be written as "a, b, c and d".
+ * Return the prefix to use before a list item in a Oxford comma-separated list.
+ * For example, ["a", "b", "c", "d"] would be written as "a, b, c, and d".
  * @param index The index of the element being rendered.
  * @param listSize The total size of the list.
  * @returns The prefix to use before the element.
@@ -55,7 +55,7 @@ export function commaListPrefix(index: number, listSize: number, and?: string): 
 		return ''
 	}
 
-	return index < listSize - 1 ? ', ' : ` ${and ?? 'and'} `
+	return index < listSize - 1 ? ', ' : `${listSize > 2 ? ',' : ''} ${and ?? 'and'} `
 }
 
 /**


### PR DESCRIPTION
## Add ERC-8213 support - closes #704
ERC-8213 cares about two things:
- EIP-712 Digest
- Calldata digest
### Changes
- Feature refactor
  - `erc8213` is typed as `Support<SoftwareWalletErc8213>` for software wallets & `Support<HardwareWalletErc8213>` for hardware wallets
  - The difference between the two: hardware wallets track data `location` (`ON_DEVICE` / `OFF_DEVICE`) per display capability, since it matters where on-device the data actually appears
  - `calldataDisplay` and `messageSigningLegibility` fields removed from `SoftwareTransactionLegibilitySupport` and `HardwareTransactionLegibilitySupport`, both now folded under `erc8213`
  - Added `CALLDATA_DIGEST` to the `CallDataDisplay` enum
  - Renamed `SAFE_HASH` → `EIP712_DIGEST` in `MessageSigningDetails`
  - Renamed `DataDecoded` enum → `DataLocation`
	- Renamed `NOT_DECODED` → `NOT_PROVIDED`
- Attribute refactor
  - PASS for software message signing: wallet must show `EIP712_DIGEST` (replaces the old EIP-712 struct OR (domainHash & messageHash) OR safeHash logic)
  - PASS for hardware message signing: wallet must show `EIP712_DIGEST` `ON_DEVICE`
  - PASS for calldata: wallet must display `CALLDATA_DIGEST`

#### Sample Hardware Wallet ERC-8213
```ts
erc8213: supported({
	calldataDisplay: {
		[CallDataDisplay.RAW_HEX]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[CallDataDisplay.FORMATTED]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[CallDataDisplay.CALLDATA_DIGEST]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
	},
	messageSigningLegibility: {
		[MessageSigningDetails.EIP712_STRUCT]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[MessageSigningDetails.DOMAIN_HASH]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[MessageSigningDetails.MESSAGE_HASH]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
		[MessageSigningDetails.EIP712_DIGEST]: {
			display: DataDisplayOptions.SHOWN_BY_DEFAULT,
			location: DataLocation.ON_DEVICE,
		},
	},
}),
```
#### Sample Software Wallet ERC-8213
```ts
erc8213: supported({
	calldataDisplay: {
		[CallDataDisplay.RAW_HEX]: DataDisplayOptions.SHOWN_BY_DEFAULT,
		[CallDataDisplay.COPY_HEX_TO_CLIPBOARD]: DataDisplayOptions.NOT_IN_UI,
		[CallDataDisplay.FORMATTED]: DataDisplayOptions.NOT_IN_UI,
		[CallDataDisplay.CALLDATA_DIGEST]: DataDisplayOptions.NOT_IN_UI,
	},
	messageSigningLegibility: {
		[MessageSigningDetails.EIP712_STRUCT]: DataDisplayOptions.SHOWN_BY_DEFAULT,
		[MessageSigningDetails.DOMAIN_HASH]: DataDisplayOptions.NOT_IN_UI,
		[MessageSigningDetails.MESSAGE_HASH]: DataDisplayOptions.NOT_IN_UI,
		[MessageSigningDetails.EIP712_DIGEST]: DataDisplayOptions.NOT_IN_UI,
	},
}),
```
