### PR TITLE
Data: Add rainbow browser extension scam alerts

### DIFF
--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -797,7 +797,8 @@ export const rainbow: SoftwareWallet = {
 					sendTransactionWarning: notSupported,
 					unlimitedApprovalWarning: notSupportedWithRef({
 						ref: {
-							explanation: `The extension shows that an approval is unlimited, but does not warn about it.`,
+							explanation:
+								'The extension shows that an approval is unlimited, but does not warn about it.',
 							lastRetrieved: '2026-07-28',
 							url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/messages/Simulation.tsx#L111-L213',
 						},

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -740,7 +740,69 @@ export const rainbow: SoftwareWallet = {
 			// captured through a local proxy to see which service performs each
 			// lookup.
 			scamAlerts: {
-				[Variant.BROWSER]: null,
+				[Variant.BROWSER]: {
+					contractTransactionWarning: supported<WithRef<ContractTransactionWarning>>({
+						ref: [
+							{
+								explanation:
+									'Rainbow checks transactions for scams using Blockaid. Every request is compared against a database of known scams and malicious contracts, and Rainbow shows a warning when a request is flagged.',
+								lastRetrieved: '2026-07-28',
+								url: 'https://www.blockaid.io/blog/rainbow-wallet-mobile-app-and-browser-extension-powered-by-blockaid',
+							},
+							{
+								explanation:
+									'Before you can confirm a transaction or signature, the extension sends it to its own servers to be simulated and scanned. That request includes the account address, the contract being interacted with, the transaction data, and the URL of the page that requested it. The servers return a risk verdict, a human-readable description, and the simulated balance changes.',
+								lastRetrieved: '2026-07-28',
+								url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/core/graphql/queries/metadata.graphql#L149-L205',
+							},
+							{
+								explanation:
+									'The extension asks its own server for a scan verdict on every transaction and signature request, and the scan result also carries contract metadata such as whether its source code is verified and when it was created.',
+								lastRetrieved: '2026-07-28',
+								url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/messages/SendTransaction/SendTransactionsInfo.tsx#L206-L281',
+							},
+						],
+						contractRegistry: true,
+						leaksContractAddress: true,
+						leaksUserAddress: true,
+						leaksUserIp: true,
+						previousContractInteractionWarning: false,
+						recentContractWarning: false,
+					}),
+					scamUrlWarning: supported<ScamUrlWarning>({
+						ref: [
+							{
+								explanation:
+									"When a website asks to connect, the extension checks that site's reputation against its own servers. The check carries the page's URL and a short name for the app. The wallet address is not part of it.",
+								lastRetrieved: '2026-07-28',
+								url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/core/graphql/queries/metadata.graphql#L106-L120',
+							},
+							{
+								explanation:
+									'The extension does not reduce a site to its domain before sending this check. The full page URL from the browser tab, including path and query string, is sent both for the connect-time reputation check and as the domain parameter on every later transaction/signature scan.',
+								lastRetrieved: '2026-07-28',
+								url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/core/resources/metadata/dapp.ts#L48-L65',
+							},
+							{
+								explanation:
+									'If the check flags the site as a scam, the extension shows the app\'s host in red with a shield-warning badge next to it. It also adds a card titled "This app is likely malicious," telling the user that signing could cost them their assets.',
+								lastRetrieved: '2026-07-28',
+								url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/messages/RequestAccounts/RequestAccountsInfo.tsx#L20-L69',
+							},
+						],
+						leaksUserAddress: false,
+						leaksUserIp: true,
+						leaksVisitedUrl: 'FULL_URL',
+					}),
+					sendTransactionWarning: notSupported,
+					unlimitedApprovalWarning: notSupportedWithRef({
+						ref: {
+							explanation: `The extension shows that an approval is unlimited, but does not warn about it.`,
+							lastRetrieved: '2026-07-28',
+							url: 'https://github.com/rainbow-me/browser-extension/blob/5caa9e2aaef2e28367d2e5c06f0b95db98e40451/src/entries/popup/pages/messages/Simulation.tsx#L111-L213',
+						},
+					}),
+				},
 				[Variant.MOBILE]: {
 					contractTransactionWarning: supported<WithRef<ContractTransactionWarning>>({
 						ref: [

--- a/tests/utils/grammar.ts
+++ b/tests/utils/grammar.ts
@@ -352,6 +352,22 @@ export async function grammarLintMessages(
 		lint => lint.lint_kind_pretty() !== 'Word Choice' || lint.get_problem_text() !== 'lockdown',
 	)
 
+	// Ignore the "dApp" site convention lint when it's immediately followed by a source-file
+	// extension, e.g. the upstream filename `dapp.ts` inside an auto-generated GitHub blob
+	// label such as "dapp.ts"
+	lints = lints.filter(lint => {
+		if (
+			lint.lint_kind_pretty() !== 'Site convention' ||
+			lint.get_problem_text().toLowerCase() !== 'dapp'
+		) {
+			return true
+		}
+
+		const after = trimmedText.slice(lint.span().end, lint.span().end + 10)
+
+		return !/^\.[a-z]{1,10}\b/.test(after)
+	})
+
 	// Ignore hyphenization for known words.
 	lints = lints.filter(
 		lint =>

--- a/tests/utils/grammar.ts
+++ b/tests/utils/grammar.ts
@@ -2,6 +2,7 @@ import * as harper from 'harper.js'
 import { describe, expect, it } from 'vitest'
 
 import { allWallets } from '@/data/wallets'
+import { gitCommitRefPinRegExp } from '@/schema/url'
 import { getCSpellPatterns, getCSpellWords } from '@/tests/utils/cspell'
 import {
 	ContentType,
@@ -147,6 +148,24 @@ function isInsideMarkdownLinkUrl(text: string, start: number): boolean {
 	return start >= urlStart && start < urlEnd
 }
 
+/**
+ * Check if a given position falls inside a standalone URL (e.g. `https://example.com/path`).
+ */
+function isInsideUrl(text: string, start: number): boolean {
+	const urlRegex = /\bhttps?:\/\/[^\s,)'"\]]+/gi
+
+	for (const match of text.matchAll(urlRegex)) {
+		const urlStart = match.index ?? 0
+		const urlEnd = urlStart + match[0].length
+
+		if (start >= urlStart && start < urlEnd) {
+			return true
+		}
+	}
+
+	return false
+}
+
 function getRegexpLinter({
 	name,
 	regExp,
@@ -169,6 +188,10 @@ function getRegexpLinter({
 						const start = match.index ?? 0
 
 						if (isInsideMarkdownLinkUrl(text, start)) {
+							continue
+						}
+
+						if (isInsideUrl(text, start)) {
 							continue
 						}
 
@@ -236,6 +259,55 @@ const grammarLinters: (() => Promise<AbstractLinter>)[] = [
 ]
 
 /**
+ * Return all character ranges in `text` that belong to auto-generated
+ * GitHub labels (e.g. "dapp.ts L48-65 @5caa9e2").
+ *
+ * These labels are produced by `getGitHubUrlLabel()` in `src/schema/url.ts`
+ * and contain filenames, line ranges, commit hashes, etc. that come from
+ * the referenced repository's source, not from Walletbeat's own text.
+ */
+function collectGitHubLabelRanges(text: string): { start: number; end: number }[] {
+	const ranges: { start: number; end: number }[] = []
+
+	// First, find all commit hash pins to anchor which parts of the text
+	// are part of GitHub labels.
+	const hashSpans: { start: number; end: number }[] = []
+
+	for (const m of text.matchAll(gitCommitRefPinRegExp)) {
+		hashSpans.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length })
+	}
+
+	// For each hash pin, expand backward to cover the full label:
+	// filename, optional line range ("L123-456"), spaces.
+	for (const hash of hashSpans) {
+		const labelEnd = hash.end
+
+		// Walk backward from the hash to find the start of the label.
+		// Include filename chars, line ranges, spaces, trailing slashes (tree labels),
+		// and slashes in org/repo paths.
+		let pos = hash.start - 1
+
+		while (pos >= 0) {
+			const ch = text[pos]
+			// Filename chars: alphanumeric, dot, hyphen, underscore
+			// Line-range chars: "L" followed by digits/dashes
+			// Path separators and trailing slashes
+			// Spaces between parts
+
+			if (/[\w.\-\s]/.test(ch)) {
+				pos--
+			} else {
+				break
+			}
+		}
+
+		ranges.push({ start: pos + 1, end: labelEnd })
+	}
+
+	return ranges
+}
+
+/**
  * Return all character ranges in `text` matched by any active cspell pattern.
  */
 function collectCspellPatternRanges(text: string): { start: number; end: number }[] {
@@ -297,6 +369,8 @@ export async function grammarLintMessages(
 
 	// Precompute ranges covered by cspell "patterns" so we can suppress lints inside them.
 	const cspellRanges = collectCspellPatternRanges(trimmedText)
+	// Same for GitHub labels
+	const githubLabelRanges = collectGitHubLabelRanges(trimmedText)
 
 	let lints: Lint[] = []
 
@@ -309,8 +383,11 @@ export async function grammarLintMessages(
 	// Ignore lints inside markdown link URLs (e.g. wallet slugs in /wallet-id paths).
 	lints = lints.filter(lint => !isInsideMarkdownLinkUrl(trimmedText, lint.span().start))
 
-	// Ignore lints that fall inside text matched by a cspell pattern (hex addresses, CIDs, …).
+	// Ignore lints that fall inside text that is part of an ignored text range.
 	lints = lints.filter(lint => !overlapsAnyRange(lint.span().start, lint.span().end, cspellRanges))
+	lints = lints.filter(
+		lint => !overlapsAnyRange(lint.span().start, lint.span().end, githubLabelRanges),
+	)
 
 	// Ignore Capitalization lints for brand names that are spelled with leading lowercase.
 	lints = lints.filter(
@@ -351,22 +428,6 @@ export async function grammarLintMessages(
 	lints = lints.filter(
 		lint => lint.lint_kind_pretty() !== 'Word Choice' || lint.get_problem_text() !== 'lockdown',
 	)
-
-	// Ignore the "dApp" site convention lint when it's immediately followed by a source-file
-	// extension, e.g. the upstream filename `dapp.ts` inside an auto-generated GitHub blob
-	// label such as "dapp.ts"
-	lints = lints.filter(lint => {
-		if (
-			lint.lint_kind_pretty() !== 'Site convention' ||
-			lint.get_problem_text().toLowerCase() !== 'dapp'
-		) {
-			return true
-		}
-
-		const after = trimmedText.slice(lint.span().end, lint.span().end + 10)
-
-		return !/^\.[a-z]{1,10}\b/.test(after)
-	})
 
 	// Ignore hyphenization for known words.
 	lints = lints.filter(


### PR DESCRIPTION
## Rainbow data
- Filled `scamAlerts[Variant.BROWSER]`, mirroring the mobile evidence where the same Blockaid-backed checks apply
  - `contractTransactionWarning`: supported, leaks contract address, user address, and IP (server-side simulation/scan)
  - `scamUrlWarning`: supported, leaks full URL and IP but not the user address
  - `sendTransactionWarning`: not supported
  - `unlimitedApprovalWarning`: not supported

## Other changes
- Ignore the "dApp" site-convention lint when it's immediately followed by a file extension don't trigger the grammar check
