### PR TITLE
Data: Mark Rainbow releaseTransparency.artifactSigning notSupported

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -378,7 +378,12 @@ export const rainbow: SoftwareWallet = {
 				uniswapUSDCToEtherSwap: null,
 			},
 			releaseTransparency: {
-				artifactSigning: null,
+				// Rainbow signs release artifacts only with the mandatory platform/store keys
+				// (Apple certificates via fastlane match; the Android upload keystore). No
+				// independent signatures or attestations are published to a verifiable channel:
+				// GitHub releases carry no assets, and the CI/publish workflows use no sigstore,
+				// cosign, GitHub build attestation, or GPG signing.
+				artifactSigning: notSupported,
 				dependencyLocking: null,
 				dependencyVulnerabilityScanning: null,
 				hasPublicChangelog: null,


### PR DESCRIPTION
## Summary

Sets `releaseTransparency.artifactSigning` for Rainbow to `notSupported`.

The attribute asks whether release artifacts are cryptographically signed **and those signatures are published** so users can independently verify them (publication channels: `GITHUB_RELEASE | SIGSTORE_REKOR | ONCHAIN | OTHER_PUBLIC`). 

Investigation of both Rainbow clients:

- **GitHub releases** (`rainbow-me/browser-extension`, `rainbow-me/rainbow`) attach **no assets** — there are no published signed artifacts or attestations.
- **CI/publish workflows** contain no `sigstore`, `cosign`, GitHub build attestation (`attest-build-provenance`), or GPG signing. (The Android workflow has a "Record build provenance" step, but it only writes the commit hash/version as human-readable text to the Actions job summary — not a cryptographic, published attestation.)
- **Mobile** artifacts are signed only with platform keys — Apple certificates via `fastlane match` and the Android upload keystore — which are embedded for store distribution and verified by Apple/Google, never published to a verifiable channel.

## Validation

- `pnpm check:astro` (tsc) — 0 errors
- `eslint` / `cspell` / `prettier` on the file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)