### PR TITLE
Chore: document why Base App securityBestPractices is null

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -182,6 +182,13 @@ export const baseApp: SoftwareWallet = {
 				scamUrlWarning: null,
 				sendTransactionWarning: notSupported,
 			},
+			// Base App is closed-source; no public URL hosts the AndroidManifest.xml
+			// or Info.plist, so the `pnpm collect:manifests` tool cannot fetch them.
+			// Filling this out requires manually extracting the manifests from the
+			// published APK/IPA. What we know without extraction: for new passkey
+			// accounts (the smart-wallet path), keyStorageMechanism would be
+			// PASSKEY_MANAGED — the WebAuthn passkey lives in the iOS Secure
+			// Enclave or Android Keystore and no private key is stored by the app.
 			securityBestPractices: null,
 			transactionLegibility: null,
 		},


### PR DESCRIPTION
## Summary

Adds a code comment above `securityBestPractices: null` for Base App explaining why the field can't currently be filled out, and records the one piece of information we already know (passkey-based key storage).

## Why this isn't a `null → supported` change

The schema's [`MobileSecurityBestPractices`](src/schema/features/security/security-best-practices.ts) requires:
- `keyStorageMechanism` (easy — `PASSKEY_MANAGED` for the new passkey path)
- `secureRng` (easy — `OS_CSPRNG`)
- **`mobileAppHardening: MobileAppManifest`** — non-optional; demands the actual `usesPermissions` array from AndroidManifest.xml and `usageDescriptions` array from Info.plist

The project's [`pnpm collect:manifests`](src/tools/manifest-collector/manifest-collector.ts) tool auto-fetches these from a public URL declared in the wallet metadata (e.g. MetaMask's GitHub raw URLs). Base App is closed-source — no such URL exists.

The `'NOT_AN_ANDROID_APP'` / `'NOT_AN_IOS_APP'` sentinels don't apply (Base App has both variants). The schema has no "manifest unavailable" sentinel.

## What would unblock filling this in

1. Download the Base App APK from a Play Store mirror, run `apktool d` to extract AndroidManifest.xml
2. Download the IPA, extract Info.plist (binary plist → XML via `plutil -convert xml1`)
3. Drop both into `data/software-wallets/manifests/base-app/`
4. Generate `android.parsed.json` / `ios.parsed.json` via the project's parsers
5. Wire up imports in base-app.ts and replace the null with the full `SecurityBestPracticesData`

That's ~30 min of offline work and requires APK/IPA access. Daimo (also passkey-based, mobile-only) is in the same null-state, so there's precedent for deferring.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass (only a comment addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)