### PR TITLE
Redirect `walletbeat.fyi` homepage to beta version.

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,10 @@ export default function Home(): React.JSX.Element {
           An open repository of EVM-compatible wallets.
         </Typography>
         <Typography variant="h4" mb={4} textAlign="center" fontWeight={300} maxWidth="90vw">
-          Check out our new beta website at <Link href='https://beta.walletbeat.eth.limo'>beta.walletbeat.eth</Link>.
+          Redirecting to our new beta website at <Link href='https://beta.walletbeat.eth.limo'>beta.walletbeat.eth</Link>.
+          <script>
+            window.location.replace('https://beta.walletbeat.eth.limo');
+          </script>
         </Typography>
         <ComparisonTable />
         <Box my={6} mb={10} mx={1}>


### PR DESCRIPTION
Received feedback from EF members that they still thought the walletbeat.fyi was the latest state of Walletbeat. Seems like overdue for this change.

cc @mozrt2 