### PR TITLE
Data: Add Rainbow releaseTransparency.hasPublicChangelog

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -381,7 +381,20 @@ export const rainbow: SoftwareWallet = {
 				artifactSigning: null,
 				dependencyLocking: null,
 				dependencyVulnerabilityScanning: null,
-				hasPublicChangelog: null,
+				hasPublicChangelog: {
+					[Variant.BROWSER]: supported({
+						ref: {
+							explanation: 'Rainbow publishes browser extension release notes via GitHub Releases.',
+							url: 'https://github.com/rainbow-me/browser-extension/releases',
+						},
+					}),
+					[Variant.MOBILE]: supported({
+						ref: {
+							explanation: 'Rainbow publishes mobile wallet release notes via GitHub Releases.',
+							url: 'https://github.com/rainbow-me/rainbow/releases',
+						},
+					}),
+				},
 				hermeticBuilds: null,
 				repositoryChangeControls: null,
 				reproducibleBuilds: null,


### PR DESCRIPTION
## Summary

Sets `releaseTransparency.hasPublicChangelog` for Rainbow to `supported`.

Rainbow publishes tagged GitHub Releases with detailed release notes for both of its open-source clients:

- **Browser extension** — [`rainbow-me/browser-extension/releases`](https://github.com/rainbow-me/browser-extension/releases) (latest `v1.6.11`, ~2KB of notes)
- **Mobile wallet** — [`rainbow-me/rainbow/releases`](https://github.com/rainbow-me/rainbow/releases) (latest `v2.0.34`, ~5KB of notes)

Both refs point at the evergreen `/releases` index rather than a tag-pinned blob, so they stay valid as new versions ship.

## Scope

First in a series of small, focused commits filling in Rainbow's open `releaseTransparency` and related attributes. Kept deliberately narrow (one attribute) for easy review. Follow-ups will cover `dependencyLocking`, `dependencyVulnerabilityScanning`, `artifactSigning`, etc.

## Validation

- `eslint data/software-wallets/rainbow.ts` — clean
- `cspell` on the file — clean
- `prettier` — file unchanged from formatted state

🤖 Generated with [Claude Code](https://claude.com/claude-code)