### PR TITLE
Fix: Add navigation to markdown pages

### DIFF
--- a/src/layouts/MarkdownPage.astro
+++ b/src/layouts/MarkdownPage.astro
@@ -59,7 +59,7 @@ const processedMarkdown = stripMarkdownTitle(
 		keywordsBefore: metadata.keywordsBefore,
 	}}
 >
-	<Navigation navigationItems={defaultNavigationItems} />
+	<Navigation slot='nav' navigationItems={defaultNavigationItems} />
 
 	<main data-sticky-container data-column='gap-8'>
 		<header data-scroll-item='inline-detached padding-match-start'>


### PR DESCRIPTION
Current website doesn't have a sidebar for mark markdown pages like the `/about` page

<img width="1916" height="1080" alt="image" src="https://github.com/user-attachments/assets/f6f91cec-d006-47fa-b024-9a9aa348c0ed" />
