### PR TITLE
Data: Add Rainbow EIP-7702 account support + delegation (Rainbow Calibur)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
 		"Buterin",
 		"Bybit",
 		"bypassable",
+		"Calibur",
 		"calldata",
 		"cBridge",
 		"CCIP",

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -4,6 +4,7 @@ import { alphabet } from '@/data/entities/alphabet'
 import { apple } from '@/data/entities/apple'
 import { rainbow as rainbowEntity } from '@/data/entities/rainbow'
 import { sentry } from '@/data/entities/sentry'
+import { rainbowCaliburContract } from '@/data/wallet-contracts/rainbow-calibur'
 import type { WalletAnalytics } from '@/schema/features'
 import { AccountType } from '@/schema/features/account-support'
 import type { AddressResolutionData } from '@/schema/features/privacy/address-resolution'
@@ -81,7 +82,25 @@ export const rainbow: SoftwareWallet = {
 	features: {
 		accountSupport: {
 			defaultAccountType: AccountType.eoa,
-			eip7702: notSupported,
+			// Rainbow ships EIP-7702 "smart wallets": EOAs are delegated to Rainbow's
+			// deployment of the Calibur delegate contract to batch approvals and actions
+			// into a single transaction. Delegation is gated behind a feature flag /
+			// remote config and applied lazily at the first operation that needs it.
+			eip7702: supported({
+				ref: [
+					{
+						explanation:
+							'Rainbow announced EIP-7702 smart wallets that delegate EOAs to bundle approvals and actions into a single transaction.',
+						url: 'https://x.com/rainbowdotme/status/2026753700216127820',
+					},
+					{
+						explanation:
+							'Both clients execute EIP-7702 (type-4) delegation as part of swap/send-calls flows via the @rainbow-me/delegation SDK; `willExecuteDelegation` decides per (address, chainId) whether the next operation delegates.',
+						url: 'https://github.com/rainbow-me/rainbow/blob/a6caacc07ddad0d40554d647dc4414945c9ebb81/src/features/delegation/willDelegate.ts',
+					},
+				],
+				contract: rainbowCaliburContract,
+			}),
 			eoa: supported({
 				ref: refTodo,
 				canExportPrivateKey: true,
@@ -125,7 +144,29 @@ export const rainbow: SoftwareWallet = {
 			}),
 		}),
 		ecosystem: {
-			delegation: null,
+			// Delegation is never offered at EOA creation or import; it is applied lazily,
+			// bundled into the first operation (e.g. a swap) that benefits from it.
+			delegation: {
+				duringEOACreation: 'NO',
+				duringEOAImport: 'NO',
+				duringFirst7702Operation: supported({
+					type: 'DELEGATION_BUNDLED_WITH_OTHER_OPERATIONS',
+					// The bundled swap/send is shown with its normal transaction details; the
+					// delegation is carried alongside rather than replacing the operation UI.
+					nonDelegationTransactionDetailsIdenticalToNormalFlow: true,
+				}),
+				fee: {
+					// No evidence Rainbow lets the user pay the delegation gas with a token on
+					// another chain.
+					crossChainGas: notSupported,
+					// Sponsored: prepared managed calls set `fees.payer: 'sponsor'`
+					// (src/features/delegation/calls.ts) and are submitted via Rainbow's own relay
+					// (relayService.ts, RAINBOW_RELAY_*). Sponsorship is gated on delegation —
+					// `predictSponsoredCallsExecution` requires `canUseDelegatedExecution` — and
+					// limited to sponsorship-eligible chains and the sponsor wallet's balance.
+					walletSponsored: featureSupported,
+				},
+			},
 		},
 		integration: {
 			browser: {

--- a/data/wallet-contracts/rainbow-calibur.ts
+++ b/data/wallet-contracts/rainbow-calibur.ts
@@ -1,0 +1,24 @@
+import type { SmartWalletContract } from '@/schema/contracts'
+import { featureSupported } from '@/schema/features/support'
+
+// Address verified on-chain: live EOAs carry the EIP-7702 delegation
+// indicator `0xef0100` followed by this address, and the deployed code exposes
+// the isValidSignature (0x1626ba7e) and validateUserOp (0x19822f7c) selectors.
+export const rainbowCaliburContract: SmartWalletContract = {
+	name: 'Rainbow Calibur',
+	address: '0x612373d7003d694220f7800eeaf8e3924c0951d3',
+	eip7702Delegatable: true,
+	methods: {
+		isValidSignature: featureSupported,
+		validateUserOp: featureSupported,
+	},
+	sourceCode: {
+		ref: {
+			explanation:
+				'Rainbow delegates EOAs to its deployment of Calibur, Uniswap’s open-source EIP-7702 smart-wallet delegate contract.',
+			label: 'Calibur (Uniswap)',
+			url: 'https://github.com/Uniswap/calibur',
+		},
+		available: true,
+	},
+}


### PR DESCRIPTION
## What

Rainbow supports EIP-7702. This fills two coupled fields plus the delegate contract:

- **`accountSupport.eip7702`** → `supported`, with the **Rainbow Calibur** delegate contract.
- **`ecosystem.delegation`** → filled: `NO`/`NO` at EOA creation/import; bundled at the first 7702 operation; sponsored.
- Adds **`data/wallet-contracts/rainbow-calibur.ts`** and `"Calibur"` to `.cspell.json`.

## Evidence

- **Product:** Rainbow's announcement that smart wallets are live, using EIP-7702 delegations to bundle approvals + actions into one transaction.
- **Source (both clients):** `src/features/delegation/willDelegate.ts` (delegation decided lazily per `(address, chainId)`, gated by feature flag / `delegation_enabled` remote config); `calls.ts` (`SPONSORED_CALLS_REQUIREMENTS` → `fees: { payer: 'sponsor' }`); `relayService.ts` (Rainbow operates the relay — `RAINBOW_RELAY_*`); `sponsoredCalls.ts` (`predictSponsoredCallsExecution` requires `canUseDelegatedExecution`, so **sponsorship is gated on delegation**).
- **On-chain:** the delegate `0x612373d7003d694220f7800eeaf8e3924c0951d3` carries contract code exposing the `isValidSignature` (`0x1626ba7e`) and `validateUserOp` (`0x19822f7c`) selectors, and live EOAs are delegated to it via the `0xef0100…` EIP-7702 indicator.

## Relationship to #607

The Rainbow Calibur contract and delegation structure originate from @DanielSinclair's #607, credit to them. That PR predates the questionnaire rewrite of `rainbow.ts` and conflicts broadly, so this carves out just the EIP-7702 + delegation pieces against current `beta`. **One correction vs #607:** `fee.walletSponsored` is `supported` here (not `notSupported`)

## Validation

- `pnpm run check:astro` — 0 errors / 0 warnings / 0 hints
- `prettier --check`, `eslint`, `cspell` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)