### PR TITLE
Data: mark Base App as not supporting ERC-7828 or ERC-7831

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -64,9 +64,13 @@ export const baseApp: SoftwareWallet = {
 		},
 		addressResolution: {
 			ref: refTodo,
+			// Confirmed in-app (Base App v29.94.123): neither ERC-7828
+			// (donations.walletbeat.eth@optimism.eth) nor ERC-7831
+			// (donations.walletbeat.eth:optimism:1) resolves in the Send recipient
+			// field. No public documentation indicates support for either standard.
 			chainSpecificAddressing: {
-				erc7828: null,
-				erc7831: null,
+				erc7828: notSupported,
+				erc7831: notSupported,
 			},
 			nonChainSpecificEnsResolution: supported<AddressResolutionData>({
 				medium: 'CHAIN_CLIENT',


### PR DESCRIPTION
## Summary

Sets `addressResolution.chainSpecificAddressing.erc7828` and `.erc7831` to `notSupported` for Base App. Both were previously `null`.

## Evidence

**Direct in-app verification (Base App v29.94.123):**

Per the schema's test procedure at [src/schema/features/privacy/address-resolution.ts:16,22](src/schema/features/privacy/address-resolution.ts:16):
- Typed `donations.walletbeat.eth@optimism.eth` (ERC-7828 format) in the Send recipient field → does not resolve
- Typed `donations.walletbeat.eth:optimism:1` (ERC-7831 format) in the Send recipient field → does not resolve

**Public-source corroboration:** no Coinbase or Base documentation, blog post, or release note describes implementation of either standard. Both ERCs are emerging proposals adopted by very few wallets.

**Pattern match:** [daimo.ts:100-101](data/software-wallets/daimo.ts:100) and [ambire.ts:290-291](data/software-wallets/ambire.ts:290) both have these two fields as `notSupported` — Base App fits the same pattern.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page reflects "ERC-7828 not supported" and "ERC-7831 not supported" in the address resolution section

🤖 Generated with [Claude Code](https://claude.com/claude-code)