### PR TITLE
Data: mark Base App duressResistance as no lock mechanism

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -161,7 +161,19 @@ export const baseApp: SoftwareWallet = {
 				}),
 				upgradePathAvailable: true,
 			}),
-			duressResistance: null,
+			// Verified in-app (Base App v29.94.123):
+			// - No app-level PIN, password, biometric toggle, or pattern lock.
+			//   Opening the app does not require any authentication.
+			// - Face ID / biometric IS required before signing transactions (this is
+			//   the passkey unlock, not an app-level lock — gated per-action rather
+			//   than at app launch).
+			// - No duress credential, decoy mode, or emergency wipe feature.
+			// Per the schema: "Set to 'NO_LOCK_MECHANISM' if the wallet has no lock
+			// screen at all."
+			duressResistance: {
+				basicUnlock: 'NO_LOCK_MECHANISM',
+				duressMode: notSupported,
+			},
 			hardwareWalletSupport: null,
 			keysHandling: null,
 			lightClient: {


### PR DESCRIPTION
## Summary

Sets `security.duressResistance` for Base App to reflect that the app has no in-app lock mechanism and no duress mode. Was `null`.

## Evidence (in-app verification, Base App v29.94.123)

1. **No app-specific PIN / passcode** — the app cannot be configured to require a PIN at launch
2. **No biometric toggle** — there is no setting to enable Face ID / fingerprint to open the app
3. **App opens without any authentication** — verified directly; tapping the app icon takes you straight in
4. **Face ID IS required before signing transactions** — but that's the passkey unlock for a specific signing action, not an app-level lock screen. By the schema's framing, this doesn't count as `basicUnlock`.
5. **No duress credential, decoy mode, or emergency wipe** — no such features visible anywhere in Settings or Privacy & Security

## Schema mapping

| Field | Value | Why |
|---|---|---|
| `basicUnlock` | `'NO_LOCK_MECHANISM'` | Per the schema's instruction: *"Set to 'NO_LOCK_MECHANISM' if the wallet has no lock screen at all."* |
| `duressMode` | `notSupported` | No duress-related features exist |

## Comparison

MetaMask uses PASSWORD + BIOMETRIC because it forces users to set an in-app password during onboarding. Ambire uses PASSWORD similarly. Base App takes a more "trust the OS / trust the passkey" approach — no app-level lock at all. This is a meaningful self-sovereignty distinction that the field captures honestly.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page reflects "no lock mechanism" / "no duress mode" in the duress resistance section

🤖 Generated with [Claude Code](https://claude.com/claude-code)