### PR TITLE
docs(comms): add Walletbeat ↔ Zerion and ↔ Ambire channels

### DIFF
--- a/governance/communications/communication-channels.md
+++ b/governance/communications/communication-channels.md
@@ -36,6 +36,12 @@ _Keep list sorted by chronological "Established" date._
   - **Established**: 2026-04
   - **Fibonacci-approximate number of participants**: 5
   - **Medium**: Telegram
+- **Walletbeat ↔ Ambire**:
+  - **Walletbeat contributors**: 0xMattmatt, polymutex, ren2140
+  - **Wallet development teams represented**: Ambire
+  - **Established**: 2026-05
+  - **Fibonacci-approximate number of participants**: 8
+  - **Medium**: Signal
 - **Walletbeat ↔ Zerion**:
   - **Walletbeat contributors**: 0xMattmatt, polymutex, ren2140
   - **Wallet development teams represented**: Zerion

--- a/governance/communications/communication-channels.md
+++ b/governance/communications/communication-channels.md
@@ -36,6 +36,12 @@ _Keep list sorted by chronological "Established" date._
   - **Established**: 2026-04
   - **Fibonacci-approximate number of participants**: 5
   - **Medium**: Telegram
+- **Walletbeat ↔ Zerion**:
+  - **Walletbeat contributors**: 0xMattmatt, polymutex, ren2140
+  - **Wallet development teams represented**: Zerion
+  - **Established**: 2026-06
+  - **Fibonacci-approximate number of participants**: 5
+  - **Medium**: Telegram
 
 ## Conference panels
 


### PR DESCRIPTION
Adds two communication channels to the disclosure list.

**Walletbeat ↔ Zerion**
- Medium: Telegram · Established: 2026-06
- Teams: Zerion · Contributors: 0xMattmatt, polymutex, ren2140
- Participants recorded as Fibonacci approximation `5` (actual ~4)

**Walletbeat ↔ Ambire**
- Medium: Signal · Established: 2026-05
- Teams: Ambire · Contributors: 0xMattmatt, polymutex, ren2140
- Participants recorded as Fibonacci approximation `8` (actual 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)