### PR TITLE
Less prominent hw embedded wallets

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -178,30 +178,6 @@ export const defaultNavigationItems = [
 			},
 		],
 	},
-	{
-		id: 'embedded-wallets',
-		title: 'Embedded Wallets',
-		href: '/embedded/summary/',
-		icon: 'wallet_embedded',
-		children: [
-			{
-				id: 'embedded-by-rating',
-				title: 'By Rating',
-				icon: 'ICON_CHART_PIE',
-				children: mapNonExemptAttributeGroupsInTree(
-					attributeTree,
-					representativeWalletForType(WalletType.EMBEDDED).overall,
-					(attrGroup, _evalGroup) => ({
-						id: `embedded-${attrGroup.id}`,
-						title: attrGroup.displayName,
-						icon: attrGroup.icon,
-						iconVariant: 'emoji' as const,
-						href: `/embedded/${attrGroup.id}/`,
-					}),
-				),
-			},
-		],
-	},
 	navigationNews,
 	navigationWalletEips,
 	navigationTesting,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,8 +44,6 @@ import HardwareWalletTable from '@/views/HardwareWalletTable.svelte'
 		</header>
 
 		<SoftwareWalletTable client:visible title='Software Wallets' />
-
-		<HardwareWalletTable client:visible title='Hardware Wallets' />
 	</main>
 </Layout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,6 @@ import Layout from '../layouts/Layout.astro'
 // Components
 import Navigation from '@/views/Navigation.astro'
 import SoftwareWalletTable from '@/views/SoftwareWalletTable.svelte'
-import HardwareWalletTable from '@/views/HardwareWalletTable.svelte'
 ---
 
 <Layout

--- a/src/views/HardwareWalletTable.svelte
+++ b/src/views/HardwareWalletTable.svelte
@@ -18,11 +18,14 @@
 		tableId?: string
 		title?: string
 	} = $props()
+
+	const titleDisclaimer = 'Hardware wallets are in beta and our methodology is subject to change at any time.'
 </script>
 
 <WalletTable
 	{tableId}
 	{title}
+	{titleDisclaimer}
 	ladders={hardwareLadders}
 	{wallets}
 	attributeTree={hardwareWalletAttributeTree}

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -32,6 +32,7 @@
 	let {
 		tableId,
 		title,
+		titleDisclaimer,
 		ladders,
 		wallets,
 		attributeTree,
@@ -39,6 +40,7 @@
 	}: {
 		tableId?: string,
 		title?: string
+		titleDisclaimer?: string
 		ladders?: Ladders<_AttributeGroupId>
 		wallets: RatedWallet<_AttributeGroupId>[]
 		attributeTree: AttributeTree<_AttributeGroupId>
@@ -396,7 +398,13 @@
 		data-row="wrap"
 	>
 		{#if title}
-			<h2>{title}</h2>
+			<div class="title-group" data-column="gap-1">
+				<h2>{title}</h2>
+
+				{#if titleDisclaimer}
+					<p class="title-disclaimer">{titleDisclaimer}</p>
+				{/if}
+			</div>
 		{/if}
 
 		<!-- Mobile-only filter UI -->
@@ -1822,6 +1830,11 @@
 				}
 			}
 		}
+	}
+
+	.title-disclaimer {
+		font-size: 0.9rem;
+		color: var(--text-secondary);
 	}
 
 	.wallet-info {


### PR DESCRIPTION
Closes #664
### Changes
- Removed embedded wallets navigation
- Removed hardware wallets table from the homepage
- Added a disclaimer in the hardware wallets table (see image)

<img width="1822" height="1099" alt="image" src="https://github.com/user-attachments/assets/7834f980-f597-43dc-bdc4-5870a9c18356" />