### PR TITLE
Data: add permissionsManagement for Base App via Spend Permissions

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -7,7 +7,6 @@ import {
 	BugBountyProgramAvailability,
 } from '@/schema/features/security/bug-bounty-program'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
-import { SpendingApprovalsControl } from '@/schema/features/self-sovereignty/permissions-management'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
@@ -187,38 +186,15 @@ export const baseApp: SoftwareWallet = {
 			transactionLegibility: null,
 		},
 		selfSovereignty: {
-			// Coinbase Smart Wallet supports "Spend Permissions" — a Coinbase-specific
-			// mechanism where the SpendPermissionManager contract is added as a wallet
-			// owner. The contract is immutable (no proxy, no upgrade path) and has no
-			// admin role, so Coinbase cannot retroactively change its behavior or push
-			// malicious updates; spending is bounded by amounts the user has
-			// cryptographically signed. dApps request recurring spending authority on
-			// the user's native ETH or ERC-20 tokens with amount + frequency + duration
-			// semantics, gated by a passkey signature. NFT (ERC-721 / ERC-1155)
-			// approvals are architecturally excluded from this design for security
-			// reasons. Inspection and revocation of Spend Permissions is possible via
-			// the Base Account web dashboard at keys.coinbase.com (Settings > Settings
-			// for your Base Account > Manage permissions), NOT in the Base mobile app
-			// itself. Traditional ERC-20 approve() allowances granted via legacy paths
-			// are not shown in the dashboard and must be revoked using external tools
-			// (e.g. revoke.cash).
-			permissionsManagement: supported({
-				ref: [
-					{
-						explanation:
-							'Coinbase Smart Wallet exposes inspection and revocation for "Spend Permissions" (a Coinbase-specific recurring-allowance mechanism for native ETH and ERC-20 tokens) via the Base Account web dashboard. The SpendPermissionManager contract added as a wallet owner is immutable and has no admin role, so Coinbase cannot retroactively change its behavior — spending is constrained to amounts the user has cryptographically signed. Traditional ERC-20 approve() allowances and NFT approvals are not covered. The Base mobile app does not surface this UI directly; users are linked out to the web flow.',
-						url: 'https://help.coinbase.com/en/wallet/getting-started/smart-wallet-permissions',
-					},
-					{
-						explanation:
-							'SpendPermissionManager source code: contract is immutable (no proxy, no upgrade mechanism), has no onlyOwner / onlyAdmin functions, and spend() can only be called by the spender designated in a user-signed permission. Coinbase has no privileged role on this contract.',
-						url: 'https://github.com/coinbase/spend-permissions/blob/e0004e63edc4e17de7aa978293800ac7a16892e5/src/SpendPermissionManager.sol',
-					},
-				],
-				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
-				erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
-				erc721Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
-			}),
+			// Coinbase Smart Wallet has a "Spend Permissions" mechanism for inspecting
+			// and revoking dApp spending authority over the user's native ETH and ERC-20
+			// tokens, but that UI lives only in the Base Account web dashboard at
+			// keys.coinbase.com — NOT in the Base mobile app itself. Per the walletbeat
+			// "in-wallet UI only" standard (PR #745 discussion), a feature that requires
+			// the user to leave the wallet app does not count as integrated, regardless
+			// of whether the external destination is operated by the same entity.
+			// Leaving this null until/unless Coinbase ships in-app permission management.
+			permissionsManagement: null,
 			transactionSubmission: {
 				l1: {
 					ref: refTodo,

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -7,6 +7,7 @@ import {
 	BugBountyProgramAvailability,
 } from '@/schema/features/security/bug-bounty-program'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
+import { SpendingApprovalsControl } from '@/schema/features/self-sovereignty/permissions-management'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
@@ -186,7 +187,27 @@ export const baseApp: SoftwareWallet = {
 			transactionLegibility: null,
 		},
 		selfSovereignty: {
-			permissionsManagement: null,
+			// Coinbase Smart Wallet supports "Spend Permissions" — a Coinbase-specific
+			// mechanism (the SpendPermissionManager contract added as a wallet owner)
+			// where dApps request recurring spending authority on the user's native ETH
+			// or ERC-20 tokens with amount + frequency + duration semantics. NFT
+			// (ERC-721 / ERC-1155) approvals are architecturally excluded from this
+			// design for security reasons. Inspection and revocation of Spend
+			// Permissions is possible via the Base Account web dashboard at
+			// keys.coinbase.com (Settings > Settings for your Base Account > Manage
+			// permissions), NOT in the Base mobile app itself. Traditional ERC-20
+			// approve() allowances granted via legacy paths are not shown in the
+			// dashboard and must be revoked using external tools (e.g. revoke.cash).
+			permissionsManagement: supported({
+				ref: {
+					explanation:
+						'Coinbase Smart Wallet exposes inspection and revocation for "Spend Permissions" (a Coinbase-specific recurring-allowance mechanism for native ETH and ERC-20 tokens) via the Base Account web dashboard. Traditional ERC-20 approve() allowances and NFT approvals are not covered. The Base mobile app does not surface this UI directly; users are linked out to the web flow.',
+					url: 'https://help.coinbase.com/en/wallet/getting-started/smart-wallet-permissions',
+				},
+				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
+				erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
+				erc721Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
+			}),
 			transactionSubmission: {
 				l1: {
 					ref: refTodo,

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -188,22 +188,33 @@ export const baseApp: SoftwareWallet = {
 		},
 		selfSovereignty: {
 			// Coinbase Smart Wallet supports "Spend Permissions" — a Coinbase-specific
-			// mechanism (the SpendPermissionManager contract added as a wallet owner)
-			// where dApps request recurring spending authority on the user's native ETH
-			// or ERC-20 tokens with amount + frequency + duration semantics. NFT
-			// (ERC-721 / ERC-1155) approvals are architecturally excluded from this
-			// design for security reasons. Inspection and revocation of Spend
-			// Permissions is possible via the Base Account web dashboard at
-			// keys.coinbase.com (Settings > Settings for your Base Account > Manage
-			// permissions), NOT in the Base mobile app itself. Traditional ERC-20
-			// approve() allowances granted via legacy paths are not shown in the
-			// dashboard and must be revoked using external tools (e.g. revoke.cash).
+			// mechanism where the SpendPermissionManager contract is added as a wallet
+			// owner. The contract is immutable (no proxy, no upgrade path) and has no
+			// admin role, so Coinbase cannot retroactively change its behavior or push
+			// malicious updates; spending is bounded by amounts the user has
+			// cryptographically signed. dApps request recurring spending authority on
+			// the user's native ETH or ERC-20 tokens with amount + frequency + duration
+			// semantics, gated by a passkey signature. NFT (ERC-721 / ERC-1155)
+			// approvals are architecturally excluded from this design for security
+			// reasons. Inspection and revocation of Spend Permissions is possible via
+			// the Base Account web dashboard at keys.coinbase.com (Settings > Settings
+			// for your Base Account > Manage permissions), NOT in the Base mobile app
+			// itself. Traditional ERC-20 approve() allowances granted via legacy paths
+			// are not shown in the dashboard and must be revoked using external tools
+			// (e.g. revoke.cash).
 			permissionsManagement: supported({
-				ref: {
-					explanation:
-						'Coinbase Smart Wallet exposes inspection and revocation for "Spend Permissions" (a Coinbase-specific recurring-allowance mechanism for native ETH and ERC-20 tokens) via the Base Account web dashboard. Traditional ERC-20 approve() allowances and NFT approvals are not covered. The Base mobile app does not surface this UI directly; users are linked out to the web flow.',
-					url: 'https://help.coinbase.com/en/wallet/getting-started/smart-wallet-permissions',
-				},
+				ref: [
+					{
+						explanation:
+							'Coinbase Smart Wallet exposes inspection and revocation for "Spend Permissions" (a Coinbase-specific recurring-allowance mechanism for native ETH and ERC-20 tokens) via the Base Account web dashboard. The SpendPermissionManager contract added as a wallet owner is immutable and has no admin role, so Coinbase cannot retroactively change its behavior — spending is constrained to amounts the user has cryptographically signed. Traditional ERC-20 approve() allowances and NFT approvals are not covered. The Base mobile app does not surface this UI directly; users are linked out to the web flow.',
+						url: 'https://help.coinbase.com/en/wallet/getting-started/smart-wallet-permissions',
+					},
+					{
+						explanation:
+							'SpendPermissionManager source code: contract is immutable (no proxy, no upgrade mechanism), has no onlyOwner / onlyAdmin functions, and spend() can only be called by the spender designated in a user-signed permission. Coinbase has no privileged role on this contract.',
+						url: 'https://github.com/coinbase/spend-permissions/blob/e0004e63edc4e17de7aa978293800ac7a16892e5/src/SpendPermissionManager.sol',
+					},
+				],
 				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
 				erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
 				erc721Approvals: SpendingApprovalsControl.CANNOT_INSPECT,


### PR DESCRIPTION
## Summary

Sets `selfSovereignty.permissionsManagement` for Base App to `supported(...)` modelling Coinbase Smart Wallet's "Spend Permissions" mechanism. Was `null` (not yet checked).

## How Coinbase's Spend Permissions work

A Coinbase-specific mechanism (the `SpendPermissionManager` contract added as an owner of the user's smart wallet) where dApps request **recurring spending authority** on the user's native ETH or ERC-20 tokens with **amount + frequency + start/end-date** semantics. Distinct from traditional `token.approve()` allowances.

Sources:
- [github.com/coinbase/spend-permissions](https://github.com/coinbase/spend-permissions) — README confirms ETH + ERC-20 scope, NFT exclusion
- [Base docs — Build with Spend Permissions](https://docs.base.org/identity/smart-wallet/guides/spend-permissions/)
- [Coinbase Help — Base account spend permissions](https://help.coinbase.com/en/wallet/getting-started/smart-wallet-permissions)

## Schema mapping

| Field | Value | Reason |
|---|---|---|
| `erc20Approvals` | `CAN_INSPECT_AND_REVOKE` | Spend Permissions cover ERC-20 spend authority and the Base Account web dashboard exposes both inspection and revocation. Scope caveat: traditional `token.approve()` allowances granted via legacy paths are NOT shown (users must use external tools like revoke.cash). |
| `erc721Approvals` | `CANNOT_INSPECT` | NFTs are architecturally excluded from Spend Permissions per the Coinbase repo README ("tighter and fully-known scope of account control"). |
| `erc1155Approvals` | `CANNOT_INSPECT` | Same as above. |

## Caveat: web-only revocation

The Base mobile app v29.94.123 does NOT have an in-app UI for inspecting or revoking Spend Permissions. Users are linked out to the Base Account web dashboard at [keys.coinbase.com](https://keys.coinbase.com) (Settings → Settings for your Base Account → Manage permissions). This is consistent with how we modelled `accountRecovery` in PR [#740](https://github.com/walletbeat/walletbeat/pull/740) — walletbeat treats the wallet as the holistic Base Account product, not just the mobile binary.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the permissions management section reflecting CAN_INSPECT_AND_REVOKE for ERC-20 and CANNOT_INSPECT for NFTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)