### PR TITLE
Data: Add Rainbow releaseTransparency.dependencyVulnerabilityScanning

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -380,7 +380,20 @@ export const rainbow: SoftwareWallet = {
 			releaseTransparency: {
 				artifactSigning: null,
 				dependencyLocking: null,
-				dependencyVulnerabilityScanning: null,
+				dependencyVulnerabilityScanning: supported({
+					ref: [
+						{
+							explanation:
+								'The browser extension runs `yarn audit:ci` (audit-ci) as a CI step, failing the build on vulnerable dependencies.',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/e600feb293b94aa16f7bb54aef9fa58f00c1422e/.github/workflows/build.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet runs `yarn audit-ci` as a CI step, failing the build on vulnerable dependencies.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/c203ae4e9cb48627310f37ebbab05dbb43211286/.github/workflows/unit-test.yml',
+						},
+					],
+				}),
 				hasPublicChangelog: null,
 				hermeticBuilds: null,
 				repositoryChangeControls: null,


### PR DESCRIPTION
## Summary

Sets `releaseTransparency.dependencyVulnerabilityScanning` for Rainbow to `supported`.

Both Rainbow repositories scan dependencies for known vulnerabilities as a **build-gating CI step** via `audit-ci`, which queries advisory databases and fails the build when a vulnerable dependency is present:

| Repo | CI step |
|------|---------|
| Browser extension | `yarn audit:ci` in `build.yml` |
| Mobile wallet | `yarn audit-ci --config audit-ci.jsonc` in `unit-test.yml` |

Both refs are pinned to commit hashes.

### Note on scope of evidence

Both repos also have `.github/dependabot.yml`, but Dependabot is intentionally **not** cited here: it runs out-of-band as a GitHub platform feature rather than inside the CI/release workflow, and it gates nothing. The attribute asks specifically about scanning "configured in CI/release workflows,".


## Validation

- `pnpm check:astro` (tsc) — 0 errors
- `eslint data/software-wallets/rainbow.ts` — clean
- `cspell` on the file — clean
- `prettier --check` on the file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)