### PR TITLE
Data: fill in transactionSubmission for Base App

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -7,7 +7,10 @@ import {
 	BugBountyProgramAvailability,
 } from '@/schema/features/security/bug-bounty-program'
 import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
-import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
+import {
+	TransactionSubmissionL2Support,
+	TransactionSubmissionL2Type,
+} from '@/schema/features/self-sovereignty/transaction-submission'
 import { featureSupported, notSupported, supported } from '@/schema/features/support'
 import { comprehensiveFeesShownByDefault } from '@/schema/features/transparency/fee-display'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
@@ -187,16 +190,33 @@ export const baseApp: SoftwareWallet = {
 		},
 		selfSovereignty: {
 			permissionsManagement: null,
+			// Base App is mobile-only and closed-source. It does not ship its own
+			// Ethereum P2P (devp2p) stack, transactions
+			// are broadcast via Coinbase's RPC infrastructure. Users cannot configure
+			// a custom RPC endpoint (chainConfigurability: notSupported above), so
+			// there is no path to self-broadcast via a self-hosted node either.
+			// For L2s: Base + Optimism (OP Stack) and Arbitrum are supported. No in-app force-inclusion UI for any L2, users
+			// would need to interact with L1 bridge contracts directly.
 			transactionSubmission: {
 				l1: {
-					ref: refTodo,
-					selfBroadcastViaDirectGossip: null,
-					selfBroadcastViaSelfHostedNode: null,
+					ref: {
+						explanation:
+							"Base App and base/account-sdk are both built by Coinbase. The SDK (open-source) handles dApp-initiated transactions for Base accounts and uses viem's HTTP RPC transport — it does not implement Ethereum's devp2p protocol. It is reasonable to infer the closed-source Base App mobile binary uses the same approach for its native send/swap features: mobile platform constraints make running a devp2p node impractical, and Coinbase has never advertised doing so. URL pinned to the SDK's HTTP RPC fallback logic.",
+						url: 'https://github.com/base/account-sdk/blob/24ab30c1a42a66bde605a43b1a60045b2fd19fec/packages/account-sdk/src/store/chain-clients/utils.ts',
+					},
+					selfBroadcastViaDirectGossip: notSupported,
+					selfBroadcastViaSelfHostedNode: notSupported,
 				},
 				l2: {
-					[TransactionSubmissionL2Type.arbitrum]: null,
-					[TransactionSubmissionL2Type.opStack]: null,
-					ref: refTodo,
+					[TransactionSubmissionL2Type.arbitrum]:
+						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					[TransactionSubmissionL2Type.opStack]:
+						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
+					ref: {
+						explanation:
+							'Per the open-source base/account-sdk that backs Base App account flows, SUPPORTED_MAINNET_CHAINS includes Base, Optimism (both OP Stack), Arbitrum, Ethereum mainnet, Polygon, Avalanche, BSC, and Zora. The Base App mobile UI confirms multi-L2 support but exposes no force-inclusion flow.',
+						url: 'https://github.com/base/account-sdk/blob/24ab30c1a42a66bde605a43b1a60045b2fd19fec/packages/account-sdk/src/store/chain-clients/utils.ts',
+					},
 				},
 			},
 		},

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -214,7 +214,7 @@ export const baseApp: SoftwareWallet = {
 						TransactionSubmissionL2Support.SUPPORTED_BUT_NO_FORCE_INCLUSION,
 					ref: {
 						explanation:
-							'Per the open-source base/account-sdk that backs Base App account flows, SUPPORTED_MAINNET_CHAINS includes Base, Optimism (both OP Stack), Arbitrum, Ethereum mainnet, Polygon, Avalanche, BSC, and Zora. The Base App mobile UI confirms multi-L2 support but exposes no force-inclusion flow.',
+							'Per the open-source base/account-sdk that backs Base App account flows, SUPPORTED_MAINNET_CHAINS includes Base, Optimism (both OP Stack), Arbitrum, and Ethereum mainnet (plus several other major chains). The Base App mobile UI confirms multi-L2 support but exposes no force-inclusion flow.',
 						url: 'https://github.com/base/account-sdk/blob/24ab30c1a42a66bde605a43b1a60045b2fd19fec/packages/account-sdk/src/store/chain-clients/utils.ts',
 					},
 				},


### PR DESCRIPTION
## Summary

Sets `selfSovereignty.transactionSubmission` for Base App. Previously all four sub-fields were `null`.

## L1 (Ethereum mainnet)

| Field | Value | Why |
|---|---|---|
| `selfBroadcastViaDirectGossip` | `notSupported` | Mobile apps generally don't ship Ethereum devp2p stacks. The open-source [base/account-sdk](https://github.com/base/account-sdk) uses viem's HTTP RPC transport exclusively — no devp2p implementation. Closed-source Base App mobile binary is inferred to follow the same pattern (running a devp2p node would be impractical on mobile and Coinbase has never advertised doing so). |
| `selfBroadcastViaSelfHostedNode` | `notSupported` | `chainConfigurability: notSupported` (already set on beta) means users cannot configure a custom RPC endpoint, so there is no path to point the wallet at a self-hosted node either. |

## L2 (Arbitrum + OP Stack)

| Field | Value | Why |
|---|---|---|
| `arbitrum` | `SUPPORTED_BUT_NO_FORCE_INCLUSION` | Arbitrum is in Base App's default chain list (verified in-app) and listed in `SUPPORTED_MAINNET_CHAINS` in base/account-sdk. No in-app force-inclusion UI. |
| `opStack` | `SUPPORTED_BUT_NO_FORCE_INCLUSION` | Base, Optimism, Zora (all OP Stack) are in the default chain list. No in-app force-inclusion UI. |

## Refs

Both `l1.ref` and `l2.ref` point at [`base/account-sdk/.../chain-clients/utils.ts`](https://github.com/base/account-sdk/blob/24ab30c1a42a66bde605a43b1a60045b2fd19fec/packages/account-sdk/src/store/chain-clients/utils.ts) at a pinned commit. The file shows:
- `getFallbackRpcUrl()` uses viem chain default HTTP RPC URLs (evidences HTTP RPC, not devp2p)
- `SUPPORTED_MAINNET_CHAINS` includes Base, Optimism, Arbitrum, Ethereum mainnet, Polygon, Avalanche, BSC, Zora (evidences the supported chain list)

Each ref's `explanation` field acknowledges that the SDK is the open-source evidence and the closed-source mobile binary's behavior is inferential. See PR discussion thread for the SDK-vs-app distinction.

## Follow-up worth flagging

walletbeat's `TransactionSubmissionL2Type` enum currently only covers `arbitrum` and `opStack`. Other major L2 families (zkSync Era, Linea, Scroll, StarkNet, Polygon zkEVM) aren't modeled — each has its own force-inclusion mechanism (or lack thereof). Worth a separate schema-extension proposal but doesn't block this PR.

## Test plan

- [ ] CI lint, prettier, type-check, and build pass
- [ ] Base App detail page renders the transaction submission section reflecting the new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)