### PR TITLE
Data: mark Base App as not supporting multiple addresses

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -132,7 +132,10 @@ export const baseApp: SoftwareWallet = {
 				ventureCapital: null,
 			},
 		},
-		multiAddress: null,
+		// Base App has no UI for adding additional Ethereum addresses to a single
+		// install — verified in-app (Base App v29.94.123). The wallet manages a
+		// single account/address per install.
+		multiAddress: notSupported,
 		privacy: {
 			analytics: {
 				crashReports: null,


### PR DESCRIPTION
## Summary

Sets `multiAddress` for Base App to `notSupported`. Was `null` (not yet checked).

## Evidence

**Direct in-app verification (Base App v29.94.123):** the wallet's profile / account screen has no option to add or switch between multiple Ethereum addresses on a single install. Each install manages exactly one account/address.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page reflects "single address" / "multi-address not supported"

🤖 Generated with [Claude Code](https://claude.com/claude-code)