### PR TITLE
CSS: add workaround for stripped `&` selectors during ESBuild minification

### DIFF
--- a/src/styles/css-attributes.css
+++ b/src/styles/css-attributes.css
@@ -1236,7 +1236,7 @@ ol {
 	--sticky-sizeInline: var(--sticky0-sizeInline);
 
 	@scope (&) to ([data-scroll-container] > *) {
-		& [data-sticky-container]:not(& [data-sticky-container] [data-sticky-container]) {
+		:is(&) [data-sticky-container]:not(:is(&) [data-sticky-container] [data-sticky-container]) {
 			--sticky-level: 1;
 
 			--sticky1-insetBlockStart: calc(var(--sticky0-insetBlockStart) + var(--sticky0-paddingBlockStart) + var(--sticky-marginBlockStart));
@@ -1260,7 +1260,7 @@ ol {
 			--sticky-sizeBlock: var(--sticky1-sizeBlock);
 			--sticky-sizeInline: var(--sticky1-sizeInline);
 
-			& [data-sticky-container]:not(& [data-sticky-container] [data-sticky-container]) {
+			:is(&) [data-sticky-container]:not(:is(&) [data-sticky-container] [data-sticky-container]) {
 				--sticky-level: 2;
 
 				--sticky2-insetBlockStart: calc(var(--sticky1-insetBlockStart) + var(--sticky1-paddingBlockStart) + var(--sticky-marginBlockStart));
@@ -1284,7 +1284,7 @@ ol {
 				--sticky-sizeBlock: var(--sticky2-sizeBlock);
 				--sticky-sizeInline: var(--sticky2-sizeInline);
 
-				& [data-sticky-container]:not(& [data-sticky-container] [data-sticky-container]) {
+				:is(&) [data-sticky-container]:not(:is(&) [data-sticky-container] [data-sticky-container]) {
 					--sticky-level: 3;
 
 					--sticky3-insetBlockStart: calc(var(--sticky2-insetBlockStart) + var(--sticky2-paddingBlockStart) + var(--sticky-marginBlockStart));
@@ -1308,7 +1308,7 @@ ol {
 					--sticky-sizeBlock: var(--sticky3-sizeBlock);
 					--sticky-sizeInline: var(--sticky3-sizeInline);
 
-					& [data-sticky-container]:not(& [data-sticky-container] [data-sticky-container]) {
+					:is(&) [data-sticky-container]:not(:is(&) [data-sticky-container] [data-sticky-container]) {
 						--sticky-level: 4;
 
 						--sticky4-insetBlockStart: calc(var(--sticky3-insetBlockStart) + var(--sticky3-paddingBlockStart) + var(--sticky-marginBlockStart));
@@ -1332,7 +1332,7 @@ ol {
 						--sticky-sizeBlock: var(--sticky4-sizeBlock);
 						--sticky-sizeInline: var(--sticky4-sizeInline);
 
-						& [data-sticky-container]:not(& [data-sticky-container] [data-sticky-container]) {
+						:is(&) [data-sticky-container]:not(:is(&) [data-sticky-container] [data-sticky-container]) {
 							--sticky-level: 5;
 
 							--sticky5-insetBlockStart: calc(var(--sticky4-insetBlockStart) + var(--sticky4-paddingBlockStart) + var(--sticky-marginBlockStart));


### PR DESCRIPTION
Follow-up to https://github.com/walletbeat/walletbeat/pull/829.

Rewrite `&` selectors as `:is(&)` so that [ESBuild does not strip them during CSS minification](https://github.com/evanw/esbuild/issues/4497) and incorrectly change the meaning of `[data-sticky-container]` `:not(& ...)` rules in the production build.

Fixes https://github.com/walletbeat/walletbeat/issues/918.