### PR TITLE
EIP tracker: add scheduled drift-check workflow

### DIFF
--- a/.github/workflows/eip-status-drift.yaml
+++ b/.github/workflows/eip-status-drift.yaml
@@ -1,0 +1,30 @@
+name: EIP status drift
+
+on:
+  workflow_dispatch: {} # On demand
+  schedule: # On schedule
+    - cron: '0 8 * * 1' # Every Monday at 08:00 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  eip-status-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.9
+      - name: Install Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Report EIP status drift
+        run: ./deploy/eip-status/report-drift.sh
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/deploy/eip-status/report-drift.sh
+++ b/deploy/eip-status/report-drift.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Runs the EIP status checker and maintains a single "EIP status drift" tracking
+# issue: opens or updates it when drift is found, and closes it once everything
+# is back in sync. Warning-only — this script never fails the workflow.
+#
+# Requires: gh (authenticated via the GH_TOKEN environment variable) and jq.
+
+LABEL='eip-status-drift'
+TITLE='EIP status drift detected'
+
+report="$(pnpm --silent check:eip-status --json)"
+
+total="$(jq '.summary.total' <<<"$report")"
+drift="$(jq '.summary.drift' <<<"$report")"
+unverifiable="$(jq '.summary.unverifiable' <<<"$report")"
+checked_at="$(jq -r '.checkedAt' <<<"$report")"
+
+echo "Checked ${total} EIPs: ${drift} drifted, ${unverifiable} unverifiable."
+
+# Ensure the tracking label exists (safe to re-run).
+gh label create "$LABEL" \
+	--color 'B60205' \
+	--description 'A tracked EIP status differs from its upstream spec' \
+	2>/dev/null || true
+
+existing="$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number // empty')"
+
+if [[ "$drift" -gt 0 ]]; then
+	body="$(mktemp)"
+	{
+		echo 'The scheduled `EIP status drift` workflow found tracked EIP statuses that differ from their upstream specs.'
+		echo
+		echo '| EIP | Walletbeat | Upstream | Spec |'
+		echo '| --- | --- | --- | --- |'
+		jq -r '.drift[] | "| \(.eip) | `\(.ours)` | `\(.upstream)` | \(.url) |"' <<<"$report"
+
+		if [[ "$unverifiable" -gt 0 ]]; then
+			echo
+			echo "<details><summary>Unverifiable (${unverifiable})</summary>"
+			echo
+			jq -r '.unverifiable[] | "- \(.eip): \(.note)"' <<<"$report"
+			echo
+			echo '</details>'
+		fi
+
+		echo
+		echo "_Last checked: ${checked_at}. Update the \`status\` field in \`data/eips/\` to match upstream (or the upstream spec if Walletbeat is ahead)._"
+	} >"$body"
+
+	if [[ -n "$existing" ]]; then
+		gh issue edit "$existing" --body-file "$body"
+		echo "Updated existing drift issue #${existing}."
+	else
+		gh issue create --title "$TITLE" --label "$LABEL" --body-file "$body"
+		echo 'Opened a new drift issue.'
+	fi
+else
+	echo 'No drift detected.'
+
+	if [[ -n "$existing" ]]; then
+		gh issue comment "$existing" \
+			--body "No drift as of ${checked_at}: tracked statuses are back in sync. Closing."
+		gh issue close "$existing"
+		echo "Closed drift issue #${existing}."
+	fi
+fi

--- a/deploy/eip-status/report-drift.sh
+++ b/deploy/eip-status/report-drift.sh
@@ -35,7 +35,7 @@ if [[ "$drift" -gt 0 ]]; then
 		echo
 		echo '| EIP | Walletbeat | Upstream | Spec |'
 		echo '| --- | --- | --- | --- |'
-		jq -r '.drift[] | "| \(.eip) | `\(.ours)` | `\(.upstream)` | \(.url) |"' <<<"$report"
+		jq -r '.drift[] | "| \(.eip) | `\(.ours)` | `\(.upstream // .upstreamRaw)` | \(.url) |"' <<<"$report"
 
 		if [[ "$unverifiable" -gt 0 ]]; then
 			echo

--- a/deploy/eip-status/report-drift.sh
+++ b/deploy/eip-status/report-drift.sh
@@ -31,11 +31,16 @@ existing="$(gh issue list --label "$LABEL" --state open --json number --jq '.[0]
 if [[ "$drift" -gt 0 ]]; then
 	body="$(mktemp)"
 	{
-		echo 'The scheduled `EIP status drift` workflow found tracked EIP statuses that differ from their upstream specs.'
+		echo 'The scheduled `EIP status drift` workflow found tracked EIPs whose recorded fields differ from their upstream specs.'
 		echo
-		echo '| EIP | Walletbeat | Upstream | Spec |'
-		echo '| --- | --- | --- | --- |'
-		jq -r '.drift[] | "| \(.eip) | `\(.ours)` | `\(.upstream // .upstreamRaw)` | \(.url) |"' <<<"$report"
+		echo '| EIP | Field | Walletbeat | Upstream | Spec |'
+		echo '| --- | --- | --- | --- | --- |'
+		# One row per mismatch: an EIP can drift on both its status and its prefix.
+		# `.upstream` is null for an upstream status Walletbeat does not model
+		# (Stagnant, Withdrawn, …), so fall back to the raw frontmatter value.
+		jq -r '.drift[] as $d | $d.mismatches[]
+			| "| \($d.eip) | \(.field) | `\(.ours)` | `\(.upstream // .upstreamRaw)` | \($d.url) |"' \
+			<<<"$report"
 
 		if [[ "$unverifiable" -gt 0 ]]; then
 			echo
@@ -47,7 +52,7 @@ if [[ "$drift" -gt 0 ]]; then
 		fi
 
 		echo
-		echo "_Last checked: ${checked_at}. Update the \`status\` field in \`data/eips/\` to match upstream (or the upstream spec if Walletbeat is ahead)._"
+		echo "_Last checked: ${checked_at}. Update the drifted field in \`data/eips/\` to match upstream (or the upstream spec if Walletbeat is ahead)._"
 	} >"$body"
 
 	if [[ -n "$existing" ]]; then


### PR DESCRIPTION
Fast-follow to #936 (stacked on it). Adds the "automatic" half of @polymutex's request on #935.

## What

A weekly `EIP status drift` GitHub Action (`workflow_dispatch` + `schedule`, Mondays 08:00 UTC) that runs `pnpm check:eip-status --json` and maintains a **single** tracking issue via `deploy/eip-status/report-drift.sh`:

- opens a `eip-status-drift`-labelled issue when a tracked status differs from upstream,
- edits that same issue on subsequent runs (no duplicate spam),
- closes it automatically once statuses are back in sync.

## Precedent / safety

Mirrors the existing scheduled `helios-refresh.yaml` (cron + `workflow_dispatch`, `pnpm install`) — so a scheduled, dependency-installing job is already an established pattern here. Unlike helios (which auto-commits to `beta`), this workflow is **read-only on the repository**: `permissions: contents: read, issues: write`, and it only files an issue through `GITHUB_TOKEN`. It never touches the branch or the deploy.

## Stacking

Based on `ren2140-eip-status-check` (#936) because the workflow calls the `check:eip-status` script added there. GitHub will retarget this to `beta` once #936 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)