### PR TITLE
Data: mark Base App crash reports and usage analytics as ALWAYS

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -163,12 +163,12 @@ export const baseApp: SoftwareWallet = {
 					ref: [
 						{
 							explanation:
-								'Apple App Store privacy label declares Product Interaction (usage data) is collected and linked to identity, used for third-party advertising, developer advertising/marketing, AND analytics. The in-app "Personalized Advertising" toggle (defaulted ON) reduces advertising-related sharing but does not stop the underlying usage analytics collection.',
+								'Apple App Store privacy label declares Product Interaction (usage data) is collected and linked to identity, used for external advertising, developer advertising/marketing, AND analytics. The in-app "Personalized Advertising" toggle (defaulted ON) reduces advertising-related sharing but does not stop the underlying usage analytics collection.',
 							url: 'https://apps.apple.com/us/app/base-formerly-coinbase-wallet/id1278383455',
 						},
 						{
 							explanation:
-								'Coinbase privacy policy: in the past 12 months, Coinbase has disclosed identifiers with third-party analytics providers and advertising partners.',
+								'Coinbase privacy policy: in the past 12 months, Coinbase has disclosed identifiers with external analytics providers and advertising partners.',
 							url: 'https://wallet.coinbase.com/privacy-policy',
 						},
 					],

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -168,7 +168,7 @@ export const baseApp: SoftwareWallet = {
 						},
 						{
 							explanation:
-								'Coinbase privacy policy: "In the past 12 months, Coinbase has disclosed identifiers with third party analytics providers and advertising partners."',
+								'Coinbase privacy policy: in the past 12 months, Coinbase has disclosed identifiers with third-party analytics providers and advertising partners.',
 							url: 'https://wallet.coinbase.com/privacy-policy',
 						},
 					],

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -1,6 +1,9 @@
 import { ren2140 } from '@/data/contributors/ren2140'
+import { coinbase } from '@/data/entities/coinbase'
+import type { WalletAnalytics } from '@/schema/features'
 import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
+import { CollectionPolicy } from '@/schema/features/privacy/data-collection'
 import { WalletProfile } from '@/schema/features/profile'
 import {
 	BugBountyPlatform,
@@ -134,9 +137,44 @@ export const baseApp: SoftwareWallet = {
 		},
 		multiAddress: null,
 		privacy: {
+			// Per direct in-app check (Settings > Privacy & Security, Base App v29.94.123):
+			// there is NO toggle to disable crash reporting, diagnostics, or usage
+			// analytics. The only data-collection toggle is "Personalized Advertising"
+			// (defaulted ON), which reduces ad-related data sharing but does not stop
+			// the underlying analytics collection.
 			analytics: {
-				crashReports: null,
-				usage: null,
+				crashReports: supported<WalletAnalytics>({
+					ref: [
+						{
+							explanation:
+								'Apple App Store privacy label declares "Diagnostics: Crash Data" and performance metrics are collected.',
+							url: 'https://apps.apple.com/us/app/base-formerly-coinbase-wallet/id1278383455',
+						},
+						{
+							explanation:
+								'No opt-out exists in the Base App Privacy & Security settings as of v29.94.123.',
+							url: 'https://wallet.coinbase.com/privacy-policy',
+						},
+					],
+					entity: coinbase,
+					policy: CollectionPolicy.ALWAYS,
+				}),
+				usage: supported<WalletAnalytics>({
+					ref: [
+						{
+							explanation:
+								'Apple App Store privacy label declares Product Interaction (usage data) is collected and linked to identity, used for third-party advertising, developer advertising/marketing, AND analytics. The in-app "Personalized Advertising" toggle (defaulted ON) reduces advertising-related sharing but does not stop the underlying usage analytics collection.',
+							url: 'https://apps.apple.com/us/app/base-formerly-coinbase-wallet/id1278383455',
+						},
+						{
+							explanation:
+								'Coinbase privacy policy: "In the past 12 months, Coinbase has disclosed identifiers with third party analytics providers and advertising partners."',
+							url: 'https://wallet.coinbase.com/privacy-policy',
+						},
+					],
+					entity: coinbase,
+					policy: CollectionPolicy.ALWAYS,
+				}),
 			},
 			appIsolation: null,
 			dataCollection: null,


### PR DESCRIPTION
## Summary

Sets `privacy.analytics.crashReports` and `privacy.analytics.usage` for Base App to `supported(...)` with `policy: CollectionPolicy.ALWAYS` and `entity: coinbase`. Both fields were previously `null` (not yet checked).

## Evidence

Triangulated from three sources:

### 1. Direct in-app check (Base App v29.94.123)

The user opened Settings → Privacy & Security and reported the only data-collection toggle is:
- **Personalized Advertising** — defaulted ON, can be toggled off
- (no toggle for crash reports / diagnostics / usage analytics)

The personalized-advertising toggle reduces *ad-related sharing* but does not stop the underlying analytics collection — so users cannot fully opt out of either field's data collection.

### 2. Apple App Store privacy nutrition label

From [apps.apple.com/us/app/base-formerly-coinbase-wallet/id1278383455](https://apps.apple.com/us/app/base-formerly-coinbase-wallet/id1278383455):

| Data | Collected? | Linked to identity? | Purpose |
|---|---|---|---|
| Crash Data + performance metrics | YES | NO | Analytics + app functionality |
| Product Interaction (usage) | YES | YES | Third-party advertising, developer advertising/marketing, AND analytics |
| Identifiers (Device ID) | YES | YES | Cross-app/cross-website tracking |

### 3. Coinbase privacy policy

From [wallet.coinbase.com/privacy-policy](https://wallet.coinbase.com/privacy-policy):

> *"In the past 12 months, Coinbase has disclosed identifiers with third party analytics providers and advertising partners."*

## Policy choice: ALWAYS (not BY_DEFAULT)

Per [src/schema/features/privacy/data-collection.ts](src/schema/features/privacy/data-collection.ts):
- `ALWAYS` = *"The data is always collected no matter what the user does"*
- `BY_DEFAULT` = *"collected by default, but the user may turn this off"*

The personalized-advertising toggle is a partial control — it reduces ad-related sharing but the underlying usage and crash data collection continues regardless. So `ALWAYS` is the more honest signal.

## Entity choice: coinbase

Per the Coinbase privacy policy, Coinbase is the data controller. They may use third-party analytics providers as processors, but Coinbase is the responsible party.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the analytics section reflecting ALWAYS collection by coinbase

🤖 Generated with [Claude Code](https://claude.com/claude-code)