### PR TITLE
Data: fill in monetization strategies for Base App

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -159,19 +159,25 @@ export const baseApp: SoftwareWallet = {
 				license: SourceNotAvailableLicense.PROPRIETARY,
 			},
 		},
+		// Coinbase is the parent company funding Base App development. Public via
+		// direct listing on Nasdaq (COIN, April 2021), so publicOffering captures
+		// the public-equity-funded nature. Base App's in-app swap UI displays a
+		// separate Coinbase-attributed fee, so transparentConvenienceFees applies.
+		// No governance token tied to Base App or Coinbase. SEC filings provide
+		// public revenue breakdown.
 		monetization: {
 			ref: 'https://www.sec.gov/edgar/browse/?CIK=0001679788',
 			revenueBreakdownIsPublic: true,
 			strategies: {
-				donations: null,
-				ecosystemGrants: null,
-				governanceTokenLowFloat: null,
-				governanceTokenMostlyDistributed: null,
-				hiddenConvenienceFees: null,
-				publicOffering: null,
-				selfFunded: null,
-				transparentConvenienceFees: null,
-				ventureCapital: null,
+				donations: false,
+				ecosystemGrants: false,
+				governanceTokenLowFloat: false,
+				governanceTokenMostlyDistributed: false,
+				hiddenConvenienceFees: false,
+				publicOffering: true,
+				selfFunded: false,
+				transparentConvenienceFees: true,
+				ventureCapital: false,
 			},
 		},
 		// Base App has no UI for adding additional Ethereum addresses to a single


### PR DESCRIPTION
## Summary

Fills in the nine `monetization.strategies` booleans for Base App. All were previously `null`. The existing `ref` (Coinbase SEC filings) and `revenueBreakdownIsPublic: true` are unchanged.

## Strategy values

| Strategy | Value | Why |
|---|---|---|
| `publicOffering` | **`true`** | Coinbase Inc. is publicly traded on Nasdaq (COIN) via direct listing in April 2021. |
| `transparentConvenienceFees` | **`true`** | Base App's in-app swap UI displays a separate Coinbase-attributed fee on swaps (verified in-app). |
| `ventureCapital` | `false` | Coinbase was VC-funded pre-IPO (YC, USV, a16z) but is no longer, the repo convention treats this as current funding state. |
| `selfFunded` | `false` | Coinbase had VC, IPO'd, has issued debt. Not bootstrapped. |
| `donations` | `false` | Not applicable to a Coinbase product. |
| `ecosystemGrants` | `false` | Not how Coinbase funds wallet development. |
| `hiddenConvenienceFees` | `false` | No evidence of undisclosed markups. |
| `governanceTokenLowFloat` | `false` | No governance token tied to Base App or Coinbase. |
| `governanceTokenMostlyDistributed` | `false` | Same. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)