### PR TITLE
Fix `funding` verifiability for non self-funded wallets

### DIFF
--- a/src/schema/attributes/transparency/funding.ts
+++ b/src/schema/attributes/transparency/funding.ts
@@ -235,48 +235,47 @@ export const funding: Attribute = {
 		const verifiabilityPredicates: VerifiabilityPredicate[] = []
 
 		for (const { strategy, value } of monetizationStrategies(ctx.features.monetization)) {
-			verifiabilityPredicates.push(
-				((): VerifiabilityPredicate => {
-					switch (strategy) {
-						case MonetizationStrategy.DONATIONS:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-						case MonetizationStrategy.ECOSYSTEM_GRANTS:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-						case MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT:
-							return () => Verifiability.VERIFIABLE
-						case MonetizationStrategy.GOVERNANCE_TOKEN_MOSTLY_DISTRIBUTED:
-							return () => Verifiability.VERIFIABLE
-						case MonetizationStrategy.HIDDEN_CONVENIENCE_FEES:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-						case MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-						case MonetizationStrategy.PUBLIC_OFFERING:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-						case MonetizationStrategy.SELF_FUNDED:
-							return () => Verifiability.UNVERIFIABLE
-						case MonetizationStrategy.VENTURE_CAPITAL:
-							return verifiabilityRequiresAtLeastOneReference({
-								referenceCountsAs: Verifiability.VERIFIABLE,
-							})
-					}
-				})(),
-			)
-
 			switch (value) {
 				case null:
 					return unrated(ctx)
 				case true:
 					strategies.push(strategy)
+					verifiabilityPredicates.push(
+						((): VerifiabilityPredicate => {
+							switch (strategy) {
+								case MonetizationStrategy.DONATIONS:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+								case MonetizationStrategy.ECOSYSTEM_GRANTS:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+								case MonetizationStrategy.GOVERNANCE_TOKEN_LOW_FLOAT:
+									return () => Verifiability.VERIFIABLE
+								case MonetizationStrategy.GOVERNANCE_TOKEN_MOSTLY_DISTRIBUTED:
+									return () => Verifiability.VERIFIABLE
+								case MonetizationStrategy.HIDDEN_CONVENIENCE_FEES:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+								case MonetizationStrategy.TRANSPARENT_CONVENIENCE_FEES:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+								case MonetizationStrategy.PUBLIC_OFFERING:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+								case MonetizationStrategy.SELF_FUNDED:
+									return () => Verifiability.UNVERIFIABLE
+								case MonetizationStrategy.VENTURE_CAPITAL:
+									return verifiabilityRequiresAtLeastOneReference({
+										referenceCountsAs: Verifiability.VERIFIABLE,
+									})
+							}
+						})(),
+					)
 					break
 				case false:
 					break // Do nothing.


### PR DESCRIPTION
The `funding` attribute pushed a verifiability predicate for every strategy in the monetization record, including those with value false. Since `SELF_FUNDED` maps to `UNVERIFIABLE` and
`verifiabilityRequiresAllOf` takes the worst, any wallet with `selfFunded: false` had its verifiability forced to UNVERIFIABLE.

Move the predicate push inside the `case true` branch.

Fixes #900