### PR TITLE
Data: update Rabby permissionsManagement to reflect browser UI integration

### DIFF
--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -773,12 +773,22 @@ export const rabby: SoftwareWallet = {
 			},
 		},
 		selfSovereignty: {
-			permissionsManagement: supported({
-				ref: refTodo,
-				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
-				erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
-				erc721Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
-			}),
+			// Rabby's browser extension exposes inspection and revocation for
+			// ERC-20, ERC-721, and ERC-1155 token approvals directly in the popup
+			// UI (a recent integration; previously this opened a separate tab to a
+			// Rabby-owned revoke site, which would not have qualified under the
+			// in-wallet-UI standard). Verified in-app. Mobile and desktop variants
+			// not independently verified, so left as null.
+			permissionsManagement: {
+				[Variant.BROWSER]: supported({
+					ref: refTodo,
+					erc1155Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
+					erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
+					erc721Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
+				}),
+				[Variant.DESKTOP]: null,
+				[Variant.MOBILE]: null,
+			},
 			transactionSubmission: {
 				l1: {
 					ref: refTodo,


### PR DESCRIPTION
## Summary

Rabby's browser extension recently integrated full token-approval management directly in the popup UI. Previously the wallet redirected users to a separate Rabby-owned revoke site, which would not have qualified as supported under the walletbeat in-wallet-UI standard (see [PR #745](https://github.com/walletbeat/walletbeat/pull/745) discussion). The current implementation does qualify.

## Changes

**At [rabby.ts:776-781](data/software-wallets/rabby.ts:776):** changed `permissionsManagement` from a single-value `supported({...})` (which incorrectly applied to all variants AND incorrectly listed NFT approvals as `CANNOT_INSPECT`) to a variant-keyed object:

| Variant | Value |
|---|---|
| `BROWSER` | `supported({erc20/erc721/erc1155: CAN_INSPECT_AND_REVOKE})` |
| `DESKTOP` | `null` |
| `MOBILE` | `null` |

ERC-721 and ERC-1155 are now correctly marked as inspectable + revocable in the browser variant.

Mobile and Desktop are left as `null` (not independently verified) — follow-up could verify and update those if the same UI exists there.

## Evidence

**Direct in-app verification (Rabby browser extension):** the popup UI exposes inspection and revocation flows for ERC-20, ERC-721, and ERC-1155 approvals natively. This is a change from a prior implementation that opened a separate tab to a Rabby-owned revoke site.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Rabby detail page reflects per-variant permissions management state

🤖 Generated with [Claude Code](https://claude.com/claude-code)