### PR TITLE
Data: add Coinbase Smart Wallet audits to Base App

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -175,7 +175,7 @@ export const baseApp: SoftwareWallet = {
 			// Legacy 12-word-recovery-phrase accounts are EOAs and out of scope for these audits.
 			publicSecurityAudits: [
 				{
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-December-2023.pdf',
+					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Cantina-December-2023.pdf',
 					auditor: cantina,
 					auditDate: '2024-01-07',
 					codeSnapshot: {
@@ -186,7 +186,7 @@ export const baseApp: SoftwareWallet = {
 					variantsScope: { [Variant.MOBILE]: true },
 				},
 				{
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Certora-February-2024.pdf',
+					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Certora-February-2024.pdf',
 					auditor: certora,
 					auditDate: '2024-02-29',
 					codeSnapshot: {
@@ -207,7 +207,7 @@ export const baseApp: SoftwareWallet = {
 					variantsScope: { [Variant.MOBILE]: true },
 				},
 				{
-					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-April-2024.pdf',
+					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Cantina-April-2024.pdf',
 					auditor: cantina,
 					auditDate: '2024-04-23',
 					codeSnapshot: {

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -1,4 +1,7 @@
 import { ren2140 } from '@/data/contributors/ren2140'
+import { cantina } from '@/data/entities/cantina'
+import { certora } from '@/data/entities/certora'
+import { code4rena } from '@/data/entities/code4rena'
 import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
 import { WalletProfile } from '@/schema/features/profile'
@@ -168,7 +171,53 @@ export const baseApp: SoftwareWallet = {
 				ethereumL1: notSupported,
 			},
 			passkeyVerification: null,
-			publicSecurityAudits: null,
+			// Audits cover the Coinbase Smart Wallet contracts that power Base App passkey-created accounts.
+			// Legacy 12-word-recovery-phrase accounts are EOAs and out of scope for these audits.
+			publicSecurityAudits: [
+				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-December-2023.pdf',
+					auditor: cantina,
+					auditDate: '2024-01-07',
+					codeSnapshot: {
+						commit: '2779bed4',
+						date: '2023-12-11',
+					},
+					unpatchedFlaws: 'NONE_FOUND',
+					variantsScope: { [Variant.MOBILE]: true },
+				},
+				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Certora-February-2024.pdf',
+					auditor: certora,
+					auditDate: '2024-02-29',
+					codeSnapshot: {
+						commit: '7aa092a',
+						date: '2024-02-08',
+					},
+					unpatchedFlaws: 'ALL_FIXED',
+					variantsScope: { [Variant.MOBILE]: true },
+				},
+				{
+					ref: 'https://code4rena.com/reports/2024-03-coinbase',
+					auditor: code4rena,
+					auditDate: '2024-05-01',
+					codeSnapshot: {
+						date: '2024-03-14',
+					},
+					unpatchedFlaws: 'ALL_FIXED',
+					variantsScope: { [Variant.MOBILE]: true },
+				},
+				{
+					ref: 'https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-April-2024.pdf',
+					auditor: cantina,
+					auditDate: '2024-04-23',
+					codeSnapshot: {
+						commit: '9edcf7f1',
+						date: '2024-04-15',
+					},
+					unpatchedFlaws: 'NONE_FOUND',
+					variantsScope: { [Variant.MOBILE]: true },
+				},
+			],
 			scamAlerts: {
 				contractTransactionWarning: supported<ContractTransactionWarning>({
 					ref: refTodo,

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -176,8 +176,8 @@ export const baseApp: SoftwareWallet = {
 			publicSecurityAudits: [
 				{
 					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Cantina-December-2023.pdf',
-					auditor: cantina,
 					auditDate: '2024-01-07',
+					auditor: cantina,
 					codeSnapshot: {
 						commit: '2779bed4',
 						date: '2023-12-11',
@@ -187,8 +187,8 @@ export const baseApp: SoftwareWallet = {
 				},
 				{
 					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Certora-February-2024.pdf',
-					auditor: certora,
 					auditDate: '2024-02-29',
+					auditor: certora,
 					codeSnapshot: {
 						commit: '7aa092a',
 						date: '2024-02-08',
@@ -198,8 +198,8 @@ export const baseApp: SoftwareWallet = {
 				},
 				{
 					ref: 'https://code4rena.com/reports/2024-03-coinbase',
-					auditor: code4rena,
 					auditDate: '2024-05-01',
+					auditor: code4rena,
 					codeSnapshot: {
 						date: '2024-03-14',
 					},
@@ -208,8 +208,8 @@ export const baseApp: SoftwareWallet = {
 				},
 				{
 					ref: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/audits/Cantina-April-2024.pdf',
-					auditor: cantina,
 					auditDate: '2024-04-23',
+					auditor: cantina,
 					codeSnapshot: {
 						commit: '9edcf7f1',
 						date: '2024-04-15',


### PR DESCRIPTION
## Summary

Populates `publicSecurityAudits` for the Base App listing with the four publicly-available audits of the Coinbase Smart Wallet contracts. Per [Base's official docs](https://docs.base.org/base-account/overview/what-is-base-account), each Base Account is an ERC-4337 Smart Wallet, so these contract-layer audits cover the security boundary for Base App passkey-created accounts.

| Audit | Auditor | Date | Scope (commit) | Findings |
|---|---|---|---|---|
| [Cantina #1](https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-December-2023.pdf) | Cantina | 2024-01-07 | smart-account `2779bed4` | 0 medium+ → `NONE_FOUND` |
| [Certora](https://github.com/coinbase/smart-wallet/blob/main/audits/Certora-February-2024.pdf) | Certora | 2024-02-29 | `7aa092a` | 1 Medium fixed → `ALL_FIXED` |
| [Code4rena](https://code4rena.com/reports/2024-03-coinbase) | Code4rena | 2024-05-01 | n/a (contest Mar 14-21, 2024) | 1 High + 2 Medium, all mitigated → `ALL_FIXED` |
| [Cantina #2](https://github.com/coinbase/smart-wallet/blob/main/audits/Cantina-April-2024.pdf) | Cantina | 2024-04-23 | `9edcf7f1` | 0 medium+ → `NONE_FOUND` |

A code comment in the file documents that these audits cover the smart-contract layer used by passkey-created accounts, and that legacy 12-word-recovery-phrase Base App accounts (still being migrated to Base Accounts per [Coinbase Help](https://help.coinbase.com/en/wallet/getting-started/smart-wallet)) are EOAs and out of scope.

## Notes

- The Cantina December 2023 audit also covered the separate Base Paymaster contract (commit `67b44ad1`); only the smart-account commit is recorded since `codeSnapshot.commit` is a single field.


🤖 Generated with [Claude Code](https://claude.com/claude-code)