### PR TITLE
EIP tracker: refresh stale statuses against upstream specs

### DIFF
--- a/data/eips/eip-7702.ts
+++ b/data/eips/eip-7702.ts
@@ -5,7 +5,7 @@ export const eip7702: Eip = {
 	formalTitle: 'Set EOA account code',
 	number: '7702',
 	prefix: EipPrefix.EIP,
-	status: EipStatus.LAST_CALL,
+	status: EipStatus.FINAL,
 	summaryMarkdown: `
 		Smart contract accounts require their own Ethereum address by definition.
 		EIP-7702 builds on top of ERC-4337 by allowing non-smart-contract accounts

--- a/data/eips/erc-4337.ts
+++ b/data/eips/erc-4337.ts
@@ -7,7 +7,7 @@ export const erc4337: Eip = {
 	formalTitle: 'Account Abstraction Using Alt Mempool',
 	number: '4337',
 	prefix: EipPrefix.ERC,
-	status: EipStatus.DRAFT,
+	status: EipStatus.FINAL,
 	summaryMarkdown: `
 		ERC-4337 defines a standard for account abstraction without changes to
 		the Ethereum protocol, relying on a separate transaction mempool that

--- a/data/eips/erc-7828.ts
+++ b/data/eips/erc-7828.ts
@@ -5,7 +5,7 @@ export const erc7828: Eip = {
 	formalTitle: 'Chain-specific addresses using ENS',
 	number: '7828',
 	prefix: EipPrefix.ERC,
-	status: EipStatus.DRAFT,
+	status: EipStatus.REVIEW,
 	summaryMarkdown: `
 		Chain-specific address format that allows specifying both an
 		account and the chain on which that account intends to transact.

--- a/src/components/WalletEipList.svelte
+++ b/src/components/WalletEipList.svelte
@@ -229,6 +229,11 @@
 			color: var(--text-secondary);
 		}
 
+		&[data-status='REVIEW'] {
+			background: color-mix(in srgb, #a78bfa 15%, transparent);
+			color: #a78bfa;
+		}
+
 		&[data-status='LIVING'] {
 			background: color-mix(in srgb, #38bdf8 15%, transparent);
 			color: #38bdf8;

--- a/src/schema/eips.ts
+++ b/src/schema/eips.ts
@@ -20,6 +20,7 @@ export type EipNumber =
  */
 export enum EipStatus {
 	DRAFT = 'DRAFT',
+	REVIEW = 'REVIEW',
 	FINAL = 'FINAL',
 	LIVING = 'LIVING',
 	LAST_CALL = 'LAST_CALL',
@@ -101,6 +102,7 @@ export function eipMarkdownLinkAndTitle(eip: Eip): string {
 export const eipStatusLabel: Record<EipStatus, string> = {
 	[EipStatus.FINAL]: 'Final',
 	[EipStatus.DRAFT]: 'Draft',
+	[EipStatus.REVIEW]: 'Review',
 	[EipStatus.LIVING]: 'Living',
 	[EipStatus.LAST_CALL]: 'Last Call',
 }


### PR DESCRIPTION
## What

Re-verified the `status` field of all 12 EIPs in the tracker against their upstream front-matter (`eips.ethereum.org` for EIPs, `ethereum/ERCs` for ERCs). Three had drifted:

| EIP | was | now | source |
|-----|-----|-----|--------|
| EIP-7702 | Last Call | **Final** | finalized with Pectra |
| ERC-4337 | Draft | **Final** | `ethereum/ERCs` front-matter |
| ERC-7828 | Draft | **Review** | `ethereum/ERCs` front-matter |

ERC-7828's real status is **Review**, which the `EipStatus` enum did not model — added `EipStatus.REVIEW` and its `Review` label. The other nine statuses were already accurate and are unchanged.

The status chip in `WalletEipList.svelte` colors each status via a `data-status` rule but had none for `REVIEW`, so the new chip would render uncolored — added a violet-400 variant, consistent with the component's existing green/sky/yellow-400 palette, in EIP-process order between Draft and Last Call.

## Verification

- `tsc --noEmit`: clean
- `prettier --check` / `cspell` / `eslint` on the changed files: clean
- Status chip now has a distinct color for every `EipStatus` value.