### PR TITLE
Talks: Create proposal for Ethereum day

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -396,7 +396,7 @@
 		"Soulbound",
 		"splittable",
 		"stablecoin",
-		"Stablecoins",
+		"stablecoins",
 		"starkware",
 		"Stax",
 		"Stańczak",

--- a/.cspell.json
+++ b/.cspell.json
@@ -396,6 +396,7 @@
 		"Soulbound",
 		"splittable",
 		"stablecoin",
+		"Stablecoins",
 		"starkware",
 		"Stax",
 		"Stańczak",

--- a/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
+++ b/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
@@ -26,6 +26,7 @@ Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 - [ ] Lightning talk (8 mins)
 - [ ] Talk (20 mins)
 - [ ] Panel Discussion (40 mins)
+
 9. What topic is your talk mostly related to? (maximum 2 answers)
 
 - [ ] Censorship Resistance & Digital Freedom
@@ -43,6 +44,7 @@ Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 - [ ] Art, NFTs, Gaming & Digital Culture
 - [ ] Regenerative Finance (ReFi) & Impact
 - [ ] Other
+
 10. Title of the Talk
 11. Abstract of the Talk
 12. Please briefly describe why you think this topic is relevant and would add value to this event.

--- a/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
+++ b/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
@@ -1,0 +1,48 @@
+## About
+
+Ethereum was built as an enduring infrastructure for a free, open, and permissionless world, where users retain control over their digital lives and self-sovereignty.
+
+Join us in Berlin for a full day of sessions with speakers from the Ethereum Foundation and the broader ecosystem, exploring Ethereum's future - its technical direction, core values, and the road ahead.
+
+## Speaker Application
+
+On June 15, 2026 at Funkhaus, we will host focused sessions exploring Ethereum’s future, technical direction, and core values as part of the Berlin Blockchain Week.
+
+We have a limited number of guest speaking slots available. Proposals should align with CROPS topics, including censorship resistance, open source technology, privacy, and security.
+
+Please note that submitting this application does not guarantee a speaking opportunity. If selected, you will receive a follow-up email with next steps.
+
+Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
+
+1. What is your name or nickname?
+2. What is your email address?
+3. Please provide your Twitter/Farcaster/Lens/GitHub URL. (Optional)
+4. Please provide the name of the project or initiative you're primarily involved with.
+5. Please provide its website or other resources where we can learn more about it.
+6. Please share a short bio and describe your role or involvement in your current project.
+7. Please provide the name and date of the last event where you gave a presentation or conducted a workshop. If available, please include the URL of the recording as well.
+8. Please select your preferred Session Type
+
+- [ ] Lightning talk (8 mins)
+- [ ] Talk (20 mins)
+- [ ] Panel Discussion (40 mins)
+9. What topic is your talk mostly related to? (maximum 2 answers)
+
+- [ ] Censorship Resistance & Digital Freedom
+- [ ] Open Source Software & Infrastructure
+- [ ] Privacy & Self-Sovereignty
+- [ ] Security Research & Network Resilience
+- [ ] Core Protocol R&D, Cryptography & Ethereum Infrastructure
+- [ ] Smart Contracts, Developer Tools & Libraries
+- [ ] Decentralized Finance (DeFi), Stablecoins & On-Chain Payments
+- [ ] Identity, Reputation & Credentials
+- [ ] DAOs & Decentralized Governance
+- [ ] AI x Ethereum / Decentralized AI
+- [ ] Public Goods Funding & Coordination
+- [ ] Local Community Building & Education
+- [ ] Art, NFTs, Gaming & Digital Culture
+- [ ] Regenerative Finance (ReFi) & Impact
+- [ ] Other
+10. Title of the Talk
+11. Abstract of the Talk
+12. Please briefly describe why you think this topic is relevant and would add value to this event.

--- a/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
+++ b/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
@@ -6,7 +6,7 @@ Join us in Berlin for a full day of sessions with speakers from the Ethereum Fou
 
 ## Speaker Application
 
-On June 15, 2026 at Funkhaus, we will host focused sessions exploring Ethereum’s future, technical direction, and core values as part of the Berlin Blockchain Week.
+On June 15, 2026 at Funkhaus, we will host focused sessions exploring Ethereum's future, technical direction, and core values as part of the Berlin Blockchain Week.
 
 We have a limited number of guest speaking slots available. Proposals should align with CROPS topics, including censorship resistance, open source technology, privacy, and security.
 
@@ -14,13 +14,19 @@ Please note that submitting this application does not guarantee a speaking oppor
 
 Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 
-1. What is your name or nickname?
-2. What is your email address?
-3. Please provide your Twitter/Farcaster/Lens/GitHub URL. (Optional)
-4. Please provide the name of the project or initiative you're primarily involved with. Walletbeat
-5. Please provide its website or other resources where we can learn more about it.
+1. What is your name or nickname? `polymutex`
+2. What is your email address? `<redacted>`
+3. Please provide your Twitter/Farcaster/Lens/GitHub URL. (Optional) `https://x.com/polymutex`
+4. Please provide the name of the project or initiative you're primarily involved with. `Walletbeat`
+5. Please provide its website or other resources where we can learn more about it. `https://walletbeat.eth.limo`
 6. Please share a short bio and describe your role or involvement in your current project.
+
+polymutex works on Walletbeat, an open-source database and rating system for Ethereum wallets following Ethereum values.
+
 7. Please provide the name and date of the last event where you gave a presentation or conducted a workshop. If available, please include the URL of the recording as well.
+
+Presented together with Nicolas Consigny at Trustless (2025-11): https://www.youtube.com/watch?v=sU3Q5aLwHSY
+
 8. Please select your preferred Session Type
 
 - [ ] Lightning talk (8 mins)
@@ -45,18 +51,18 @@ Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 - [ ] Regenerative Finance (ReFi) & Impact
 - [ ] Other
 
-10. Title of the Talk: CROPS for wallets: rating the Ethereum wallet ecosystem on its own values
+10. Title of the Talk: `CROPS for wallets: Rating Ethereum wallet ecosystem on its own values`
 
 11. Abstract of the Talk:
 
-Ethereum is built around a clear set of values: censorship resistance, openness, privacy, and security. And through wallets, you experience Ethereum, but most wallets today don't live up to those values.
+Ethereum is built around a clear set of values: Censorship Resistance, Openness, Privacy, and Security. Users experience Ethereum through wallets, yet most wallets today don't live up to these very values.
 
-Walletbeat is an open framework that evaluates Ethereum wallets through CROPS criteria. L2BEAT, for wallets.
+Walletbeat is L2BEAT for wallets: An open framework that evaluates Ethereum wallets through CROPS values.
 
-This talk walks through what each CROPS dimension actually means in a wallet context, what the current landscape looks like, and what the current obstacles are for wallets to fully inherit Ethereum values. We’ll cover where the Ethereum wallet ecosystem is making progress, where it’s stuck, and what meaningful CROPS alignment actually looks like in practice for modern wallets.
+This talk walks through how CROPS values map to wallets, what the current wallet landscape looks like, and what obstacles exist for wallets to fully embody Ethereum values. We'll cover where the Ethereum wallet ecosystem is making progress, where it's stuck, and what meaningful CROPS alignment actually looks like in practice for modern wallets.
 
 12. Please briefly describe why you think this topic is relevant and would add value to this event.
 
-Wallets are Ethereum's front door. Every user who interacts with Ethereum does so through wallets. If wallets don't embody CROPS values, those values are useless to users no matter how strong the Ethereum values are.
+Wallets are how users use and experience Ethereum. If wallets don't provide users with CROPS guarantees and properties, these values are effectively meaningless to users no matter how robust their implementation is at the protocol/consensus level.
 
-CROPS turns those values into something more practical and measurable for the wallet ecosystem. The goal is to give attendees a clearer picture of the current wallet landscape, the tradeoffs wallets are making today, and a framework for evaluating whether wallets truly uphold Ethereum’s values.
+Walletbeat turns CROPS values into practical and measurable objectives for the wallet ecosystem. The goal of the talk is to give attendees a clearer picture of the current wallet landscape, the tradeoffs wallets and users are making today, and a framework for evaluating whether wallets truly uphold Ethereum's values now and in the future.

--- a/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
+++ b/resources/talks/2026-06-eth-berlin/ethereum-day/proposal.md
@@ -17,21 +17,21 @@ Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 1. What is your name or nickname?
 2. What is your email address?
 3. Please provide your Twitter/Farcaster/Lens/GitHub URL. (Optional)
-4. Please provide the name of the project or initiative you're primarily involved with.
+4. Please provide the name of the project or initiative you're primarily involved with. Walletbeat
 5. Please provide its website or other resources where we can learn more about it.
 6. Please share a short bio and describe your role or involvement in your current project.
 7. Please provide the name and date of the last event where you gave a presentation or conducted a workshop. If available, please include the URL of the recording as well.
 8. Please select your preferred Session Type
 
 - [ ] Lightning talk (8 mins)
-- [ ] Talk (20 mins)
+- [x] Talk (20 mins)
 - [ ] Panel Discussion (40 mins)
 
 9. What topic is your talk mostly related to? (maximum 2 answers)
 
-- [ ] Censorship Resistance & Digital Freedom
+- [x] Censorship Resistance & Digital Freedom
 - [ ] Open Source Software & Infrastructure
-- [ ] Privacy & Self-Sovereignty
+- [x] Privacy & Self-Sovereignty
 - [ ] Security Research & Network Resilience
 - [ ] Core Protocol R&D, Cryptography & Ethereum Infrastructure
 - [ ] Smart Contracts, Developer Tools & Libraries
@@ -45,6 +45,18 @@ Follow the Berlin Ethereum Meetup account to learn more and stay up to date!
 - [ ] Regenerative Finance (ReFi) & Impact
 - [ ] Other
 
-10. Title of the Talk
-11. Abstract of the Talk
+10. Title of the Talk: CROPS for wallets: rating the Ethereum wallet ecosystem on its own values
+
+11. Abstract of the Talk:
+
+Ethereum is built around a clear set of values: censorship resistance, openness, privacy, and security. And through wallets, you experience Ethereum, but most wallets today don't live up to those values.
+
+Walletbeat is an open framework that evaluates Ethereum wallets through CROPS criteria. L2BEAT, for wallets.
+
+This talk walks through what each CROPS dimension actually means in a wallet context, what the current landscape looks like, and what the current obstacles are for wallets to fully inherit Ethereum values. We’ll cover where the Ethereum wallet ecosystem is making progress, where it’s stuck, and what meaningful CROPS alignment actually looks like in practice for modern wallets.
+
 12. Please briefly describe why you think this topic is relevant and would add value to this event.
+
+Wallets are Ethereum's front door. Every user who interacts with Ethereum does so through wallets. If wallets don't embody CROPS values, those values are useless to users no matter how strong the Ethereum values are.
+
+CROPS turns those values into something more practical and measurable for the wallet ecosystem. The goal is to give attendees a clearer picture of the current wallet landscape, the tradeoffs wallets are making today, and a framework for evaluating whether wallets truly uphold Ethereum’s values.


### PR DESCRIPTION
They're mainly advocating for CROPS as of their speaker application form:

> We have a limited number of guest speaking slots available. Proposals should align with CROPS topics, including censorship resistance, open source technology, privacy, and security.

Rough topics / ideas I can think of for Ethereum day:
- Why open source matters and what "self-sovereignty" means for wallets.
  - Verifiability. Not verifiable = a very red flag for wallets. Verifiability is crypto's nature and it should be reflected by wallets.
- Hidden centralization of wallet ecosystems
  - Servers, RPCs. If wallet teams stop tomorrow, can we still use it? Introduce the walkaway test.