### PR TITLE
Data: add keysHandling for Base App

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -6,6 +6,10 @@ import {
 	BugBountyPlatform,
 	BugBountyProgramAvailability,
 } from '@/schema/features/security/bug-bounty-program'
+import {
+	KeyGenerationLocation,
+	MultiPartyKeyReconstruction,
+} from '@/schema/features/security/keys-handling'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
@@ -163,7 +167,27 @@ export const baseApp: SoftwareWallet = {
 			}),
 			duressResistance: null,
 			hardwareWalletSupport: null,
-			keysHandling: null,
+			// New passkey accounts (rawErc4337 default): WebAuthn passkey generated in
+			// the device secure enclave (iOS) / Android Keystore. Legacy 12-word-phrase
+			// accounts: BIP39 seed phrase generated locally. Both paths fall under
+			// FULLY_ON_USER_DEVICE / NON_MULTIPARTY — keys never leave the device
+			// during generation, and there is no key-splitting or threshold scheme.
+			keysHandling: {
+				ref: [
+					{
+						explanation:
+							'Per Coinbase Help, Smart Wallet passkeys are stored on the device (in the platform passkey store backed by iOS Secure Enclave or Android Keystore). The user retains control of the device-bound credential.',
+						url: 'https://help.coinbase.com/en/wallet/getting-started/smart-wallet-passkeys',
+					},
+					{
+						explanation:
+							'Per Coinbase Help, legacy 12-word recovery phrase accounts are generated on-device using BIP39; the seed phrase is shown only to the user and stored locally.',
+						url: 'https://help.coinbase.com/en/wallet/managing-account/wallet-recovery-phrase',
+					},
+				],
+				keyGeneration: KeyGenerationLocation.FULLY_ON_USER_DEVICE,
+				multipartyKeyReconstruction: MultiPartyKeyReconstruction.NON_MULTIPARTY,
+			},
 			lightClient: {
 				ethereumL1: notSupported,
 			},


### PR DESCRIPTION
## Summary

Sets `security.keysHandling` for Base App to reflect that both account-type paths generate keys fully on-device with no key-splitting. Previously `null`.

## Schema mapping

| Field | Value | Why |
|---|---|---|
| `keyGeneration` | `FULLY_ON_USER_DEVICE` | Both new passkey accounts (rawErc4337 default — WebAuthn passkey created in iOS Secure Enclave / Android Keystore) AND legacy 12-word-phrase accounts (BIP39 generated locally) keep all key material on the user's device during generation. |
| `multipartyKeyReconstruction` | `NON_MULTIPARTY` | Neither account-type path uses MPC, secret sharing, or threshold signing. The smart wallet supports multi-owner, but each owner's key is independent — not a share of a single key. |

## Sources

Cites two Coinbase Help pages rather than `refTodo` since direct documentation exists for both account-type paths:

1. [Coinbase Help — Smart wallet passkeys](https://help.coinbase.com/en/wallet/getting-started/smart-wallet-passkeys) — confirms passkeys are stored on the device's platform passkey store
2. [Coinbase Help — Wallet recovery phrase](https://help.coinbase.com/en/wallet/managing-account/wallet-recovery-phrase) — covers the legacy BIP39 path

Matches the [daimo](data/software-wallets/daimo.ts) pattern (also passkey-based mobile-only wallet) for the field values, but with citable sources instead of `refTodo`.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders keys handling section reflecting FULLY_ON_USER_DEVICE / NON_MULTIPARTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)