### PR TITLE
Data: add account recovery drills to zerion not supported

### DIFF
--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -182,7 +182,15 @@ export const zerion: SoftwareWallet = {
 		profile: WalletProfile.GENERIC,
 		security: {
 			accountRecovery: {
-				drills: null,
+				drills: notSupportedWithRef({
+					ref: [
+						{
+							explanation:
+								'Zerion only warns about backing up the recovery phrase if it has never been backed up (`lastBackedUp == null`). Once the backup is confirmed `lastBackedUp` is set and never reset, so the reminder never reappears.',
+							url: 'https://github.com/zeriontech/zerion-wallet-extension/blob/482c0a5f57cee79b618147c804a92a98240c559a/src/ui/components/BackupInfoNote/BackupInfoNote.tsx#L12-L18',
+						},
+					],
+				}),
 				guardianRecovery: notSupported,
 			},
 			bugBountyProgram: supported<BugBountyProgramImplementation>({


### PR DESCRIPTION
Just like metamask #985, only warns users to backup if not yet backed up in the first place