### PR TITLE
base-app: reunite walletCall comment with its field

### DIFF
--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -163,12 +163,6 @@ export const baseApp: SoftwareWallet = {
 				'6963': featureSupported,
 			},
 		},
-		// Base App accounts run Coinbase Smart Wallet logic, which exposes
-		// EIP-5792 wallet_sendCalls with atomic batching. Atomicity is a
-		// contract-level property (executeBatch) that holds on every chain the
-		// wallet is deployed to, including Ethereum L1. Confirmed live on
-		// mainnet: a wallet_sendCalls batch was executed as an ERC-4337
-		// UserOperation routed through the account's executeBatch (see refs).
 		licensing: {
 			type: LicensingType.SINGLE_WALLET_REPO_AND_LICENSE,
 			walletAppLicense: {
@@ -475,6 +469,12 @@ export const baseApp: SoftwareWallet = {
 				reproducibleBuilds: null,
 			},
 		},
+		// Base App accounts run Coinbase Smart Wallet logic, which exposes
+		// EIP-5792 wallet_sendCalls with atomic batching. Atomicity is a
+		// contract-level property (executeBatch) that holds on every chain the
+		// wallet is deployed to, including Ethereum L1. Confirmed live on
+		// mainnet: a wallet_sendCalls batch was executed as an ERC-4337
+		// UserOperation routed through the account's executeBatch (see refs).
 		walletCall: supported({
 			ref: [
 				{


### PR DESCRIPTION
## What

Comment-only move in `data/software-wallets/base-app.ts`: relocates the six-line explanatory comment about Base App's EIP-5792 atomic batching so it sits above the `walletCall` block it describes.

## Why

#916 moved the `walletCall` data from `integration` to the new top-level feature field, but the comment stayed at the old location.

No data or rating changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)