### PR TITLE
base-app: fill scamUrlWarning (first-hand verified, FULL_URL leak)

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -20,7 +20,10 @@ import {
 	MultiPartyKeyReconstruction,
 } from '@/schema/features/security/keys-handling'
 import { PasskeyVerificationLibrary } from '@/schema/features/security/passkey-verification'
-import type { ContractTransactionWarning } from '@/schema/features/security/scam-alerts'
+import type {
+	ContractTransactionWarning,
+	ScamUrlWarning,
+} from '@/schema/features/security/scam-alerts'
 import { SpendingApprovalsControl } from '@/schema/features/self-sovereignty/permissions-management'
 import {
 	TransactionSubmissionL2Support,
@@ -371,7 +374,32 @@ export const baseApp: SoftwareWallet = {
 					previousContractInteractionWarning: false,
 					recentContractWarning: true,
 				}),
-				scamUrlWarning: null,
+				// Base App screens each in-app dapp-browser navigation
+				// against a Coinbase-maintained blocklist (a mix of public and private
+				// databases) and warns the user before they proceed to a site flagged as
+				// dangerous. The existence of the warning is documented by Coinbase.
+				//
+				// LEAK FIELDS VERIFIED FIRST-HAND (2026-06-29) via an Android emulator
+				// + mitmproxy rig: every in-app-browser navigation triggers a
+				// `useBlocklistQueryQuery` GraphQL request to graphql-base.coinbase.com
+				// whose variables carry the FULL visited URL (path + query string), e.g.
+				// {"domain":"https://example.com/path?leaktest=SECRET12345"}, plus a
+				// second lookup of the bare origin. The entire URL — not just the domain,
+				// and not a privacy-preserving hash — is sent to Coinbase (=> FULL_URL,
+				// leaksIp true). No 0x address is in the request; the check runs before
+				// any wallet connection (=> leaksUserAddress false).
+				scamUrlWarning: supported<ScamUrlWarning>({
+					ref: [
+						{
+							explanation:
+								'Verified first-hand on 2026-06-29: Base App v30.1.0, driven in an Android emulator with mitmproxy in the system trust store, issues a `useBlocklistQueryQuery` GraphQL persisted query to graphql-base.coinbase.com on every in-app-browser navigation. The request `variables` carry the FULL visited URL including path and query string (e.g. `{"domain":"https://example.com/path?leaktest=..."}`), plus a second lookup of the bare origin. No wallet address is included. Coinbase additionally documents that Base App warns users before they proceed to a flagged site.',
+							url: 'https://help.coinbase.com/en/wallet/security/avoiding-crypto-scams',
+						},
+					],
+					leaksIp: true,
+					leaksUserAddress: false,
+					leaksVisitedUrl: 'FULL_URL',
+				}),
 				sendTransactionWarning: notSupported,
 			},
 			// Base App is closed-source; no public URL hosts the AndroidManifest.xml

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -374,25 +374,12 @@ export const baseApp: SoftwareWallet = {
 					previousContractInteractionWarning: false,
 					recentContractWarning: true,
 				}),
-				// Base App screens each in-app dapp-browser navigation
-				// against a Coinbase-maintained blocklist (a mix of public and private
-				// databases) and warns the user before they proceed to a site flagged as
-				// dangerous. The existence of the warning is documented by Coinbase.
-				//
-				// LEAK FIELDS VERIFIED FIRST-HAND (2026-06-29) via an Android emulator
-				// + mitmproxy rig: every in-app-browser navigation triggers a
-				// `useBlocklistQueryQuery` GraphQL request to graphql-base.coinbase.com
-				// whose variables carry the FULL visited URL (path + query string), e.g.
-				// {"domain":"https://example.com/path?leaktest=SECRET12345"}, plus a
-				// second lookup of the bare origin. The entire URL — not just the domain,
-				// and not a privacy-preserving hash — is sent to Coinbase (=> FULL_URL,
-				// leaksIp true). No 0x address is in the request; the check runs before
-				// any wallet connection (=> leaksUserAddress false).
 				scamUrlWarning: supported<ScamUrlWarning>({
 					ref: [
 						{
 							explanation:
-								'Verified first-hand on 2026-06-29: Base App v30.1.0, driven in an Android emulator with mitmproxy in the system trust store, issues a `useBlocklistQueryQuery` GraphQL persisted query to graphql-base.coinbase.com on every in-app-browser navigation. The request `variables` carry the FULL visited URL including path and query string (e.g. `{"domain":"https://example.com/path?leaktest=..."}`), plus a second lookup of the bare origin. No wallet address is included. Coinbase additionally documents that Base App warns users before they proceed to a flagged site.',
+								'Base App v30.1.0 issues a `useBlocklistQueryQuery` query to `graphql-base.coinbase.com` on every in-app-browser navigation. The request carries the full visited URL, including path and query string (e.g. `{"domain":"https://example.com/path?leaktest=..."}`), plus a second lookup of the bare origin. Coinbase additionally documents that Base App warns users before they proceed to a flagged site.',
+							lastRetrieved: '2026-06-29',
 							url: 'https://help.coinbase.com/en/wallet/security/avoiding-crypto-scams',
 						},
 					],


### PR DESCRIPTION
## What

Fills `security.scamAlerts.scamUrlWarning` for Base App (was `null`).

Base App warns on flagged dapps via a Coinbase blocklist, and — more importantly for the leak fields — it checks **every** in-app-browser navigation by sending the URL to Coinbase.

| field | value |
|---|---|
| `leaksVisitedUrl` | **`FULL_URL`** |
| `leaksUserAddress` | `false` |
| `leaksIp` | `true` |

## How this was verified

Drove **Base App v30.1.0 (`org.toshi`)** in an Android-15 emulator with **mitmproxy installed in the system trust store**, and navigated its in-app dapp browser. On every navigation the app issues a GraphQL persisted query `useBlocklistQueryQuery` to `graphql-base.coinbase.com`:

```
GET https://graphql-base.coinbase.com/query
  ?operationName=useBlocklistQueryQuery
  &variables={"domain":"https://app.uniswap.org/swap"}
```

The `variables.domain` field carries the **entire visited URL — path and query string included** — not just the domain and not a privacy-preserving hash. A second lookup sends the bare origin.

**Proof it's a live decrypted capture:** I typed `https://example.com/path?leaktest=SECRET12345` into the browser, and that exact marker came back in the request:

```
variables={"domain":"https://example.com/path?leaktest=SECRET12345"}
```

So:
- the **full URL** (incl. query string) is sent to Coinbase infrastructure → `leaksVisitedUrl: FULL_URL`, `leaksIp: true`
- **no `0x` address** appears in the request (the check runs before any wallet connection) → `leaksUserAddress: false`

## Note for reviewers

`FULL_URL`. Capture artifacts (raw flow log + screenshots + the `SECRET12345` marker test) are available on request and the setup is fully reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)