### PR TITLE
Data: add Base App permissionsManagement (in-app Token Approvals screen)

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -21,6 +21,7 @@ import {
 } from '@/schema/features/security/keys-handling'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
+import { SpendingApprovalsControl } from '@/schema/features/self-sovereignty/permissions-management'
 import {
 	TransactionSubmissionL2Support,
 	TransactionSubmissionL2Type,
@@ -378,15 +379,21 @@ export const baseApp: SoftwareWallet = {
 			transactionLegibility: null,
 		},
 		selfSovereignty: {
-			// Coinbase Smart Wallet has a "Spend Permissions" mechanism for inspecting
-			// and revoking dApp spending authority over the user's native ETH and ERC-20
-			// tokens, but that UI lives only in the Base Account web dashboard at
-			// keys.coinbase.com — NOT in the Base mobile app itself. Per the walletbeat
-			// "in-wallet UI only" standard (PR #745 discussion), a feature that requires
-			// the user to leave the wallet app does not count as integrated, regardless
-			// of whether the external destination is operated by the same entity.
-			// Leaving this null until/unless Coinbase ships in-app permission management.
-			permissionsManagement: null,
+			// Base App exposes in-app ERC-20 token approval management via a "Token
+			// Approvals" screen (verified in-app, Base App v29.94.123). Users can
+			// inspect and revoke individual approvals directly in the wallet UI,
+			// across multiple chains (Ethereum, Base, Optimism observed). The screen
+			// covers traditional ERC-20 token.approve() allowances and Permit2-style
+			// allowances. NFT (ERC-721 / ERC-1155) approvals are NOT surfaced in this
+			// view — only fungibles. This satisfies the in-wallet-UI standard
+			// established in the prior #745 review (which was reverted under the
+			// assumption that revocation lived only at keys.coinbase.com).
+			permissionsManagement: supported({
+				ref: refTodo,
+				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
+				erc20Approvals: SpendingApprovalsControl.CAN_INSPECT_AND_REVOKE,
+				erc721Approvals: SpendingApprovalsControl.CANNOT_INSPECT,
+			}),
 			// Base App is mobile-only and closed-source. It does not ship its own
 			// Ethereum P2P (devp2p) stack, transactions
 			// are broadcast via Coinbase's RPC infrastructure. Users cannot configure

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -382,7 +382,7 @@ export const baseApp: SoftwareWallet = {
 			// Base App exposes in-app ERC-20 token approval management via a "Token
 			// Approvals" screen (verified in-app, Base App v29.94.123). Users can
 			// inspect and revoke individual approvals directly in the wallet UI,
-			// across multiple chains (Ethereum, Base, Optimism observed). The screen
+			// across multiple chains. The screen
 			// covers traditional ERC-20 token.approve() allowances and Permit2-style
 			// allowances. NFT (ERC-721 / ERC-1155) approvals are NOT surfaced in this
 			// view.

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -385,9 +385,7 @@ export const baseApp: SoftwareWallet = {
 			// across multiple chains (Ethereum, Base, Optimism observed). The screen
 			// covers traditional ERC-20 token.approve() allowances and Permit2-style
 			// allowances. NFT (ERC-721 / ERC-1155) approvals are NOT surfaced in this
-			// view — only fungibles. This satisfies the in-wallet-UI standard
-			// established in the prior #745 review (which was reverted under the
-			// assumption that revocation lived only at keys.coinbase.com).
+			// view.
 			permissionsManagement: supported({
 				ref: refTodo,
 				erc1155Approvals: SpendingApprovalsControl.CANNOT_INSPECT,


### PR DESCRIPTION
## Summary

Sets `selfSovereignty.permissionsManagement` for Base App to `supported` with ERC-20 approvals at `CAN_INSPECT_AND_REVOKE`. Replaces the `null` state on beta.

This is a **revival of [PR #745](https://github.com/walletbeat/walletbeat/pull/745) with new evidence**. #745 was reverted to null after @polymutex's review established that the only revocation surface we knew about (keys.coinbase.com web dashboard) did not meet the in-wallet-UI standard. Since then, ren2140 discovered an in-app **Token Approvals** screen in Base App v29.94.123 that handles inspection and revocation directly in the mobile app UI — satisfying the same standard.

## Evidence

Direct in-app verification (Base App v29.94.123). Navigation: **Settings → Privacy & Security → Token Approvals**. The screen:

- Title: "Token Approvals"; subhead: *"To keep your assets safe, it's a good practice to regularly revoke approvals"*
- Lists allowances **per-token, per-chain**, with the spender address visible
- **Multi-chain**: Ethereum, Base, Optimism observed in a single user's list
- Covers traditional **ERC-20 `token.approve()`** allowances and **Permit2** allowances
- **Revoke** button per entry — actionable, not read-only
- All entries are ERC-20 / fungibles — no NFT approvals shown

## Schema mapping

| Field | Value | Why |
|---|---|---|
| `erc20Approvals` | `CAN_INSPECT_AND_REVOKE` | In-app, multi-chain, covers traditional approve() and Permit2 |
| `erc721Approvals` | `CANNOT_INSPECT` | NFTs are not surfaced in the Token Approvals screen |
| `erc1155Approvals` | `CANNOT_INSPECT` | Same |

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the permissions management section reflecting ERC-20 `CAN_INSPECT_AND_REVOKE`, NFTs `CANNOT_INSPECT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)