### PR TITLE
Data: Mark Rainbow releaseTransparency.reproducibleBuilds notSupported

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -384,7 +384,11 @@ export const rainbow: SoftwareWallet = {
 				hasPublicChangelog: null,
 				hermeticBuilds: null,
 				repositoryChangeControls: null,
-				reproducibleBuilds: null,
+				// Rainbow publishes no reproducible-build tooling, documentation, or
+				// verification process, and its release builds are not hermetic (they fetch
+				// inputs from the network during the build), so an independent party cannot
+				// rebuild the released artifacts and confirm a bit-for-bit match.
+				reproducibleBuilds: notSupported,
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

Sets `releaseTransparency.reproducibleBuilds` for Rainbow to `notSupported`.

Reproducible builds mean an independent party can rebuild from source and obtain a bit-for-bit identical artifact. Rainbow does not meet this:

- **No reproducible-build tooling or flags** in any build workflow (no `SOURCE_DATE_EPOCH`, deterministic-build configuration, etc.).
- **No documentation or verification process** for reproducing a release (code search for "reproducible build" returns nothing in either repo).
- **Builds are not hermetic** (see #797) — they fetch inputs from the network during the build, making outputs non-deterministic.
- **GitHub releases carry no assets**, so there is nothing published to independently rebuild against and compare.

Per the Base App precedent for negative-by-absence verdicts, the rationale is documented in a code comment rather than a fabricated reference.

## Scope

Completes the build-transparency trio (`dependencyLocking` #794, `hermeticBuilds` #797, `reproducibleBuilds`). Part of the `releaseTransparency` series (#793–#797). The only remaining field in the block, `repositoryChangeControls`, requires admin-level read access to the rainbow-me repos' branch-protection settings and is left `null`.

## Validation

- `eslint` / `cspell` / `prettier` on the file — clean
- (Type validity is a trivial `null` → `notSupported` change; CI runs the full `check:astro` suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)