### PR TITLE
Data: Add Rainbow releaseTransparency.dependencyLocking

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -379,7 +379,25 @@ export const rainbow: SoftwareWallet = {
 			},
 			releaseTransparency: {
 				artifactSigning: null,
-				dependencyLocking: null,
+				dependencyLocking: supported({
+					ref: [
+						{
+							explanation:
+								'The browser extension CI runs `yarn install --immutable` and a dedicated `yarn check-lockfile` step, failing the build if yarn.lock is out of sync.',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/e600feb293b94aa16f7bb54aef9fa58f00c1422e/.github/workflows/build.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet Android release build installs dependencies with `yarn install --immutable`, which fails if yarn.lock would change.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/d79896d683cfa0ef8a8a6133057c4060acdbe63c/.github/workflows/android-play-store.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet iOS release build installs dependencies with `yarn install --immutable`, which fails if yarn.lock would change.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/4782c0a9010ea5783761144fb46ef0b55f4cc572/.github/actions/ios-build/action.yaml',
+						},
+					],
+				}),
 				dependencyVulnerabilityScanning: null,
 				hasPublicChangelog: null,
 				hermeticBuilds: null,


### PR DESCRIPTION
## Summary

Sets `releaseTransparency.dependencyLocking` for Rainbow to `supported`.

Both Rainbow repositories commit a `yarn.lock` and enforce it across **every** build path using Yarn Berry's `--immutable` flag, which fails the build if resolved dependencies don't exactly match the lockfile:

| Build path | Enforcement |
|------------|-------------|
| Browser extension (`build.yml`) | `yarn install --immutable` + dedicated `yarn check-lockfile` step |
| Mobile — Android release (`android-play-store.yml`) | `yarn install --immutable` |
| Mobile — iOS release (`ios-build` composite action) | `yarn install --immutable` |

All refs are pinned to commit hashes. The two mobile refs cite the actual release pipelines (not just the unit-test CI), so the verdict reflects what ships to users.

## Validation

- `eslint data/software-wallets/rainbow.ts` — clean
- `cspell` on the file — clean
- `prettier --check` on the file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)