### PR TITLE
Fix `s !== null` filter in `calculateAttributeGroupScore`

### DIFF
--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -295,7 +295,7 @@ export function calculateAttributeGroupScore<
 
 			return { score, weight }
 		})
-		.filter((s): s is WeightedScore => s !== null)
+		.filter((s): s is WeightedScore => s.score !== null)
 
 	if (isNonEmptyArray(subScores)) {
 		let hasUnratedComponent = false

--- a/src/schema/score.ts
+++ b/src/schema/score.ts
@@ -24,13 +24,17 @@ export type MaybeUnratedScore = null | {
 
 /** Compute a weighted aggregate score. */
 export const weightedScore = (scores: NonEmptyArray<WeightedScore>): Score => {
-	if (scores.every(({ score }) => score === null)) {
+	const nonNullScores = scores.filter(
+		(s): s is WeightedScore & { score: number } => s.score !== null,
+	)
+
+	if (nonNullScores.length === 0) {
 		return null
 	}
 
-	const [totalScore, totalWeight] = scores.reduce(
+	const [totalScore, totalWeight] = nonNullScores.reduce(
 		([totalScore, totalWeight], { score, weight }) => [
-			totalScore + (score === null ? 0 : score) * weight,
+			totalScore + score * weight,
 			totalWeight + weight,
 		],
 		[0, 0] as [number, number],


### PR DESCRIPTION
The filter `s !== null` was a no-op since the map always returns an object. The `score` field is `null` for EXEMPT attributes, so exempt entries added weight to the denominator with score 0.

Also hardened `weightedScore` in `score.ts` to skip null-score entries.

Fixes #899