### PR TITLE
Data: mark Base App as not supporting hardware wallets

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -167,7 +167,7 @@ export const baseApp: SoftwareWallet = {
 			// There is also nothing in the Base App documentation that indicates support
 			// for hardware wallets.
 			hardwareWalletSupport: {
-				ref: refTodo,
+				ref: refNotNecessary,
 				wallets: {},
 			},
 			keysHandling: null,

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -162,7 +162,14 @@ export const baseApp: SoftwareWallet = {
 				upgradePathAvailable: true,
 			}),
 			duressResistance: null,
-			hardwareWalletSupport: null,
+			// Base App exposes no UI for adding, pairing, or managing hardware wallet keys
+			// and there are no settings for Ledger, Trezor, or other hardware devices.
+			// There is also nothing in the Base App documentation that indicates support
+			// for hardware wallets.
+			hardwareWalletSupport: {
+				ref: refTodo,
+				wallets: {},
+			},
 			keysHandling: null,
 			lightClient: {
 				ethereumL1: notSupported,


### PR DESCRIPTION
## Summary

Sets `hardwareWalletSupport` for Base App to `{ ref: refTodo, wallets: {} }` (matching the daimo convention for "explicitly verified, no hardware wallets supported"), replacing the previous `null` ("not yet checked").

## Evidence

Verified three ways:

1. **In-app UI walkthrough (Base App v29.94.123)** — Settings shows Display / Account Management / Connect to Coinbase / Privacy & Security / Trading / Help / Legal. None mention hardware wallets. Account Management contains only a Sign Out action. No UI exists to add, pair, or manage Ledger / Trezor / other hardware devices.
2. **Base App documentation** — nothing in [help.coinbase.com/en/base](https://help.coinbase.com/en/base) or [docs.base.org](https://docs.base.org) describes hardware wallet pairing. Existing "Coinbase Wallet + Ledger" articles describe (a) the legacy browser extension or (b) importing a Ledger seed phrase as an EOA (which is account import, not hardware-wallet pairing).
3. **Base team questionnaire response (2026-03-13)** — hardware wallets are not mentioned anywhere in the response. The supported account types are listed as "EOA + 7702 delegation / 4337".

## Convention

Per the schema at [src/schema/features/security/hardware-wallet-support.ts](src/schema/features/security/hardware-wallet-support.ts): *"Omit a type entirely rather than setting it to not supported — only list wallets that have been explicitly verified."* Empty `wallets: {}` is the "verified no support" signal, distinct from `null` ("not checked").

The empirical evidence (in-app UI absence + documentation absence) is captured in a code comment above the field. `ref: refTodo` matches the pattern used by [daimo.ts](data/software-wallets/daimo.ts), [elytro.ts](data/software-wallets/elytro.ts), [family.ts](data/software-wallets/family.ts), [pillarx.ts](data/software-wallets/pillarx.ts), and [mtpelerin.ts](data/software-wallets/mtpelerin.ts) for the same "no hardware wallet support" claim.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the hardware wallet section as "no hardware wallets supported" rather than as missing/unknown

🤖 Generated with [Claude Code](https://claude.com/claude-code)