### PR TITLE
Data: Restore Rainbow releaseTransparency fields reverted by hermetic-builds merge

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -440,10 +440,54 @@ export const rainbow: SoftwareWallet = {
 				uniswapUSDCToEtherSwap: null,
 			},
 			releaseTransparency: {
-				artifactSigning: null,
-				dependencyLocking: null,
-				dependencyVulnerabilityScanning: null,
-				hasPublicChangelog: null,
+				artifactSigning: notSupported,
+				dependencyLocking: supported({
+					ref: [
+						{
+							explanation:
+								'The browser extension CI runs `yarn install --immutable` and a dedicated `yarn check-lockfile` step, failing the build if yarn.lock is out of sync.',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/e600feb293b94aa16f7bb54aef9fa58f00c1422e/.github/workflows/build.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet Android release build installs dependencies with `yarn install --immutable`, which fails if yarn.lock would change.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/d79896d683cfa0ef8a8a6133057c4060acdbe63c/.github/workflows/android-play-store.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet iOS release build installs dependencies with `yarn install --immutable`, which fails if yarn.lock would change.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/4782c0a9010ea5783761144fb46ef0b55f4cc572/.github/actions/ios-build/action.yaml',
+						},
+					],
+				}),
+				dependencyVulnerabilityScanning: supported({
+					ref: [
+						{
+							explanation:
+								'The browser extension runs `yarn audit:ci` (audit-ci) as a CI step, failing the build on vulnerable dependencies.',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/e600feb293b94aa16f7bb54aef9fa58f00c1422e/.github/workflows/build.yml',
+						},
+						{
+							explanation:
+								'The mobile wallet runs `yarn audit-ci` as a CI step, failing the build on vulnerable dependencies.',
+							url: 'https://github.com/rainbow-me/rainbow/blob/c203ae4e9cb48627310f37ebbab05dbb43211286/.github/workflows/unit-test.yml',
+						},
+					],
+				}),
+				hasPublicChangelog: {
+					[Variant.BROWSER]: supported({
+						ref: {
+							explanation: 'Rainbow publishes browser extension release notes via GitHub Releases.',
+							url: 'https://github.com/rainbow-me/browser-extension/releases',
+						},
+					}),
+					[Variant.MOBILE]: supported({
+						ref: {
+							explanation: 'Rainbow publishes mobile wallet release notes via GitHub Releases.',
+							url: 'https://github.com/rainbow-me/rainbow/releases',
+						},
+					}),
+				},
 				hermeticBuilds: notSupportedWithRef({
 					ref: [
 						{


### PR DESCRIPTION
## What

Restores four Rainbow `releaseTransparency` fields that were silently reverted to `null`:

| Field | Restored value |
|---|---|
| `artifactSigning` | `notSupported` |
| `dependencyLocking` | `supported` (3 refs: `--immutable` + `check-lockfile`) |
| `dependencyVulnerabilityScanning` | `supported` (2 refs: `audit:ci` / `audit-ci`) |
| `hasPublicChangelog` | per-variant `supported` (browser + mobile GitHub Releases) |

## Why

These fields were researched, reviewed, and merged in separate PRs (commits `19b5c7aa`, `a4cbe27e`, `e415a2f0`, `751a3840`). They were then reverted to `null` by the **`hermetic-builds` merge** (`f19d0590`): that branch was cut from an older base (`6471234`) before the four field PRs landed and was never rebased. All five fields live in the single `releaseTransparency` object, so the stale branch's snapshot (those four still `null`) overwrote the freshly-merged values at merge time. Only `hermeticBuilds` was the intended change. The revert wasn't visible in the `hermetic-builds` diff because those lines were `null` on both sides of that PR.

This change re-applies the original, already-reviewed values verbatim from their merge parents. No new research.

## Validation

- `pnpm run check:astro` — 0 errors, 0 warnings, 0 hints
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)