### PR TITLE
Data: mark Base App as not supporting any private transfer technologies

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -1,6 +1,7 @@
 import { ren2140 } from '@/data/contributors/ren2140'
 import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
+import { PrivateTransferTechnology } from '@/schema/features/privacy/transaction-privacy'
 import { WalletProfile } from '@/schema/features/profile'
 import {
 	BugBountyPlatform,
@@ -141,7 +142,18 @@ export const baseApp: SoftwareWallet = {
 			appIsolation: null,
 			dataCollection: null,
 			privacyPolicy: 'https://wallet.coinbase.com/dapp-privacy-policy',
-			transactionPrivacy: null,
+			// Base App ships no built-in privacy features as of v29.94.123. Default
+			// transfers are public ERC-20 / ETH sends on Base. Coinbase has signaled
+			// future work on private transactions (Iron Fish acquisition, March 2025),
+			// but no stealth address, Railgun, Privacy Pools, or Tornado Cash Nova
+			// integration is in the app today. Confirmed by direct app testing.
+			transactionPrivacy: {
+				defaultFungibleTokenTransferMode: 'PUBLIC',
+				[PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
+				[PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
+				[PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
+				[PrivateTransferTechnology.RAILGUN]: notSupported,
+			},
 		},
 		profile: WalletProfile.GENERIC,
 		security: {


### PR DESCRIPTION
## Summary

Sets `privacy.transactionPrivacy` for Base App to "all public, no privacy tech supported," matching daimo's pattern.

## Changes

**At [base-app.ts:144](data/software-wallets/base-app.ts:144):**

```ts
transactionPrivacy: {
    defaultFungibleTokenTransferMode: 'PUBLIC',
    [PrivateTransferTechnology.STEALTH_ADDRESSES]: notSupported,
    [PrivateTransferTechnology.TORNADO_CASH_NOVA]: notSupported,
    [PrivateTransferTechnology.PRIVACY_POOLS]: notSupported,
    [PrivateTransferTechnology.RAILGUN]: notSupported,
},
```

Plus the corresponding import.

## Evidence

- **Direct app testing** (Base App v29.94.123) — no UI for private transfers, no stealth address option, no Railgun/Privacy Pools/Tornado integration
- **App reviews** ([Base App review 2026](https://cryptoadventure.com/base-app-coinbase-wallet-review-2026-self-custody-with-a-mainstream-ux/)) — no mention of privacy features
- **Coinbase forward-looking signal** — Iron Fish team acquisition in March 2025 with the goal of "Base building private transactions." This is in development, not shipped. Worth re-checking when Coinbase makes a launch announcement.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the transaction privacy section as "no privacy tech supported"

🤖 Generated with [Claude Code](https://claude.com/claude-code)