### PR TITLE
Enforce that commits must be signed.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -203,6 +203,7 @@
 		"globalthis",
 		"Gnosis",
 		"GoPlus",
+		"gpgsig",
 		"greekfetacheese",
 		"GridPlus",
 		"grindy",

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,6 +33,8 @@ jobs:
             command: pnpm run check:misc
           - name: Build – Astro
             command: pnpm run check:build:post:quiet
+          - name: Commit signature
+            command: pnpm run check:signed-commit
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"astro": "cross-env ASTRO_TELEMETRY_DISABLED=1 astro",
 		"build": "deploy/build.sh",
-		"check:all": "pnpm run \"/^check:(astro|vitest|lint|syntax|spelling:quiet|misc|build:post:quiet)$/\"",
+		"check:all": "pnpm run \"/^check:(astro|vitest|lint|syntax|spelling:quiet|misc|build:post:quiet|signed-commit:quiet)$/\"",
 		"check:quick": "pnpm run \"/^check:(lint:quick|syntax|spelling:quiet|misc)$/\"",
 		"check:astro": "pnpm run astro check --minimumSeverity=hint --minimumFailingSeverity=hint",
 		"check:build:post": "tests/postbuild.sh",
@@ -24,6 +24,8 @@
 		"check:syntax": "prettier --check .",
 		"check:treasury:markdown": "tsx src/tools/treasury-markdown-updater/treasury-markdown-updater.ts",
 		"check:features:markdown": "tsx src/tools/features-markdown-generator/features-markdown-generator.ts",
+		"check:signed-commit": "bash tests/signed-commit.test.sh",
+		"check:signed-commit:quiet": "bash tests/signed-commit.test.sh --quiet",
 		"check:vitest": "vitest --typecheck --cache --run",
 		"generate:css-attributes": "pnpm run \"/^generate:css-attributes:.+/\"",
 		"generate:css-attributes:typescript": "tsx src/styles/generate/css-attributes-typescript.ts",

--- a/tests/signed-commit.test.sh
+++ b/tests/signed-commit.test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Verify that the latest commit on the current branch is GPG-signed.
+# Checks for the presence of a `gpgsig` field in the commit object.
+
+commit_object="$(git cat-file -p HEAD)"
+
+if ! echo "$commit_object" | grep -q '^gpgsig '; then
+	echo "The latest commit is not signed." >&2
+	echo 'Please sign your commits.' >&2
+	exit 1
+fi
+
+if ! echo "$@" | grep -q quiet; then
+	echo 'The latest commit is signed.' >&2
+fi
+exit 0


### PR DESCRIPTION
Suggested by @darrylyeo.