### PR TITLE
Data: model Base App accounts as ERC-4337 Smart Wallets

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -1,11 +1,13 @@
 import { ren2140 } from '@/data/contributors/ren2140'
-import { AccountType } from '@/schema/features/account-support'
+import { coinbaseSmartWalletContract } from '@/data/wallet-contracts/coinbase-smart-wallet'
+import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
 import { WalletProfile } from '@/schema/features/profile'
 import {
 	BugBountyPlatform,
 	BugBountyProgramAvailability,
 } from '@/schema/features/security/bug-bounty-program'
+import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
@@ -46,7 +48,9 @@ export const baseApp: SoftwareWallet = {
 	},
 	features: {
 		accountSupport: {
-			defaultAccountType: AccountType.eoa,
+			// New signups create passkey-based ERC-4337 Smart Wallets per https://docs.base.org/base-account/overview/what-is-base-account.
+			// Legacy 12-word-recovery-phrase users still hold EOAs; Coinbase is migrating them to Base Accounts.
+			defaultAccountType: AccountType.rawErc4337,
 			eip7702: notSupported,
 			eoa: supported({
 				ref: 'https://help.coinbase.com/en/wallet/managing-account/wallet-recovery-phrase',
@@ -59,7 +63,18 @@ export const baseApp: SoftwareWallet = {
 				},
 			}),
 			mpc: notSupported,
-			rawErc4337: notSupported,
+			rawErc4337: supported({
+				ref: {
+					explanation:
+						'Base Accounts are ERC-4337 Smart Wallets created via passkey signup. The user is sole owner by default (passkey held in device secure enclave); Coinbase does not hold a co-owner key per https://wallet.coinbase.com/terms-of-service. The underlying contract supports multi-owner via addOwner/removeOwnerAtIndex, but as of Base App v29.94.123 the mobile app does not expose any passkey or owner management UI (Account Management shows only Sign out). Optional recovery-key signup likely lives in keys.coinbase.com rather than the mobile app.',
+					url: 'https://docs.base.org/base-account/overview/what-is-base-account',
+				},
+				contract: coinbaseSmartWalletContract,
+				controllingSharesInSelfCustodyByDefault: 'YES',
+				keyRotationTransactionGeneration: TransactionGenerationCapability.RELYING_ON_EXTERNAL_API,
+				tokenTransferTransactionGeneration:
+					TransactionGenerationCapability.USING_PROPRIETARY_STANDALONE_APP,
+			}),
 			safe: notSupported,
 		},
 		addressResolution: {
@@ -167,7 +182,17 @@ export const baseApp: SoftwareWallet = {
 			lightClient: {
 				ethereumL1: notSupported,
 			},
-			passkeyVerification: null,
+			passkeyVerification: supported({
+				ref: {
+					explanation:
+						'Coinbase Smart Wallet verifies passkey signatures on-chain via webauthn-sol, which uses the RIP-7212 precompile when available and falls back to FreshCryptoLib.',
+					url: 'https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/src/CoinbaseSmartWallet.sol',
+				},
+				details:
+					'Uses base-org/webauthn-sol (built on Daimo WebAuthn.sol). Tries RIP-7212 P-256 precompile first, falls back to FreshCryptoLib.',
+				library: PasskeyVerificationLibrary.WEB_AUTHN_SOL,
+				libraryUrl: 'https://github.com/base-org/webauthn-sol',
+			}),
 			publicSecurityAudits: null,
 			scamAlerts: {
 				contractTransactionWarning: supported<ContractTransactionWarning>({

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -1,4 +1,5 @@
 import { ren2140 } from '@/data/contributors/ren2140'
+import { coinbaseEip7702ProxyContract } from '@/data/wallet-contracts/coinbase-eip7702-proxy'
 import { coinbaseSmartWalletContract } from '@/data/wallet-contracts/coinbase-smart-wallet'
 import { AccountType, TransactionGenerationCapability } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
@@ -51,7 +52,14 @@ export const baseApp: SoftwareWallet = {
 			// New signups create passkey-based ERC-4337 Smart Wallets per https://docs.base.org/base-account/overview/what-is-base-account.
 			// Legacy 12-word-recovery-phrase users still hold EOAs; Coinbase is migrating them to Base Accounts.
 			defaultAccountType: AccountType.rawErc4337,
-			eip7702: notSupported,
+			eip7702: supported({
+				ref: {
+					explanation:
+						'Legacy Base App EOA users can be upgraded to smart-wallet behavior via EIP-7702 delegation to the EIP7702Proxy (an ERC-1967 proxy whose implementation can be set to the Coinbase Smart Wallet). The delegation is sponsored by Coinbase on Base mainnet and is performed transparently as part of dApp interactions; there is no user-facing "upgrade my account" UI in the Base App. Per the Base team questionnaire response (2026-03-13), accounts are "EOA + 7702 delegation / 4337".',
+					url: 'https://blog.base.dev/securing-eip-7702-upgrades',
+				},
+				contract: coinbaseEip7702ProxyContract,
+			}),
 			eoa: supported({
 				ref: 'https://help.coinbase.com/en/wallet/managing-account/wallet-recovery-phrase',
 				canExportPrivateKey: true,

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -49,7 +49,7 @@ export const baseApp: SoftwareWallet = {
 	},
 	features: {
 		accountSupport: {
-			// New signups create passkey-based ERC-4337 Smart Wallets per https://docs.base.org/base-account/overview/what-is-base-account.
+			// New accounts created via passkey onboarding are ERC-4337 Smart Wallets per https://docs.base.org/base-account/overview/what-is-base-account.
 			// Legacy 12-word-recovery-phrase users still hold EOAs; Coinbase is migrating them to Base Accounts.
 			defaultAccountType: AccountType.rawErc4337,
 			eip7702: supported({
@@ -74,7 +74,7 @@ export const baseApp: SoftwareWallet = {
 			rawErc4337: supported({
 				ref: {
 					explanation:
-						'Base Accounts are ERC-4337 Smart Wallets created via passkey signup. The user is sole owner by default (passkey held in device secure enclave); Coinbase does not hold a co-owner key per https://wallet.coinbase.com/terms-of-service. The underlying contract supports multi-owner via addOwner/removeOwnerAtIndex, but as of Base App v29.94.123 the mobile app does not expose any passkey or owner management UI (Account Management shows only Sign out). Optional recovery-key signup likely lives in keys.coinbase.com rather than the mobile app.',
+						'Base Accounts are ERC-4337 Smart Wallets created via passkey onboarding. The user is sole owner by default (passkey held in device secure enclave); Coinbase does not hold a co-owner key per https://wallet.coinbase.com/terms-of-service. The underlying contract supports multi-owner via addOwner/removeOwnerAtIndex, but as of Base App v29.94.123 the mobile app does not expose any passkey or owner management UI (Account Management shows only Sign out). Optional recovery-key setup likely lives in keys.coinbase.com rather than the mobile app.',
 					url: 'https://docs.base.org/base-account/overview/what-is-base-account',
 				},
 				contract: coinbaseSmartWalletContract,

--- a/data/wallet-contracts/coinbase-eip7702-proxy.ts
+++ b/data/wallet-contracts/coinbase-eip7702-proxy.ts
@@ -1,0 +1,19 @@
+import type { SmartWalletContract } from '@/schema/contracts'
+import { featureSupported } from '@/schema/features/support'
+
+export const coinbaseEip7702ProxyContract: SmartWalletContract = {
+	name: 'Coinbase EIP-7702 Proxy',
+	address: '0x7702cb554e6bfb442cb743a7df23154544a7176c',
+	eip7702Delegatable: true,
+	methods: {
+		isValidSignature: featureSupported,
+		validateUserOp: featureSupported,
+	},
+	sourceCode: {
+		ref: {
+			label: 'Coinbase EIP-7702 Proxy (base/eip-7702-proxy)',
+			url: 'https://github.com/base/eip-7702-proxy/blob/429ba3c76186a72949235e23cc84267bf456b48a/src/EIP7702Proxy.sol',
+		},
+		available: true,
+	},
+}

--- a/data/wallet-contracts/coinbase-smart-wallet.ts
+++ b/data/wallet-contracts/coinbase-smart-wallet.ts
@@ -1,0 +1,19 @@
+import type { SmartWalletContract } from '@/schema/contracts'
+import { featureSupported } from '@/schema/features/support'
+
+export const coinbaseSmartWalletContract: SmartWalletContract = {
+	name: 'Coinbase Smart Wallet',
+	address: '0x00000110dcdedc9581cb5ecb8467282f2926534d',
+	eip7702Delegatable: false,
+	methods: {
+		isValidSignature: featureSupported,
+		validateUserOp: featureSupported,
+	},
+	sourceCode: {
+		ref: {
+			label: 'Coinbase Smart Wallet (audited commit 9edcf7f1)',
+			url: 'https://github.com/coinbase/smart-wallet/blob/9edcf7f174c3ebef100a4400e6a17c746ea521a4/src/CoinbaseSmartWallet.sol',
+		},
+		available: true,
+	},
+}


### PR DESCRIPTION
## Summary

Updates the Base App listing to model accounts as **both** ERC-4337 Smart Wallets and EIP-7702-delegatable, per the Base team's Fileverse questionnaire response (2026-03-13) which states accounts are *"EOA + 7702 delegation / 4337"*. Adds contract entities for the deployed Coinbase Smart Wallet implementation and the dedicated EIP-7702 proxy. Also populates `passkeyVerification`.

## Changes

### New files

- `data/wallet-contracts/coinbase-smart-wallet.ts` — Coinbase Smart Wallet v1.1 implementation at `0x00000110dcdedc9581cb5ecb8467282f2926534d` (verified on Base Mainnet, same address across 248 chains via Safe Singleton Factory)
- `data/wallet-contracts/coinbase-eip7702-proxy.ts` — EIP7702Proxy at `0x7702cb554e6bfb442cb743a7df23154544a7176c` (verified, deployed on all Coinbase Smart Wallet supported chains)

### `data/software-wallets/base-app.ts`

| Field | Was | Now |
|---|---|---|
| `defaultAccountType` | `AccountType.eoa` | `AccountType.rawErc4337` |
| `eip7702` | `notSupported` | `supported({ contract: coinbaseEip7702ProxyContract })` |
| `rawErc4337` | `notSupported` | `supported({ contract: coinbaseSmartWalletContract })` |
| `eoa: supported` | unchanged | unchanged (legacy users still in migration backlog) |
| `passkeyVerification` | `null` | `supported({ library: WEB_AUTHN_SOL, ... })` |

## Why each field

**Account model:** Per [Base's official docs](https://docs.base.org/base-account/overview/what-is-base-account): *"Under the hood, each Base Account is an ERC-4337 Smart Wallet."* New passkey signups create smart wallets at contract addresses. Legacy users with 12-word phrases still have EOAs ([Coinbase Help](https://help.coinbase.com/en/wallet/getting-started/smart-wallet)).

**EIP-7702:** [github.com/base/eip-7702-proxy](https://github.com/base/eip-7702-proxy) is a dedicated ERC-1967 proxy designed as a safe 7702 delegation target. Coinbase sponsors the delegation tx on Base mainnet. Architecture write-up: [Securing EIP-7702 Upgrades — Base blog](https://blog.base.dev/securing-eip-7702-upgrades). The Base App doesn't expose an "upgrade my account" UI button — delegation happens transparently when a legacy EOA user interacts with a dApp that needs smart-wallet behavior. (The `coinbase/smart-wallet` README warns against delegating *directly* to the CoinbaseSmartWallet implementation; the EIP7702Proxy is the safe path.)

**Self-custody (`controllingSharesInSelfCustodyByDefault: 'YES'`):** Triangulated three ways:
1. [`CoinbaseSmartWalletFactory.createAccount`](https://github.com/coinbase/smart-wallet/blob/0fe87f18488fa89b792896d79de3200242778a68/src/CoinbaseSmartWalletFactory.sol) lets the caller set the entire owners array — no hardcoded Coinbase address
2. [Base Account Terms of Service](https://wallet.coinbase.com/terms-of-service) state Coinbase does not custody the wallet and cannot recover the user's key/passkey
3. Passkey is generated in the device secure enclave; backup via iCloud/Google Password Manager is E2E encrypted

**Key rotation (`RELYING_ON_EXTERNAL_API`):** The CoinbaseSmartWallet contract supports `addOwner`/`removeOwnerAtIndex`, but the Base App v29.94.123 mobile UI does not expose any passkey or owner management — Account Management contains only "Sign out", and Privacy & Security has nothing relevant. The optional recovery-key flow described in Coinbase Help likely lives in [keys.coinbase.com](https://keys.coinbase.com), not the mobile app.

**Passkey verification (`WEB_AUTHN_SOL`):** Confirmed via the [Code4rena audit](https://code4rena.com/reports/2024-03-coinbase) and source. CoinbaseSmartWallet imports from [`base-org/webauthn-sol`](https://github.com/base-org/webauthn-sol) which builds on Daimo's WebAuthn.sol; tries RIP-7212 P-256 precompile first, falls back to FreshCryptoLib.



🤖 Generated with [Claude Code](https://claude.com/claude-code)