### PR TITLE
Refactor: Security best practices

### DIFF
--- a/resources/docs/features.md
+++ b/resources/docs/features.md
@@ -2782,9 +2782,9 @@ Security best-practices for the mobile app variant.
 
 Security best-practices data for a wallet, broken down by variant.
 
-- `browser` (`WithRef<BrowserSecurityBestPractices> | 'NOT_A_BROWSER_EXTENSION'`): Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent.
-- `mobile` (`WithRef<MobileSecurityBestPractices> | 'NOT_A_MOBILE_APP'`): Mobile app variant. Set to 'NOT_A_MOBILE_APP' if absent.
-- `desktop` (`WithRef<SecurityBestPracticesBase> | 'NOT_A_DESKTOP_APP'`): Desktop app variant. Set to 'NOT_A_DESKTOP_APP' if absent.
+- `browser` (`| WithRef<BrowserSecurityBestPractices> | 'NOT_A_BROWSER_EXTENSION' | 'SOURCE_NOT_AVAILABLE'`): Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
+- `mobile` (`WithRef<MobileSecurityBestPractices> | 'NOT_A_MOBILE_APP' | 'SOURCE_NOT_AVAILABLE'`): Mobile app variant. Set to 'NOT_A_MOBILE_APP' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
+- `desktop` (`WithRef<SecurityBestPracticesBase> | 'NOT_A_DESKTOP_APP' | 'SOURCE_NOT_AVAILABLE'`): Desktop app variant. Set to 'NOT_A_DESKTOP_APP' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
 
 ---
 

--- a/resources/docs/features.md
+++ b/resources/docs/features.md
@@ -2606,6 +2606,7 @@ How the wallet stores the user's private key.
 - `HARDWARE_SECURITY_MODULE` = `'HARDWARE_SECURITY_MODULE'`: The key is stored inside a hardware security module or secure enclave that prevents key extraction by other software.
 - `OS_SANDBOXED_PLAINTEXT` = `'OS_SANDBOXED_PLAINTEXT'`: The key is stored in plaintext, but in OS-sandboxed app storage that other apps and processes cannot read.
 - `PASSKEY_MANAGED` = `'PASSKEY_MANAGED'`: No private key is stored on the device. The wallet uses passkey-managed smart contract accounts
+- `NOT_VERIFIABLE` = `'NOT_VERIFIABLE'`: The key storage mechanism cannot be determined because the wallet's source code is not publicly available.
 
 ---
 
@@ -2616,6 +2617,7 @@ The entropy source used when generating the wallet's private key.
 - `OS_CSPRNG` = `'OS_CSPRNG'`: OS-provided Cryptographically Secure Pseudorandom RNG.
 - `HARDWARE_ENTROPY` = `'HARDWARE_ENTROPY'`: Dedicated hardware entropy source.
 - `LIBRARY_RNG` = `'LIBRARY_RNG'`: A library-provided RNG whose quality is not independently verified.
+- `NOT_VERIFIABLE` = `'NOT_VERIFIABLE'`: The RNG source cannot be determined because the wallet's source code is not publicly available.
 
 ---
 
@@ -2782,7 +2784,10 @@ Security best-practices for the mobile app variant.
 
 Security best-practices data for a wallet, broken down by variant.
 
-- `browser` (`| WithRef<BrowserSecurityBestPractices> | 'NOT_A_BROWSER_EXTENSION' | 'SOURCE_NOT_AVAILABLE'`): Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
+- `browser` (`| WithRef<BrowserSecurityBestPractices> | 'NOT_A_BROWSER_EXTENSION' | 'SOURCE_NOT_AVAILABLE'`): Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and no data can be obtained at all.
+
+  For closed-source wallets whose browser extension manifest is publicly available (e.g. via the Chrome Web Store), fill in actual manifest data and setting keyStorageMechanism / secureRng to KeyStorageMechanism.NOT_VERIFIABLE / SecureRngSource.NOT_VERIFIABLE
+
 - `mobile` (`WithRef<MobileSecurityBestPractices> | 'NOT_A_MOBILE_APP' | 'SOURCE_NOT_AVAILABLE'`): Mobile app variant. Set to 'NOT_A_MOBILE_APP' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
 - `desktop` (`WithRef<SecurityBestPracticesBase> | 'NOT_A_DESKTOP_APP' | 'SOURCE_NOT_AVAILABLE'`): Desktop app variant. Set to 'NOT_A_DESKTOP_APP' if absent. Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security properties cannot be independently verified.
 

--- a/src/schema/attributes/security/security-best-practices.ts
+++ b/src/schema/attributes/security/security-best-practices.ts
@@ -985,7 +985,7 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 			),
 			exampleRating(
 				mdParagraph(
-					"The wallet is closed-source. For browser wallets with a public extension manifest, set `keyStorageMechanism` and `secureRng` to `NOT_VERIFIABLE` while filling in actual manifest data. For mobile/desktop or when no data is obtainable at all, set the variant to `'SOURCE_NOT_AVAILABLE'`.",
+					'The wallet is closed-source. Security properties such as key storage, random number generation, and manifests cannot be independently verified.',
 				),
 				sourceNotAvailable(EvaluationContext.forTest(() => securityBestPractices)),
 			),

--- a/src/schema/attributes/security/security-best-practices.ts
+++ b/src/schema/attributes/security/security-best-practices.ts
@@ -44,6 +44,27 @@ import { aggregateVariantEvaluations, exempt, pickWorstRating, unrated } from '.
 
 export type SecurityBestPracticesValue = null
 
+function sourceNotAvailable(
+	ctx: EvaluationContext<SecurityBestPracticesValue>,
+): Evaluation<SecurityBestPracticesValue> {
+	return ctx.build({
+		outcome: {
+			id: 'source_not_available',
+			rating: Rating.FAIL,
+			displayName: 'Source code not available',
+			shortExplanation: mdSentence(
+				"{{WALLET_NAME}}'s source code is not publicly available, so security best practices cannot be independently verified.",
+			),
+		},
+		details: paragraph(
+			'{{WALLET_NAME}} does not make its source code publicly available. As a result, it is not possible to independently verify how it handles key storage, random number generation, or deployment hardening.',
+		),
+		howToImprove: mdParagraph(
+			'{{WALLET_NAME}} should open-source its code so that key storage, random number generation, and deployment hardening can be independently verified.',
+		),
+	})
+}
+
 function keyStoragePass(
 	ctx: EvaluationContext<SecurityBestPracticesValue>,
 	mechanism: KeyStorageMechanism.HARDWARE_SECURITY_MODULE | KeyStorageMechanism.PASSKEY_MANAGED,
@@ -922,6 +943,12 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 					},
 				),
 			),
+			exampleRating(
+				mdParagraph(
+					"The wallet's source code is not publicly available, so key storage, RNG, and deployment hardening cannot be independently verified.",
+				),
+				sourceNotAvailable(EvaluationContext.forTest(() => securityBestPractices)),
+			),
 		],
 	},
 	aggregate: aggregateVariantEvaluations<SecurityBestPracticesValue>,
@@ -959,6 +986,10 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 				return exempt(ctx, sentence('This wallet does not have a browser extension variant.'))
 			}
 
+			if (securityBestPractices.browser === 'SOURCE_NOT_AVAILABLE') {
+				return sourceNotAvailable(ctx)
+			}
+
 			const browser = ctx.popRefs<BrowserSecurityBestPractices>(securityBestPractices.browser)
 
 			subEvaluations.push(
@@ -976,6 +1007,10 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 				return exempt(ctx, sentence('This wallet does not have a mobile app variant.'))
 			}
 
+			if (securityBestPractices.mobile === 'SOURCE_NOT_AVAILABLE') {
+				return sourceNotAvailable(ctx)
+			}
+
 			const mobile = ctx.popRefs<MobileSecurityBestPractices>(securityBestPractices.mobile)
 
 			subEvaluations.push(
@@ -988,6 +1023,10 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 		if (variant === Variant.DESKTOP) {
 			if (securityBestPractices.desktop === 'NOT_A_DESKTOP_APP') {
 				return exempt(ctx, sentence('This wallet does not have a desktop app variant.'))
+			}
+
+			if (securityBestPractices.desktop === 'SOURCE_NOT_AVAILABLE') {
+				return sourceNotAvailable(ctx)
 			}
 
 			const desktop = ctx.popRefs<SecurityBestPracticesBase>(securityBestPractices.desktop)

--- a/src/schema/attributes/security/security-best-practices.ts
+++ b/src/schema/attributes/security/security-best-practices.ts
@@ -131,6 +131,27 @@ function keyStorageFail(
 	})
 }
 
+function keyStorageUnverifiable(
+	ctx: EvaluationContext<SecurityBestPracticesValue>,
+): Evaluation<SecurityBestPracticesValue> {
+	return ctx.build({
+		outcome: {
+			id: 'key_storage_not_verifiable',
+			rating: Rating.FAIL,
+			displayName: 'Key storage cannot be verified',
+			shortExplanation: mdSentence(
+				"{{WALLET_NAME}}'s source code is not publicly available, so the key storage mechanism cannot be independently verified.",
+			),
+		},
+		details: paragraph(
+			'{{WALLET_NAME}} does not make its source code publicly available. As a result, it is not possible to independently verify how it stores private keys.',
+		),
+		howToImprove: mdParagraph(
+			'{{WALLET_NAME}} should open-source its code so that its key storage mechanism can be independently verified.',
+		),
+	})
+}
+
 function evaluateKeyStorage(
 	ctx: EvaluationContext<SecurityBestPracticesValue>,
 	mechanism: KeyStorageMechanism,
@@ -144,6 +165,8 @@ function evaluateKeyStorage(
 			return keyStoragePartial(ctx, mechanism)
 		case KeyStorageMechanism.ENCRYPTED_WITH_USER_SECRET_WEAK_KDF:
 			return keyStorageFail(ctx)
+		case KeyStorageMechanism.NOT_VERIFIABLE:
+			return keyStorageUnverifiable(ctx)
 		default:
 			return keyStorageFail(ctx)
 	}
@@ -184,6 +207,23 @@ function evaluateSecureRng(
 				),
 				howToImprove: mdParagraph(
 					"{{WALLET_NAME}} should use the operating system's CSPRNG for key generation.",
+				),
+			})
+		case SecureRngSource.NOT_VERIFIABLE:
+			return ctx.build({
+				outcome: {
+					id: 'rng_not_verifiable',
+					rating: Rating.FAIL,
+					displayName: 'RNG source cannot be verified',
+					shortExplanation: mdSentence(
+						"{{WALLET_NAME}}'s source code is not publicly available, so the entropy source used for key generation cannot be independently verified.",
+					),
+				},
+				details: paragraph(
+					'{{WALLET_NAME}} does not make its source code publicly available. As a result, it is not possible to independently verify what entropy source it uses for key generation.',
+				),
+				howToImprove: mdParagraph(
+					'{{WALLET_NAME}} should open-source its code so that the entropy source used for key generation can be independently verified.',
 				),
 			})
 		default:
@@ -945,7 +985,7 @@ export const securityBestPractices: Attribute<SecurityBestPracticesValue> = {
 			),
 			exampleRating(
 				mdParagraph(
-					"The wallet's source code is not publicly available, so key storage, RNG, and deployment hardening cannot be independently verified.",
+					"The wallet is closed-source. For browser wallets with a public extension manifest, set `keyStorageMechanism` and `secureRng` to `NOT_VERIFIABLE` while filling in actual manifest data. For mobile/desktop or when no data is obtainable at all, set the variant to `'SOURCE_NOT_AVAILABLE'`.",
 				),
 				sourceNotAvailable(EvaluationContext.forTest(() => securityBestPractices)),
 			),

--- a/src/schema/features/security/security-best-practices.ts
+++ b/src/schema/features/security/security-best-practices.ts
@@ -433,12 +433,27 @@ export interface MobileSecurityBestPractices extends SecurityBestPracticesBase {
  * Security best-practices data for a wallet, broken down by variant.
  */
 export interface SecurityBestPracticesData {
-	/** Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent. */
-	browser: WithRef<BrowserSecurityBestPractices> | 'NOT_A_BROWSER_EXTENSION'
+	/**
+	 * Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent.
+	 * Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security
+	 * properties cannot be independently verified.
+	 */
+	browser:
+		| WithRef<BrowserSecurityBestPractices>
+		| 'NOT_A_BROWSER_EXTENSION'
+		| 'SOURCE_NOT_AVAILABLE'
 
-	/** Mobile app variant. Set to 'NOT_A_MOBILE_APP' if absent. */
-	mobile: WithRef<MobileSecurityBestPractices> | 'NOT_A_MOBILE_APP'
+	/**
+	 * Mobile app variant. Set to 'NOT_A_MOBILE_APP' if absent.
+	 * Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security
+	 * properties cannot be independently verified.
+	 */
+	mobile: WithRef<MobileSecurityBestPractices> | 'NOT_A_MOBILE_APP' | 'SOURCE_NOT_AVAILABLE'
 
-	/** Desktop app variant. Set to 'NOT_A_DESKTOP_APP' if absent. */
-	desktop: WithRef<SecurityBestPracticesBase> | 'NOT_A_DESKTOP_APP'
+	/**
+	 * Desktop app variant. Set to 'NOT_A_DESKTOP_APP' if absent.
+	 * Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security
+	 * properties cannot be independently verified.
+	 */
+	desktop: WithRef<SecurityBestPracticesBase> | 'NOT_A_DESKTOP_APP' | 'SOURCE_NOT_AVAILABLE'
 }

--- a/src/schema/features/security/security-best-practices.ts
+++ b/src/schema/features/security/security-best-practices.ts
@@ -34,6 +34,12 @@ export enum KeyStorageMechanism {
 	 * smart contract accounts
 	 */
 	PASSKEY_MANAGED = 'PASSKEY_MANAGED',
+
+	/**
+	 * The key storage mechanism cannot be determined because the wallet's
+	 * source code is not publicly available.
+	 */
+	NOT_VERIFIABLE = 'NOT_VERIFIABLE',
 }
 
 /**
@@ -48,6 +54,12 @@ export enum SecureRngSource {
 
 	/** A library-provided RNG whose quality is not independently verified. */
 	LIBRARY_RNG = 'LIBRARY_RNG',
+
+	/**
+	 * The RNG source cannot be determined because the wallet's source code
+	 * is not publicly available.
+	 */
+	NOT_VERIFIABLE = 'NOT_VERIFIABLE',
 }
 
 /**
@@ -435,8 +447,13 @@ export interface MobileSecurityBestPractices extends SecurityBestPracticesBase {
 export interface SecurityBestPracticesData {
 	/**
 	 * Browser extension variant. Set to 'NOT_A_BROWSER_EXTENSION' if absent.
-	 * Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and security
-	 * properties cannot be independently verified.
+	 * Set to 'SOURCE_NOT_AVAILABLE' if the wallet is closed-source and no data
+	 * can be obtained at all.
+	 *
+	 * For closed-source wallets whose browser extension manifest is publicly
+	 * available (e.g. via the Chrome Web Store), fill in actual
+	 * manifest data and setting keyStorageMechanism / secureRng to
+	 * KeyStorageMechanism.NOT_VERIFIABLE / SecureRngSource.NOT_VERIFIABLE
 	 */
 	browser:
 		| WithRef<BrowserSecurityBestPractices>


### PR DESCRIPTION
# Refactor: Security best practices

Closed-source wallets had no way to populate `securityBestPractices`, leaving them permanently gray (`UNRATED`). This looks like Walletbeat "not being able to gather data" rather than the wallet being closed-source.

Fixed by adding two mechanisms:

- **`SOURCE_NOT_AVAILABLE`** on variant fields (`browser`, `mobile`, `desktop`): returns as `FAIL` when **no data** is obtainable at all
- **`KeyStorageMechanism.NOT_VERIFIABLE` / `SecureRngSource.NOT_VERIFIABLE`**: allows browser wallets fill in real manifest data (which is always public in extension stores) while marking the enum fields as `FAIL`
  - Allows users / researches to fill in individual data (manifest data) regardless if the source code is not publicly available.

A sample wallet data would look like:

```ts
securityBestPractices: {
  browser: {
	  ref: refTodo,
	  browserExtensionHardening: parseBrowserExtensionManifest(metamaskRawExtManifest),
	  keyStorageMechanism: KeyStorageMechanism.NOT_VERIFIABLE,
	  secureRng: SecureRngSource.NOT_VERIFIABLE,
  },
  desktop: 'NOT_A_DESKTOP_APP',
  mobile: 'SOURCE_NOT_AVAILABLE',
},
```

Fixes #746