### PR TITLE
Fix: Decode binary strings, unreviewed filter, and ISO timestamp as benign strings

### DIFF
--- a/src/tools/wallet-data-collection/wallet-capture-annotations.ts
+++ b/src/tools/wallet-data-collection/wallet-capture-annotations.ts
@@ -73,7 +73,11 @@ function optionalGlobMatches(pattern: string | null, value: string): boolean {
 	return globToRegExp(pattern).test(value)
 }
 
-const GLOBAL_BENIGN_REGULAR_EXPRESSIONS: RegExp[] = [/^chrome-extension:\/\/\w+$/]
+const GLOBAL_BENIGN_REGULAR_EXPRESSIONS: RegExp[] = [
+	/^chrome-extension:\/\/\w+$/,
+	// ISO-8601 timestamps (e.g. event/request timestamps) are not user-identifying on their own.
+	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/,
+]
 
 export interface SaveOptions {
 	/** Verify existing file contents instead of saving. */

--- a/src/tools/wallet-data-collection/wallet-capture-file.ts
+++ b/src/tools/wallet-data-collection/wallet-capture-file.ts
@@ -2483,11 +2483,11 @@ export class WalletCaptureFlow {
 
 			return matcher === null || matcher.purposes !== 'NOT_WALLET_INITIATED'
 		})
-		const keepIndexes = await Promise.all(
+		const readyIndexes = await Promise.all(
 			filtered.map(async req => await req.isReadyForReview(strings)),
 		)
 
-		return filtered.filter((_, i) => keepIndexes[i])
+		return filtered.filter((_, i) => !readyIndexes[i])
 	}
 
 	public unreviewedRequests(): WalletRequestReview[] {

--- a/src/tools/wallet-data-collection/wallet-capture-file.ts
+++ b/src/tools/wallet-data-collection/wallet-capture-file.ts
@@ -91,7 +91,8 @@ interface EncodedWalletDataFlow {
  * Encoded representation of a UserDataString: raw string with optional piece classification.
  */
 interface EncodedUserDataString {
-	str: string
+	str?: string
+	strBase64?: string
 	piece?: UserInfo
 	pieces?: UserInfo[]
 }
@@ -837,12 +838,27 @@ export class UserDataString {
 			pieces.push(...userInfoEnums.assertArray(record.pieces))
 		}
 
-		return new UserDataString(expectString(record.str, `${at}.str`), assertNonEmptyArray(pieces))
+		let str: string
+
+		if (record.strBase64 !== undefined) {
+			const b64 = expectString(record.strBase64, `${at}.strBase64`)
+			const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+
+			str = new TextDecoder('utf-8').decode(Uint8Array.from(atob(padded), c => c.charCodeAt(0)))
+		} else {
+			str = expectString(record.str, `${at}.str`)
+		}
+
+		return new UserDataString(str, assertNonEmptyArray(pieces))
 	}
 
 	public encode(): EncodedUserDataString {
 		const sortedPieces = [...this.pieces].sort(compareUserInfo)
-		const result: EncodedUserDataString = { str: this.str }
+		const bytes = new TextEncoder().encode(this.str)
+		const isAscii = bytes.every(b => b < 128)
+		const result: EncodedUserDataString = isAscii
+			? { str: this.str }
+			: { strBase64: btoa(String.fromCharCode(...bytes)).replace(/=+$/, '') }
 
 		if (sortedPieces.length === 1) {
 			result.piece = sortedPieces[0]

--- a/src/tools/wallet-data-collection/wallet-data-collection-lib.ts
+++ b/src/tools/wallet-data-collection/wallet-data-collection-lib.ts
@@ -768,7 +768,7 @@ function globalAnnotationsPath(): string {
 	return 'data/collection/global.annotations.json'
 }
 
-async function openCaptureFile(options: GlobalOptions): Promise<WalletCaptureFile> {
+export async function openCaptureFile(options: GlobalOptions): Promise<WalletCaptureFile> {
 	const annotations = WalletCaptureAnnotations.fromFile(
 		options.id,
 		annotationsPath(options),
@@ -1527,6 +1527,24 @@ export async function handleSearch(opts: SearchOptions): Promise<void> {
 	}
 }
 
+function looksBinary(str: string): boolean {
+	// Scan the whole string, not just a prefix: multi-part payloads (e.g. Sentry envelopes)
+	// can have many KB of clean JSON text followed by a raw binary tail (e.g. replay_recording),
+	// which a prefix-only sample would miss entirely.
+	let suspiciousCount = 0
+
+	for (let i = 0; i < str.length; i++) {
+		const code = str.charCodeAt(i)
+
+		// Replacement character (failed UTF-8 decode) or control chars other than tab/newline/CR.
+		if (code === 0xfffd || (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d)) {
+			suspiciousCount++
+		}
+	}
+
+	return str.length > 0 && suspiciousCount / str.length > 0.01
+}
+
 function displayRequestInfo(
 	request: WalletRequest,
 	options: {
@@ -1611,7 +1629,15 @@ function displayRequestInfo(
 	}
 
 	if (request.content !== null && request.content.trim() !== '') {
-		log(`${header('Content')}${formatStr(request.content.toString())}`)
+		const content = request.content.toString()
+
+		if (looksBinary(content)) {
+			log(
+				`${header('Content')}${fadedOut(`[binary payload, ${content.length} bytes, not displayed]`)}`,
+			)
+		} else {
+			log(`${header('Content')}${formatStr(content)}`)
+		}
 	}
 
 	if (Object.keys(request.cookies).length > 0) {
@@ -1695,13 +1721,17 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 	while (prioritizedStrings.length > 0 && !userStopped) {
 		const strEntry = prioritizedStrings[0]
 		const strValue = strEntry.str
+		const strIsBinary = looksBinary(strValue.str)
+		const displayStr = strIsBinary
+			? `[binary payload, ${strValue.str.length} bytes, not displayed]`
+			: strValue.str
 
 		log('\n' + chalk.bgBlue.gray('='.repeat(80)))
 		log(chalk.bgBlue.gray('='.repeat(80)))
 		function header(header: string): string {
 			return ' '.repeat(16 - header.length) + chalk.bold(header) + chalk.gray(':') + ' '
 		}
-		log(`${header('String')}${highlightStr(strValue.str)}`)
+		log(`${header('String')}${strIsBinary ? displayStr : highlightStr(strValue.str)}`)
 
 		if (strValue.pieces.size > 0) {
 			log(`${header('Info')}${Array.from(strValue.pieces).toSorted().join(', ')}`)
@@ -1713,7 +1743,9 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 		for (const [roughKey, count] of Array.from(strEntry.getRoughOccurrences()).toSorted(
 			(a, b) => b[1] - a[1],
 		)) {
-			const highlightedKey = roughKey.split(strValue.str).join(highlightStr(strValue.str))
+			const highlightedKey = strIsBinary
+				? roughKey
+				: roughKey.split(strValue.str).join(highlightStr(strValue.str))
 
 			log(
 				`       ${chalk.gray('-')} ${highlightedKey}${count === 1 ? '' : ` ${chalk.gray('(')}seen ${chalk.bold(count.toString())} times${chalk.gray(')')}`}`,
@@ -1724,7 +1756,7 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 		displayRequestInfo(strEntry.firstOrigin.request, {
 			captureStrings: walletDataStrings,
 			highlight: (s: string): string => {
-				if (!s.includes(strValue.str)) {
+				if (strIsBinary || !s.includes(strValue.str)) {
 					return s
 				}
 
@@ -1867,7 +1899,7 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 				if (specialOption === '__GLOBAL_BENIGN__') {
 					capture.addBenignString(strValue.str, true)
 					await capture.save(getSaveOptions(opts))
-					log(`✅ Marked string "${strValue.str}" as globally benign.`)
+					log(`✅ Marked string "${displayStr}" as globally benign.`)
 					confirmed = true
 					continue
 				}
@@ -1875,7 +1907,7 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 				if (specialOption === '__BENIGN__') {
 					capture.addBenignString(strValue.str, false)
 					await capture.save(getSaveOptions(opts))
-					log(`✅ Marked string "${strValue.str}" as benign.`)
+					log(`✅ Marked string "${displayStr}" as benign.`)
 					confirmed = true
 					continue
 				}
@@ -1907,9 +1939,7 @@ async function handleReviewStringsInteractive(opts: GlobalOptions): Promise<void
 
 			capture.userData.add(merged)
 			await capture.save(getSaveOptions(opts))
-			log(
-				`✅ Marked string "${strValue.str}" as ${Array.from(merged.pieces).toSorted().join(', ')}.`,
-			)
+			log(`✅ Marked string "${displayStr}" as ${Array.from(merged.pieces).toSorted().join(', ')}.`)
 			confirmed = true
 		}
 
@@ -1976,10 +2006,14 @@ async function handleReviewStringsAgent(opts: ReviewStringsOptions): Promise<voi
 	for (const strEntry of toShow) {
 		const strValue = strEntry.str
 		const suggestions = classifyStringHeuristically(strEntry)
+		const strIsBinary = looksBinary(strValue.str)
+		const displayStr = strIsBinary
+			? `[binary payload, ${strValue.str.length} bytes, not displayed]`
+			: strValue.str
 
 		log('')
 		log('-'.repeat(68))
-		log(`  String   : ${strValue.str}`)
+		log(`  String   : ${displayStr}`)
 		log(`  Entropy  : ${strEntry.score.toFixed(2)}`)
 		log(
 			`  Tagged   : ${
@@ -2001,7 +2035,7 @@ async function handleReviewStringsAgent(opts: ReviewStringsOptions): Promise<voi
 				log(`    - ${roughKey}${seenText}`)
 			}
 
-			log(`  Sample Request (string highlighted as \`𜱭𜱭𜱭${strValue.str}𜱫𜱫𜱫\`):`)
+			log(`  Sample Request (string highlighted as \`𜱭𜱭𜱭${displayStr}𜱫𜱫𜱫\`):`)
 		}
 
 		displayRequestInfo(strEntry.firstOrigin.request, {
@@ -2019,6 +2053,13 @@ async function handleReviewStringsAgent(opts: ReviewStringsOptions): Promise<voi
 		})
 
 		log('')
+
+		if (strIsBinary) {
+			log('  This string looks like binary data, so no shell commands are suggested for it.')
+			log('')
+			continue
+		}
+
 		log('  Suggested commands to deal with this string:')
 
 		const escaped = strValue.str.replace(/'/g, "'\"'\"'")


### PR DESCRIPTION
# Fix: Decode binary strings, unreviewed filter, and ISO timestamp as benign strings

## Changes
- Fixed `unreviewedRequests()`/`prioritizedUnreviewedRequests()` filtering with the inverted condition
- Binary payloads (e.g. Sentry `replay_recording` envelopes) no longer get stuffed into `EncodedUserDataString.str` as raw text. Added `strBase64` as an alternate encoding, chosen automatically in `encode()` when the string isn't ASCII
  - Added `looksBinary()` in `wallet-data-collection-lib.ts` to detect these before printing, so `displayRequestInfo`.
- Added ISO-8601 timestamps to `GLOBAL_BENIGN_REGULAR_EXPRESSIONS`