### PR TITLE
Remove a few not-so-useful tooltips.

### DIFF
--- a/src/schema/attribute-groups.ts
+++ b/src/schema/attribute-groups.ts
@@ -350,28 +350,6 @@ export const calculateOverallScore = <_AttributeGroupId extends string>(
 }
 
 /**
- * Format title text for an attribute group.
- * @param attrGroup The attribute group to format.
- * @param groupScore The score for the group, or null if not available.
- * @param showScores Whether to show scores in the title.
- * @returns Formatted title text showing icon and score (if enabled) or just display name.
- */
-export const formatAttributeGroupTitleText = (
-	attrGroup: AttributeGroup<string>,
-	groupScore: MaybeUnratedScore,
-	showScores: boolean,
-) =>
-	`${attrGroup.icon} ${attrGroup.displayName}${
-		showScores
-			? `\n\n${
-					groupScore !== null && groupScore.score !== null
-						? `${(groupScore.score * 100).toFixed(0)}%${groupScore.hasUnratedComponent ? ' (has unrated components)' : ''}`
-						: 'N/A'
-				}`
-			: ''
-	}`
-
-/**
  * Look up an attribute group by ID, verifying that it exists and is not
  * entirely exempt from the given EvaluationTree.
  */

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -970,23 +970,3 @@ export function exampleRating<_OutcomeMetadata extends OutcomeMetadata = null>(
 		sampleEvaluations,
 	}
 }
-
-/**
- * Format title text for an attribute pie slice.
- * @param attribute The evaluated attribute to format.
- * @param suffix Optional suffix to append to the title.
- * @returns Formatted title text in the format: "(icon) title [(eval icon) EVAL OUTCOME]\n\n(displayName)"
- */
-export const formatAttributeTitleText = (
-	attribute: EvaluatedAttribute<OutcomeMetadata>,
-	suffix?: string,
-) =>
-	`${attribute.evaluation.outcome.icon ?? attribute.attribute.icon} ${
-		attribute.attribute.displayName
-	}${suffix ?? ''} [${ratingIcons[attribute.evaluation.outcome.rating]} ${
-		attribute.evaluation.outcome.rating
-	}]${
-		![Rating.EXEMPT, Rating.UNRATED].includes(attribute.evaluation.outcome.rating)
-			? `\n\n${attribute.evaluation.outcome.displayName}`
-			: ''
-	}`

--- a/src/views/WalletAttributeSummary.svelte
+++ b/src/views/WalletAttributeSummary.svelte
@@ -40,12 +40,10 @@
 
 	// Functions
 	import { variantToName } from '@/constants/variants'
-	import { slugifyCamelCase } from '@/types/utils/text'
 	import { getWalletUrl } from '@/utils/urls'
 
 
 	// Components
-	import InfoIcon from '@material-icons/svg/svg/info/baseline.svg?raw'
 	import Typography from '../components/Typography.svelte'
 	import Tooltip from '@/components/Tooltip.svelte'
 	import WalletStageSummary from './WalletStageSummary.svelte'
@@ -153,15 +151,6 @@
 			{/if}
 		{/if}
 	</p>
-
-	<div>
-		<a
-			href={getWalletUrl(wallet, { variant, attributeAnchor: slugifyCamelCase(attribute.attribute.id) })}
-		>
-			<span>{@html InfoIcon}</span>
-			Learn more
-		</a>
-	</div>
 </div>
 
 

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -52,7 +52,6 @@
 		type AttributeGroup,
 		calculateAttributeGroupScore,
 		calculateOverallScore,
-		formatAttributeGroupTitleText,
 	} from '@/schema/attribute-groups'
 	import { toFullyQualified } from '@/schema/reference'
 	import { getAttributeOverride } from '@/schema/wallet'
@@ -407,10 +406,6 @@
 	const overallScore = $derived(
 		calculateOverallScore(attributeTree, wallet.overall, () => true),
 	)
-
-
-	// Functions
-	import { formatAttributeTitleText } from '@/schema/attributes'
 
 
 	// Components
@@ -954,7 +949,7 @@
 									href={`#${slugifyCamelCase(attrGroup.id)}`}
 									interestfor={slugifyCamelCase(attrGroup.id)}
 								>
-									<h2 title={formatAttributeGroupTitleText(attrGroup, score, showScores)}>
+									<h2>
 										{attrGroup.displayName}
 									</h2>
 								</a>
@@ -1074,9 +1069,7 @@
 									href={`#${slugifyCamelCase(attribute.id)}`}
 									interestfor={slugifyCamelCase(attribute.id)}
 								>
-									<h3
-										title={formatAttributeTitleText(evalAttr)}
-									>
+									<h3>
 										{attribute.displayName}
 									</h3>
 								</a>

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -234,8 +234,8 @@
 
 	// Functions
 	import { variantToName } from '@/constants/variants'
-	import { calculateAttributeGroupScore, calculateOverallScore, formatAttributeGroupTitleText } from '@/schema/attribute-groups'
-	import { evaluatedAttributesEntries, ratingToColor, formatAttributeTitleText } from '@/schema/attributes'
+	import { calculateAttributeGroupScore, calculateOverallScore } from '@/schema/attribute-groups'
+	import { evaluatedAttributesEntries, ratingToColor } from '@/schema/attributes'
 	import { formatScore } from '@/schema/score'
 	import { isLabeledUrl } from '@/schema/url'
 	import { hasVariant } from '@/schema/variants'
@@ -800,40 +800,29 @@
 						{@const stageValue = typeof stage === 'string' ? stage : stage.id}
 						{@const stageFilterId = `stage-${stageValue}`}
 
-						<Tooltip>
-							<div
-								role="button"
-								tabindex="0"
-								aria-label={stage === 'QUALIFIED_FOR_NO_STAGES' ? 'Filter by No Stage' : stage && typeof stage === 'object' ? `Filter by ${stage.label}` : 'Filter by stage'}
-								onclick={event => {
-									event.preventDefault()
-									event.stopPropagation()
-									toggleAttributeFilterById?.(stageFilterId)
-								}}
-								onkeydown={event => {
-									if (event.key !== 'Enter' && event.key !== ' ') return
+						<div
+							role="button"
+							tabindex="0"
+							aria-label={stage === 'QUALIFIED_FOR_NO_STAGES' ? 'Filter by No Stage' : stage && typeof stage === 'object' ? `Filter by ${stage.label}` : 'Filter by stage'}
+							onclick={event => {
+								event.preventDefault()
+								event.stopPropagation()
+								toggleAttributeFilterById?.(stageFilterId)
+							}}
+							onkeydown={event => {
+								if (event.key !== 'Enter' && event.key !== ' ') return
 
-									event.preventDefault()
-									event.stopPropagation()
-									toggleAttributeFilterById?.(stageFilterId)
-								}}
-							>
-								<WalletStageBadge
-									{stage}
-									{ladderEvaluation}
-									size="medium"
-								/>
-							</div>
-
-							{#snippet TooltipContent()}
-								<WalletStageSummary
-									{wallet}
-									{ladders}
-									{stage}
-									{ladderEvaluation}
-								/>
-							{/snippet}
-						</Tooltip>
+								event.preventDefault()
+								event.stopPropagation()
+								toggleAttributeFilterById?.(stageFilterId)
+							}}
+						>
+							<WalletStageBadge
+								{stage}
+								{ladderEvaluation}
+								size="medium"
+							/>
+						</div>
 					{/if}
 				{:else if column.id === 'displayName'}
 					{@const displayName = value}
@@ -938,13 +927,11 @@
 															label: `#${erc4337.number}`,
 															filterId: 'accountType-erc4337',
 															type: 'eip',
-															eipTooltipContent: erc4337,
 														},
 														AccountType.eip7702 in accountTypes && {
 															label: `#${eip7702.number}`,
 															filterId: 'accountType-eip7702',
 															type: 'eip',
-															eipTooltipContent: eip7702,
 														},
 														AccountType.safe in accountTypes && {
 															label: 'Safe',
@@ -963,49 +950,16 @@
 										]
 											.filter(Boolean)
 									) as tag (tag.label)}
-										{#if tag.eipTooltipContent}
-											<Tooltip
-												placement="inline-end"
-											>
-												<div
-													data-tag={tag.type}
-													role="button"
-													tabindex="0"
-													aria-label="Filter by {tag.label}"
-													onclick={event => {
-														event.stopPropagation()
-														toggleFilterById!(tag.filterId)
-													}}
-													onkeydown={event => {
-														if (event.key !== 'Enter' && event.key !== ' ') return
-
-														event.stopPropagation()
-														toggleFilterById!(tag.filterId)
-													}}
-												>
-													{tag.label}
-												</div>
-
-												{#snippet TooltipContent()}
-													<div class="eip-tooltip-content">
-														<EipDetails
-															eip={tag.eipTooltipContent}
-														/>
-													</div>
-												{/snippet}
-											</Tooltip>
-										{:else}
-											<button
-												data-tag={tag.type}
-												aria-label="Filter by {tag.label}"
-												onclick={event => {
-													event.stopPropagation()
-													toggleFilterById!(tag.filterId)
-												}}
-											>
-												{tag.label}
-											</button>
-										{/if}
+										<button
+											data-tag={tag.type}
+											aria-label="Filter by {tag.label}"
+											onclick={event => {
+												event.stopPropagation()
+												toggleFilterById!(tag.filterId)
+											}}
+										>
+											{tag.label}
+										</button>
 									{/each}
 								</div>
 							</div>
@@ -1157,11 +1111,6 @@
 												:
 													'var(--rating-unrated)'
 											),
-											titleText: formatAttributeGroupTitleText(
-												attrGroup,
-												groupScore,
-												summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.ScoreDot,
-											),
 											gradient: attributeGroupFlowerGradient,
 											weight: 1,
 											...evalGroup && {
@@ -1187,7 +1136,6 @@
 															),
 															arcLabel: '',
 															arcIconId: attribute.attribute.icon,
-															titleText: formatAttributeTitleText(attribute),
 															...attribute.evaluation.outcome.rating === Rating.EXEMPT && {
 																opacity: 0.33,
 															},
@@ -1366,14 +1314,6 @@
 							}
 						>
 							<Pie
-								title={
-									formatAttributeGroupTitleText(
-										attrGroup,
-										groupScore,
-										summaryVisualization === SummaryVisualization.Score || summaryVisualization === SummaryVisualization.ScoreDot,
-									)
-								}
-
 								layout={PieLayout.FullTop}
 								radius={44}
 								levels={[
@@ -1430,7 +1370,6 @@
 												),
 												arcLabel: '',
 												arcIconId: attribute.attribute.icon,
-												titleText: formatAttributeTitleText(attribute, tooltipSuffix),
 												...attribute.evaluation.outcome.rating === Rating.EXEMPT && {
 													opacity: 0.33,
 												},
@@ -1553,8 +1492,6 @@
 							}
 						>
 							<Pie
-								title={formatAttributeTitleText(attribute)}
-
 								layout={PieLayout.HalfTop}
 								radius={24}
 								levels={
@@ -1593,7 +1530,6 @@
 												weight: 1,
 												arcLabel: '',
 												arcIconId: attribute.icon,
-												titleText: formatAttributeTitleText(attribute),
 											}
 										]
 									:
@@ -1722,7 +1658,6 @@
 									arcLabel: (groupScore !== null && groupScore.hasUnratedComponent) ? '*' : '',
 									arcIconId: attrGroup.icon,
 									color: groupScore !== null ? scoreToColor(groupScore.score) : 'var(--rating-unrated)',
-									titleText: formatAttributeGroupTitleText(attrGroup, groupScore, false),
 									gradient: attributeGroupFlowerGradient,
 									weight: 1,
 									...evalGroup && {
@@ -1742,7 +1677,6 @@
 													),
 													arcLabel: '',
 													arcIconId: attribute.attribute.icon,
-													titleText: formatAttributeTitleText(attribute),
 													...attribute.evaluation.outcome.rating === Rating.EXEMPT && { opacity: 0.33 },
 												}))
 										),


### PR DESCRIPTION
This removes:
- Stage tooltips on wallet table (takes over the page)
- EIP tooltips on wallet tale (also takes over the page)
- One of the 2 tooltips shown on pie slice (don't need 2 tooltips), fixes #998
- The "Learn more" button on the other pie slice tooltip (not clickable in practice because they go away before the mouse pointer can reach them), mentioned in #975
- The `<h2>` tooltip on attribute group headers on the per-wallet page (the move to non-emoji attribute group icons makes the tooltip say something like "self_sovereignty Self-sovereignty" which isn't helpful nor descriptive).