### PR TITLE
<Pie>: slice gradients

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -8,6 +8,11 @@
 		arcIconId?: string
 		titleText: string
 		href?: string
+		gradient?: {
+			areaRadiusStops?: number[]
+			colors: string[]
+			transparentStopColor?: string
+		}
 		children?: Slice[]
 	}
 
@@ -129,7 +134,66 @@
 
 
 	// Functions
-	const getLevelConfig = (level: number): LevelConfig => levels[Math.min(level, levels.length - 1)]
+	const getLevelConfig = (level: number) => levels[Math.min(level, levels.length - 1)]
+
+	const sliceFill = (slice: ComputedSlice) => {
+		if (!slice.children?.length || !slice.gradient) return slice.color
+
+		const colorWeights = slice.gradient.colors
+			.map(color => ({
+				color,
+				weight: slice.children
+					.filter(child => child.color === color)
+					.reduce((sum, child) => sum + child.weight, 0),
+			}))
+			.filter(({ weight }) => weight > 0)
+
+		if (colorWeights.length <= 1) return colorWeights[0]?.color ?? slice.color
+
+		const areaRadiusStops = slice.gradient.areaRadiusStops
+		const totalWeight = colorWeights.reduce((sum, entry) => sum + entry.weight, 0)
+		const minimumStopGap = Math.min(8, (slice.computed.outerR - slice.computed.innerR) / Math.max(colorWeights.length - 1, 1))
+		const stopPositions = colorWeights
+			.map(({ weight }, index, weights) => {
+				const areaFraction = (weights.slice(0, index).reduce((sum, entry) => sum + entry.weight, 0) + weight / 2) / totalWeight
+				const scaledStopIndex = areaRadiusStops ? areaFraction * (areaRadiusStops.length - 1) : 0
+				const stopIndex = Math.floor(scaledStopIndex)
+				const normalizedRadius = (
+					areaRadiusStops ?
+						areaRadiusStops[stopIndex] + (
+							areaRadiusStops[Math.min(stopIndex + 1, areaRadiusStops.length - 1)] - areaRadiusStops[stopIndex]
+						) * (scaledStopIndex - stopIndex)
+					:
+						Math.sqrt(
+							(
+								slice.computed.innerR ** 2
+								+ (slice.computed.outerR ** 2 - slice.computed.innerR ** 2) * areaFraction
+							),
+					)
+				)
+
+				return areaRadiusStops ? slice.computed.innerR + (slice.computed.outerR - slice.computed.innerR) * normalizedRadius : normalizedRadius
+			})
+			.reduce<number[]>(
+				(stops, stop, index) => [
+					...stops,
+					Math.max(stop, index === 0 ? slice.computed.innerR : stops[index - 1] + minimumStopGap),
+				],
+				[],
+			)
+			.reduceRight<number[]>(
+				(stops, stop, index) => [
+					Math.min(
+						stop,
+						index === colorWeights.length - 1 ? slice.computed.outerR : stops[0] - minimumStopGap,
+					),
+					...stops,
+				],
+				[],
+			)
+
+		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')}), ${slice.color}`
+	}
 
 	const computeSlices = (
 		{
@@ -288,7 +352,8 @@
 		style:--slice-arcSize={Math.abs(slice.computed.totalAngle) > 180 ? 'large' : 'small'}
 		class:full-ring={Math.abs(slice.computed.totalAngle) >= 359.99}
 
-		style:--slice-fill={slice.color}
+		style:--slice-color={slice.color}
+		style:--slice-fill={sliceFill(slice)}
 		style:--slice-labelSize={slice.computed.labelSize}
 
 		data-slice-id={slice.id}
@@ -512,7 +577,7 @@
 					--slice-outerStartX: calc(var(--pie-originX) + sin(var(--slice-angleOuterStart)) * var(--slice-outerR) * 1px);
 					--slice-outerStartY: calc(var(--pie-originY) - cos(var(--slice-angleOuterStart)) * var(--slice-outerR) * 1px);
 
-					background-color: var(--slice-fill);
+					background: var(--slice-fill);
 
 					clip-path: shape(
 						from
@@ -646,7 +711,7 @@
 
 				&:not(:hover, :focus-within) > .slice-shape > .label[data-wbicon] {
 					filter: none;
-					color: contrast-color(--slice-fill);
+					color: contrast-color(--slice-color);
 					opacity: 1;
 				}
 

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -187,9 +187,9 @@ export function borderRatingToColor(rating: Rating): string {
 		case Rating.PASS:
 			return '#B5ED9D' // Green
 		case Rating.UNRATED:
-			return '#F8ECEC' // Gray
+			return '#bdc3c7' // Gray
 		case Rating.EXEMPT:
-			return '#D5D4FB' // Gray
+			return '#bdc3c7' // Gray
 	}
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,8 +32,8 @@
 	--rating-pass: light-dark(#B5ED9D99,#B5ED9D);
 	--rating-fail: light-dark(#FF969699,#FB6682);
 	--rating-partial: light-dark(#FFCC7399,#FFCC73);
-	--rating-neutral: light-dark(#D5D4FB99,#D5D4FB);
-	--rating-unrated: #F8ECEC;
+	--rating-neutral: #bdc3c7;
+	--rating-unrated: light-dark(oklch(0.75 0.02 244.87), oklch(0.67 0.01 264.61));
 	--rating-icon-color: #000000;
 
 	--icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 3 3'%3E%3Cpath d='m.5 1 1 1 1-1' fill='none' stroke='black' stroke-width='0.5' stroke-linecap='round' stroke-linejoin='round' /%3E%3C/svg%3E");

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -233,8 +233,6 @@
 	import { isNonEmptyArray, nonEmptyMap } from '@/types/utils/non-empty'
 	import { isAttributeUsedInStage, stagesById } from '@/utils/stage-attributes'
 
-
-	// Score helpers
 	const getWalletScore = (wallet: RatedWallet): number | null => {
 		const overallScore = calculateOverallScore(
 			wallet.overall,
@@ -335,7 +333,7 @@
 	import WalletIcon from 'lucide-static/icons/wallet.svg?raw'
 
 	import Filters from '@/components/Filters.svelte'
-	import Pie, { PieLayout } from '@/components/Pie.svelte'
+	import Pie, { PieLayout, type Slice } from '@/components/Pie.svelte'
 	import Select from '@/components/Select.svelte'
 	import Table, { ColumnAlignment, SortDirection } from '@/components/Table.svelte'
 	import Tooltip from '@/components/Tooltip.svelte'
@@ -353,6 +351,24 @@
 	// Styles
 	import { scoreToColor, stageToColor } from '@/utils/colors'
 	import type { WBIconFontID } from '@/styles/wbicons'
+
+
+	// Flower visualization helpers
+	const attributeGroupFlowerGradient: NonNullable<Slice['gradient']> = {
+		areaRadiusStops: [
+			0.000000, 0.038097, 0.075252, 0.111402, 0.146585, 0.180353, 0.213312, 0.245668, 0.277513,
+			0.308937, 0.339923, 0.370813, 0.401695, 0.432635, 0.463538, 0.494531, 0.525379, 0.555836,
+			0.586127, 0.616255, 0.646222, 0.676031, 0.705683, 0.735183, 0.764631, 0.793975, 0.823297,
+			0.852492, 0.881757, 0.911014, 0.940339, 0.969777, 1.000000,
+		],
+		colors: [
+			ratingToColor(Rating.UNRATED),
+			ratingToColor(Rating.FAIL),
+			ratingToColor(Rating.PARTIAL),
+			ratingToColor(Rating.PASS),
+		],
+		transparentStopColor: ratingToColor(Rating.UNRATED),
+	}
 </script>
 
 
@@ -1132,6 +1148,7 @@
 												groupScore,
 												summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.ScoreDot,
 											),
+											gradient: attributeGroupFlowerGradient,
 											weight: 1,
 											...evalGroup && {
 												children: (
@@ -1644,6 +1661,7 @@
 									arcIconId: attrGroup.icon,
 									color: groupScore !== null ? scoreToColor(groupScore.score) : 'var(--rating-unrated)',
 									titleText: formatAttributeGroupTitleText(attrGroup, groupScore, false),
+									gradient: attributeGroupFlowerGradient,
 									weight: 1,
 									...evalGroup && {
 										children: (


### PR DESCRIPTION
## Components

* `<Pie>`:
  * support parent slice gradients derived from child slice rating colors
  * use `radial-gradient(in oklch ...)` for perceptual color interpolation
  * place gradient stops using the attribute scoring weights
  * use a baked inverse-area lookup for the default rounded category petal shape, generated from the actual clipped geometry so outer-tip curvature is represented without doing the full area integration at render time
  * render unrated portions as transparent over the existing unrated gray

## Views

* `<WalletTable>`:
  * order parent-petal stops as unrated → fail → partial → pass
  * exclude exempt attributes from parent-petal gradients

---

<img width="785" height="926" alt="Screenshot 2026-06-16 at 06 12 03" src="https://github.com/user-attachments/assets/cef32988-145e-4973-b530-18fafa5a4ee0" />

<img width="784" height="922" alt="Screenshot 2026-06-16 at 06 25 42" src="https://github.com/user-attachments/assets/5c14207e-9c8b-4318-a6d4-cba2b790ae54" />
