### PR TITLE
L1 provider independence: Set verifiability bit.

### DIFF
--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -125,7 +125,7 @@ export const ratingIcons = {
 } as const
 
 /**
- * Convert a rating to the icon displayed on the slice tooltip.
+ * Convert a rating to a human-readable text.
  */
 export function ratingToText(rating: Rating): string {
 	switch (rating) {
@@ -699,11 +699,7 @@ export class EvaluationContext<_OutcomeMetadata extends OutcomeMetadata = null> 
 		attribute: Attribute<_OutcomeMetadata>,
 		features: ResolvedFeatures,
 	): EvaluationContext<_OutcomeMetadata> {
-		const ctx = new EvaluationContext<_OutcomeMetadata>(() => attribute, features, false)
-
-		ctx.isForTest = true
-
-		return ctx
+		return new EvaluationContext<_OutcomeMetadata>(() => attribute, features, false)
 	}
 
 	private constructor(

--- a/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
+++ b/src/schema/attributes/self-sovereignty/l1-provider-independence.ts
@@ -4,6 +4,7 @@ import {
 	EvaluationContext,
 	exampleRating,
 	Rating,
+	Verifiability,
 } from '@/schema/attributes'
 import { isSupported, notSupported } from '@/schema/features/support'
 import { markdown, mdParagraph, paragraph, sentence } from '@/types/content'
@@ -197,6 +198,9 @@ export const l1ProviderIndependence: Attribute = {
 		],
 	},
 	evaluate: ctx => {
+		// Self-verifiable via RPC configuration or selective traffic blocking.
+		ctx.setVerifiability(Verifiability.VERIFIABLE)
+
 		if (ctx.features.chainConfigurability === null) {
 			return unrated(ctx)
 		}


### PR DESCRIPTION
Remove fallback `isForTest = true` from main EvaluationContext constructor.