### PR TITLE
<Pie>: centered slice alignment; translucent "unrated" material

### DIFF
--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -153,7 +153,11 @@
 			}))
 			.filter(({ weight }) => weight > 0)
 
-		if (colorWeights.length <= 1) return colorWeights[0]?.color ?? slice.color
+		if (colorWeights.length <= 1) {
+			const color = colorWeights[0]?.color ?? slice.color
+
+			return color === slice.gradient.transparentStopColor ? 'transparent' : color
+		}
 
 		const areaRadiusStops = slice.gradient.areaRadiusStops
 		const totalWeight = colorWeights.reduce((sum, entry) => sum + entry.weight, 0)
@@ -197,7 +201,7 @@
 				[],
 			)
 
-		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')}), ${slice.color}`
+		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')})`
 	}
 
 	const computeSlices = (

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -71,6 +71,7 @@
 
 		// View options
 		layout = PieLayout.HalfTop,
+		centerFirstSlice = true,
 		padding = 0,
 		radius = 47,
 		labelSize = radius / 4,
@@ -116,6 +117,7 @@
 
 		// View options
 		layout?: (typeof PieLayout)[keyof typeof PieLayout]
+		centerFirstSlice?: boolean
 		radius?: number
 		padding?: number
 		labelSize?: number
@@ -203,10 +205,12 @@
 			slices,
 			startAngle,
 			endAngle,
+			firstSliceMidAngle,
 		}: {
 			slices: Slice[]
 			startAngle: number
 			endAngle: number
+			firstSliceMidAngle?: number
 		},
 		cy = 0,
 		level = 0,
@@ -230,8 +234,10 @@
 		const effectiveTotalAngle = effectiveEndAngle - effectiveStartAngle - orientation * totalGapAngle
 
 		const totalWeight = slices.reduce((acc, slice) => acc + slice.weight, 0)
+		const computedFirstSliceMidAngle = effectiveStartAngle + effectiveTotalAngle * ((slices[0]?.weight ?? 0) / (totalWeight || 1)) / 2
+		const angleOffset = (firstSliceMidAngle ?? computedFirstSliceMidAngle) - computedFirstSliceMidAngle
 
-		let currentAngle = effectiveStartAngle
+		let currentAngle = effectiveStartAngle + angleOffset
 
 		return slices.map(({ children, ...slice }, i) => {
 			const totalAngle = effectiveTotalAngle * (slice.weight / totalWeight)
@@ -278,6 +284,7 @@
 		computeSlices(
 			{
 				slices,
+				firstSliceMidAngle: centerFirstSlice ? 0 : undefined,
 				...(
 					layout === PieLayout.FullLeft ?
 						{
@@ -289,7 +296,7 @@
 							startAngle: 360 - getLevelConfig(0).angleGap / 2,
 							endAngle: 0 + getLevelConfig(0).angleGap / 2,
 						}
-					: // layout === PieLayout.HalfTop ?
+					: // layout === PieLayout.HalfTop
 						{
 							startAngle: -90,
 							endAngle: 90,

--- a/src/components/Pie.svelte
+++ b/src/components/Pie.svelte
@@ -156,7 +156,7 @@
 		if (colorWeights.length <= 1) {
 			const color = colorWeights[0]?.color ?? slice.color
 
-			return color === slice.gradient.transparentStopColor ? 'transparent' : color
+			return color === slice.gradient.transparentStopColor ? 'var(--rating-unrated)' : color
 		}
 
 		const areaRadiusStops = slice.gradient.areaRadiusStops
@@ -201,8 +201,14 @@
 				[],
 			)
 
-		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')})`
+		return `radial-gradient(in oklch circle at var(--pie-originX) var(--pie-originY), ${colorWeights.map(({ color }, index) => `${color === slice.gradient.transparentStopColor ? 'transparent' : color} ${stopPositions[index]}px`).join(', ')}), var(--rating-unrated)`
 	}
+
+	const sliceBackdropFilter = (slice: ComputedSlice) => (
+		slice.gradient || slice.color === 'var(--rating-unrated)'
+			? 'var(--rating-unrated-backdropFilter)'
+			: 'none'
+	)
 
 	const computeSlices = (
 		{
@@ -368,6 +374,7 @@
 
 		style:--slice-color={slice.color}
 		style:--slice-fill={sliceFill(slice)}
+		style:--slice-backdropFilter={sliceBackdropFilter(slice)}
 		style:--slice-labelSize={slice.computed.labelSize}
 
 		data-slice-id={slice.id}
@@ -595,6 +602,7 @@
 					--slice-outerStartY: calc(var(--pie-originY) - cos(var(--slice-angleOuterStart)) * var(--slice-outerR) * 1px);
 
 					background: var(--slice-fill);
+					backdrop-filter: var(--slice-backdropFilter, none);
 
 					clip-path: shape(
 						from

--- a/src/styles/css-attributes.css
+++ b/src/styles/css-attributes.css
@@ -782,6 +782,7 @@ summary {
 	--badge-backgroundColor: color-mix(in srgb, var(--accent) 33%, transparent);
 	--badge-borderColor: color-mix(in srgb, var(--accent) 40%, transparent);
 	--badge-textColor: currentColor;
+	--badge-backdropFilter: none;
 
 	display: inline-flex;
 	gap: 0.15em;
@@ -791,6 +792,7 @@ summary {
 	border-radius: 0.375em;
 	background-color: var(--badge-backgroundColor);
 	border: 1px solid var(--badge-borderColor);
+	backdrop-filter: var(--badge-backdropFilter);
 
 	color: var(--badge-textColor);
 	font-weight: 600;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,7 +30,8 @@
 	--rating-fail: light-dark(#FF969699,#FB6682);
 	--rating-partial: light-dark(#FFCC7399,#FFCC73);
 	--rating-neutral: #bdc3c7;
-	--rating-unrated: light-dark(oklch(0.75 0.02 244.87), oklch(0.67 0.01 264.61));
+	--rating-unrated: light-dark(oklch(0.75 0.02 244.87 / 0.45), oklch(0.72 0.015 264.61 / 0.35));
+	--rating-unrated-backdropFilter: blur(6px);
 	--rating-icon-color: #000000;
 
 	--icon-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 3 3'%3E%3Cpath d='m.5 1 1 1 1-1' fill='none' stroke='black' stroke-width='0.5' stroke-linecap='round' stroke-linejoin='round' /%3E%3C/svg%3E");

--- a/src/views/ScoreBadge.svelte
+++ b/src/views/ScoreBadge.svelte
@@ -45,6 +45,7 @@
 	data {
 		&[value='UNRATED'] {
 			--accent: var(--rating-unrated);
+			--badge-backdropFilter: var(--rating-unrated-backdropFilter);
 		}
 	}
 </style>

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -1730,12 +1730,12 @@
 			from {
 				--isTransformed: 1;
 				--pie-slice-highlightIndex: 0;
-				--pie-rotate: calc(-0.25turn + 0.5turn / var(--attributesCount));
+				--pie-rotate: 0turn;
 			}
 			to {
 				--isTransformed: 1;
 				--pie-slice-highlightIndex: var(--attributesCount);
-				--pie-rotate: calc(-0.25turn + 0.5turn / var(--attributesCount) + 1turn);
+				--pie-rotate: 1turn;
 			}
 			100% {
 				--isTransformed: 0;

--- a/src/views/WalletStageBadge.svelte
+++ b/src/views/WalletStageBadge.svelte
@@ -70,6 +70,7 @@
 		&[value='NO_STAGES'],
 		&[value='NOT_APPLICABLE'] {
 			--accent: var(--rating-unrated);
+			--badge-backdropFilter: var(--rating-unrated-backdropFilter);
 		}
 
 		&[value='NO_STAGES'] {


### PR DESCRIPTION
* Default pies to have first slice centered north instead of bordering north
  * fixes https://github.com/walletbeat/walletbeat/issues/912
* Fix regression where slice base background colors were no longer neutral
* Add backdrop blur behind "unrated" slices and related badges instead of a solid gray fill

<img width="771" height="761" alt="Screenshot 2026-07-13 at 03 50 43" src="https://github.com/user-attachments/assets/c0da06c1-1bc2-40b1-bb04-6f9e404c58e7" />

<img width="425" alt="Screenshot 2026-07-13 at 03 38 25" src="https://github.com/user-attachments/assets/dc1e0446-1cad-4c46-82db-bf368ab08fb7" /> <img width="340" alt="Screenshot 2026-07-13 at 03 57 23" src="https://github.com/user-attachments/assets/ef895e39-2dd2-4cea-8b26-4e460cb04ee8" />


## Components

* `<Pie>`:
  * center the first slice at the top by default
  * remove the wallet page's pie rotation offset
  * drop the solid fill behind transparent gradient stops
  * blur unrated slices against content behind the pie

## Views

* `<ScoreBadge>` / `<WalletStageBadge>`:
  * apply backdrop blur to unrated badge fills
