### PR TITLE
Remove wallet blurb field

### DIFF
--- a/.agents/skills/wallet-create/SKILL.md
+++ b/.agents/skills/wallet-create/SKILL.md
@@ -27,7 +27,7 @@ Before doing anything else:
    - Hardware: `data/hardware-wallets/[wallet-name].ts`
    - Embedded: `data/embedded-wallets/[wallet-name].ts`
    - If the file **already exists**, let the contributor know and suggest using `/wallet-update` instead to populate feature data.
-4. Ask the contributor for their preferred display name or nickname, then immediately check whether a file for them already exists in `data/contributors/`. Also ask for the wallet's one-sentence blurb — this is the only piece of content only they can provide. If they need a new contributor file, also ask for their affiliation (company / role, if any) and a URL to their profile (GitHub, Twitter, etc.).
+4. Ask the contributor for their preferred display name or nickname, then immediately check whether a file for them already exists in `data/contributors/`. If they need a new contributor file, also ask for their affiliation (company / role, if any) and a URL to their profile (GitHub, Twitter, etc.).
 5. Read the following files in parallel:
    - The matching template for the wallet type:
      - Software: `data/software-wallets/unrated.tmpl.ts`
@@ -136,7 +136,6 @@ Copy the template (`data/[type]-wallets/unrated.tmpl.ts`) to `data/[type]-wallet
 - `id`: Camel case wallet name (e.g., `'rainbow'`) — must match the icon filename
 - `displayName`: The wallet's official display name
 - `tableName`: Short name for table display (often same as `displayName`)
-- `blurb`: Use the blurb collected in step 4, wrapped in `paragraph(\`...\`)`
 - Rename the exported constant from `unratedTemplate` / `unratedHardwareTemplate` / `unratedEmbeddedTemplate` to the camel case wallet name (e.g., `rainbow`, `ledgerNano`, `privySdk`).
 - `contributors`: `[yourContributorConstant]`
 - `iconExtension`: `'svg'` (or `'png'` if no SVG available)

--- a/.cspell.json
+++ b/.cspell.json
@@ -365,7 +365,6 @@
 		"MTBF",
 		"mtpelerin",
 		"multicall",
-		"multichain",
 		"multifactor",
 		"multisend",
 		"multisig",

--- a/.cspell.json
+++ b/.cspell.json
@@ -127,7 +127,6 @@
 		"Crecimiento",
 		"cron",
 		"Crunchbase",
-		"cryptoassets",
 		"Cryptpad",
 		"CSPRNG",
 		"ctfassets",

--- a/.cspell.json
+++ b/.cspell.json
@@ -390,7 +390,6 @@
 		"Nunchuk",
 		"oeth",
 		"offchain",
-		"offramp",
 		"OKG",
 		"oklch",
 		"OKX",

--- a/.cspell.json
+++ b/.cspell.json
@@ -294,7 +294,6 @@
 		"KeepKey",
 		"Kernal",
 		"keycard",
-		"Keycards",
 		"KeyLabs",
 		"keystone3",
 		"keystore",

--- a/.cspell.json
+++ b/.cspell.json
@@ -397,7 +397,6 @@
 		"onchain",
 		"ondemand",
 		"onekey",
-		"onramp",
 		"OpenGraph",
 		"OpenZeppelin",
 		"opsec",

--- a/.cspell.json
+++ b/.cspell.json
@@ -597,7 +597,6 @@
 		"UTXOs",
 		"v2",
 		"VC",
-		"Venmo",
 		"Veridise",
 		"verifiability",
 		"viem",

--- a/data/embedded-wallets/unrated.tmpl.ts
+++ b/data/embedded-wallets/unrated.tmpl.ts
@@ -3,18 +3,12 @@ import type { EmbeddedWallet } from '@/data/embedded-wallets'
 import { WalletProfile } from '@/schema/features/profile'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const unratedEmbeddedTemplate: EmbeddedWallet = {
 	metadata: {
 		id: 'unrated',
 		displayName: 'Unrated embedded wallet template',
 		tableName: 'Unrated',
-		blurb: paragraph(`
-			This is a fictitious embedded wallet with all of its fields unrated.
-			It is meant to be useful to copy-paste to other wallet files
-			when initially creating the skeleton structure for their data.
-		`),
 		contributors: [exampleContributor],
 		iconExtension: 'svg',
 		lastUpdated: '2020-01-01',

--- a/data/hardware-wallets/bitbox.ts
+++ b/data/hardware-wallets/bitbox.ts
@@ -32,16 +32,12 @@ import { notSupported, notSupportedWithRef, supported } from '@/schema/features/
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const bitboxWallet: HardwareWallet = {
 	metadata: {
 		id: 'bitbox',
 		displayName: 'BitBox',
 		tableName: 'BitBox',
-		blurb: paragraph(`
-			BitBox02 is a hardware wallet with fully open-source firmware and a unique secure chip architecture that doesn't require trusting closed-source code.
-		`),
 		contributors: [patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/cypherock.ts
+++ b/data/hardware-wallets/cypherock.ts
@@ -22,7 +22,6 @@ import { notSupported, notSupportedWithRef, supported } from '@/schema/features/
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { keylabs } from '../entities/keylabs'
 
@@ -31,9 +30,6 @@ export const cypherockWallet: HardwareWallet = {
 		id: 'cypherock',
 		displayName: 'Cypherock Wallet',
 		tableName: 'Cypherock',
-		blurb: paragraph(`
-			The Cypherock has a secure element (EAL6+ rated) and uses a unique card-tapping system for transaction authorization.
-		`),
 		contributors: [patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/firefly.ts
+++ b/data/hardware-wallets/firefly.ts
@@ -6,17 +6,12 @@ import { noDataExtraction } from '@/schema/features/security/transaction-legibil
 import { notSupported, notSupportedWithRef } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const fireflyWallet: HardwareWallet = {
 	metadata: {
 		id: 'firefly',
 		displayName: 'Firefly Wallet',
 		tableName: 'Firefly',
-		blurb: paragraph(`
-			Firefly Wallet is a hardware wallet that uses biometrics
-			for user authentication and secure private key management.
-		`),
 		contributors: [nconsigny, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.DIY,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/gridplus.ts
+++ b/data/hardware-wallets/gridplus.ts
@@ -35,17 +35,12 @@ import { notSupported, supported } from '@/schema/features/support'
 import { fullyClosedSource } from '@/schema/features/transparency/license'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const gridplusWallet: HardwareWallet = {
 	metadata: {
 		id: 'gridplus',
 		displayName: 'GridPlus Wallet',
 		tableName: 'GridPlus',
-		blurb: paragraph(`
-			GridPlus Wallet is a secure hardware wallet that combines secure key storage
-			with convenient authentication methods.
-		`),
 		contributors: [nconsigny, patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/imkey.ts
+++ b/data/hardware-wallets/imkey.ts
@@ -24,20 +24,12 @@ import {
 } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const imkeyWallet: HardwareWallet = {
 	metadata: {
 		id: 'imkey',
 		displayName: 'imKey',
 		tableName: 'imKey',
-		blurb: paragraph(`
-			Incubated by imToken, imKey is a reliable digital wallet that supports access to 50+ major networks
-			(including Bitcoin, Ethereum, and Tron). Built with an EAL6+ certified secure chip, imKey ensures
-			private keys are generated, stored, and used entirely within the device for maximum protection.
-			Seamlessly integrated with imToken on mobile and compatible with the Rabby browser extension on PC,
-			imKey enables users to manage assets, interact with apps, and perform transactions with enhanced security and flexibility.
-		`),
 		contributors: [mako],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/keycard-shell.ts
+++ b/data/hardware-wallets/keycard-shell.ts
@@ -26,20 +26,12 @@ import { featureSupported, notSupported, supported } from '@/schema/features/sup
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const keycardShell: HardwareWallet = {
 	metadata: {
 		id: 'keycard-shell',
 		displayName: 'Keycard Shell',
 		tableName: 'Keycard Shell',
-		blurb: paragraph(`
-			Keycard Shell is a modular, fully open-source, air-gapped hardware wallet that signs
-			via QR codes (ERC-4527). It has a built-in keypad, display, and camera, optional USB
-			(can be turned off), and uses removable Keycards for secure key storage and backups.
-			Keycard is a BIP-32 HD wallet running on JavaCard with EAL6+ secure element. Supports
-			BIP-39 and SLIP-39 seed phrases.
-		`),
 		contributors: [phift, mmlado],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/keystone.ts
+++ b/data/hardware-wallets/keystone.ts
@@ -25,7 +25,6 @@ import {
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { keylabs } from '../entities/keylabs'
 import { slowMist } from '../entities/slowmist'
@@ -35,10 +34,6 @@ export const keystoneWallet: HardwareWallet = {
 		id: 'keystone',
 		displayName: 'Keystone Wallet',
 		tableName: 'Keystone',
-		blurb: paragraph(`
-			Keystone Wallet is a self-custodial hardware wallet that provides secure private
-			key storage. It uses QR codes for air-gapped transaction signing.
-		`),
 		contributors: [nconsigny, patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/ledger.ts
+++ b/data/hardware-wallets/ledger.ts
@@ -23,15 +23,10 @@ import { notSupported, notSupportedWithRef, supported } from '@/schema/features/
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import type { WalletMetadata } from '@/schema/wallet'
-import { paragraph } from '@/types/content'
 export const ledgerWalletMetadata: WalletMetadata = {
 	id: 'ledger',
 	displayName: 'Ledger Wallet',
 	tableName: 'Ledger',
-	blurb: paragraph(`
-			Ledger Wallet is a self-custodial wallet built by Ledger. It
-			integrates with Ledger hardware wallets to provide secure cryptocurrency management.
-		`),
 	contributors: [nconsigny, patrickalphac, mattmatt],
 	hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 	hardwareWalletModels: [

--- a/data/hardware-wallets/ngrave.ts
+++ b/data/hardware-wallets/ngrave.ts
@@ -21,16 +21,12 @@ import { notSupported, notSupportedWithRef, supported } from '@/schema/features/
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const ngrave: HardwareWallet = {
 	metadata: {
 		id: 'ngrave',
 		displayName: 'NGRAVE Zero',
 		tableName: 'NGRAVE',
-		blurb: paragraph(`
-			NGRAVE Zero is a hardware wallet with EAL7+ secure element, biometric authentication, and QR code scanning capabilities. However, it fails to properly display transaction and message data for verification.
-		`),
 		contributors: [patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/onekey.ts
+++ b/data/hardware-wallets/onekey.ts
@@ -22,7 +22,6 @@ import { notSupported, notSupportedWithRef, supported } from '@/schema/features/
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { slowMist } from '../entities/slowmist'
 
@@ -31,9 +30,6 @@ export const onekeyWallet: HardwareWallet = {
 		id: 'onekey',
 		displayName: 'OneKey Pro',
 		tableName: 'OneKey Pro',
-		blurb: paragraph(`
-			OneKey Pro is a hardware wallet with excellent haptic feedback, air gap mode, and EAL6+ secure element.
-		`),
 		contributors: [patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/trezor.ts
+++ b/data/hardware-wallets/trezor.ts
@@ -23,17 +23,12 @@ import {
 import { notSupported, notSupportedWithRef, supported } from '@/schema/features/support'
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const trezorWallet: HardwareWallet = {
 	metadata: {
 		id: 'trezor',
 		displayName: 'Trezor Wallet',
 		tableName: 'Trezor',
-		blurb: paragraph(`
-			Trezor Wallet is a self-custodial hardware wallet built by SatoshiLabs. It
-			provides secure storage for cryptocurrencies with an easy-to-use interface.
-		`),
 		contributors: [nconsigny, patrickalphac, mattmatt],
 		hardwareWalletManufactureType: HardwareWalletManufactureType.FACTORY_MADE,
 		hardwareWalletModels: [

--- a/data/hardware-wallets/unrated.tmpl.ts
+++ b/data/hardware-wallets/unrated.tmpl.ts
@@ -10,18 +10,12 @@ import {
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const unratedHardwareTemplate: HardwareWallet = {
 	metadata: {
 		id: 'unrated',
 		displayName: 'Unrated hardware wallet template',
 		tableName: 'Unrated',
-		blurb: paragraph(`
-			This is a fictitious hardware wallet with all of its fields unrated.
-			It is meant to be useful to copy-paste to other wallet files
-			when initially creating the skeleton structure for their data.
-		`),
 		contributors: [exampleContributor],
 		iconExtension: 'svg',
 		lastUpdated: '2020-01-01',

--- a/data/software-wallets/ambire.ts
+++ b/data/software-wallets/ambire.ts
@@ -73,7 +73,6 @@ import { FOSSLicense, LicensingType } from '@/schema/features/transparency/licen
 import { type References, refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import { parseBrowserExtensionManifest } from '@/tools/manifest-collector/browser-ext-manifest-parser'
-import { paragraph } from '@/types/content'
 import { nonEmptySet } from '@/types/utils/non-empty'
 
 import { ambireEntity } from '../entities/ambire'
@@ -209,10 +208,6 @@ export const ambire: SoftwareWallet = {
 		id: 'ambire',
 		displayName: 'Ambire',
 		tableName: 'Ambire',
-		blurb: paragraph(`
-			The first hybrid Account abstraction wallet to support Basic (EOA) and Smart accounts, 
-			improving security and user experience.
-			`),
 		contributors: [jiojosbg, nconsigny, mattmatt, polymutex, ren2140],
 		iconExtension: 'svg',
 		lastUpdated: '2026-07-22',

--- a/data/software-wallets/base-app.ts
+++ b/data/software-wallets/base-app.ts
@@ -35,17 +35,12 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const baseApp: SoftwareWallet = {
 	metadata: {
 		id: 'base-app',
 		displayName: 'Base App',
 		tableName: 'Base App',
-		blurb: paragraph(`
-			Base is a secure onchain wallet and browser that puts you in
-			control of your crypto, NFTs, DeFi activity, and digital assets.
-		`),
 		contributors: [ren2140],
 		iconExtension: 'svg',
 		lastUpdated: '2026-03-19',

--- a/data/software-wallets/bitget.ts
+++ b/data/software-wallets/bitget.ts
@@ -21,7 +21,6 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { mattmatt } from '../contributors/0xmattmatt'
 
@@ -30,9 +29,6 @@ export const bitget: SoftwareWallet = {
 		id: 'bitget',
 		displayName: 'Bitget Wallet',
 		tableName: 'Bitget',
-		blurb: paragraph(`
-			Bitget Wallet is a leading multi-chain decentralized wallet that is committed to providing a wide range of asset management and DeFi services for its users.
-		`),
 		contributors: [mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2026-01-17',

--- a/data/software-wallets/completed.tmpl.ts
+++ b/data/software-wallets/completed.tmpl.ts
@@ -111,7 +111,6 @@ import {
 import type { ArtifactSigningDetails } from '@/schema/features/transparency/release-transparency'
 import { type MustRef, type References, refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 import type { NonEmptyArray } from '@/types/utils/non-empty'
 import { nonEmptySet } from '@/types/utils/non-empty'
 
@@ -206,11 +205,6 @@ export const completedTemplate: SoftwareWallet = {
 		id: 'completed',
 		displayName: 'Completed wallet template',
 		tableName: 'Completed',
-		blurb: paragraph(`
-			This is a fictitious wallet with all of its rated fields set to PASS values.
-			It is meant to serve as a reference for contributors to understand what
-			best-in-class implementation looks like for each walletbeat attribute.
-		`),
 		contributors: [exampleContributor],
 		iconExtension: 'svg',
 		lastUpdated: '2026-02-27',

--- a/data/software-wallets/daimo.ts
+++ b/data/software-wallets/daimo.ts
@@ -31,7 +31,7 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { mdParagraph, paragraph } from '@/types/content'
+import { mdParagraph } from '@/types/content'
 
 import { binance } from '../entities/binance'
 import { daimoInc } from '../entities/daimo'
@@ -46,11 +46,6 @@ export const daimo: SoftwareWallet = {
 		id: 'daimo',
 		displayName: 'Daimo',
 		tableName: 'Daimo',
-		blurb: paragraph(`
-			Daimo aims to replicate a Venmo-like experience onchain.
-			It focuses on cheap stablecoin payments and fast onramp and
-			offramp of USD / USDC with minimal fees.
-		`),
 		contributors: [polymutex, nconsigny],
 		iconExtension: 'svg',
 		lastUpdated: '2025-03-12',

--- a/data/software-wallets/elytro.ts
+++ b/data/software-wallets/elytro.ts
@@ -10,7 +10,6 @@ import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 const elytroAudits: SecurityAudit[] = [
 	{
@@ -46,9 +45,6 @@ export const elytro: SoftwareWallet = {
 		id: 'elytro',
 		displayName: 'Elytro',
 		tableName: 'Elytro',
-		blurb: paragraph(
-			'Coming soon. We build secured and decentralized public infra for humanity on Ethereum. We believe in a free, open, and self-own internet. We start by building a smart contract account.',
-		),
 		contributors: [nconsigny],
 		iconExtension: 'svg',
 		lastUpdated: '2025-03-12',

--- a/data/software-wallets/family.ts
+++ b/data/software-wallets/family.ts
@@ -7,14 +7,12 @@ import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const family: SoftwareWallet = {
 	metadata: {
 		id: 'family',
 		displayName: 'Family',
 		tableName: 'Family',
-		blurb: paragraph(''),
 		contributors: [lucemans],
 		iconExtension: 'png',
 		lastUpdated: '2025-04-22',

--- a/data/software-wallets/frame.ts
+++ b/data/software-wallets/frame.ts
@@ -15,13 +15,11 @@ import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/
 import { notSupported, supported } from '@/schema/features/support'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 export const frame: SoftwareWallet = {
 	metadata: {
 		id: 'frame',
 		displayName: 'Frame',
 		tableName: 'Frame',
-		blurb: paragraph('Frame...'),
 		contributors: [polymutex, nconsigny, lucemans, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2025-03-13',

--- a/data/software-wallets/gem.ts
+++ b/data/software-wallets/gem.ts
@@ -10,18 +10,12 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const gemwallet: SoftwareWallet = {
 	metadata: {
 		id: 'gemwallet',
 		displayName: 'Gem Wallet',
 		tableName: 'Gem Wallet',
-		blurb: paragraph(`
-			Gem Wallet is a fully open source multichain mobile wallet with transparent
-			revenue reporting. Built for iOS and Android with a focus on security and
-			user sovereignty.
-		`),
 		contributors: [h3rman],
 		iconExtension: 'svg',
 		lastUpdated: '2025-10-14',

--- a/data/software-wallets/imtoken.ts
+++ b/data/software-wallets/imtoken.ts
@@ -38,7 +38,6 @@ import {
 } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { cure53 } from '../entities/cure53'
 import { imToken } from '../entities/imtoken'
@@ -48,9 +47,6 @@ export const imtoken: SoftwareWallet = {
 		id: 'imtoken',
 		displayName: 'imToken',
 		tableName: 'imToken',
-		blurb: paragraph(`
-			imToken is a reliable and intuitive digital wallet, enabling easy access to over 50+ major networks including Bitcoin, Ethereum, and Tron. imToken supports hardware wallets, token swap and app browser etc., and provides secure and trusted non-custodial wallet services to millions of users in more than 150 countries and regions around the world.
-		`),
 		contributors: [mako, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2025-10-28',

--- a/data/software-wallets/metamask.ts
+++ b/data/software-wallets/metamask.ts
@@ -65,7 +65,7 @@ import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import { parseBrowserExtensionManifest } from '@/tools/manifest-collector/browser-ext-manifest-parser'
 import { parseMobileManifestJson } from '@/tools/manifest-collector/mobile-manifest-parser'
-import { mdParagraph, paragraph } from '@/types/content'
+import { mdParagraph } from '@/types/content'
 import { nonEmptySet } from '@/types/utils/non-empty'
 
 import { alphabet } from '../entities/alphabet'
@@ -84,11 +84,6 @@ export const metamask: SoftwareWallet = {
 		id: 'metamask',
 		displayName: 'MetaMask',
 		tableName: 'MetaMask',
-		blurb: paragraph(`
-			MetaMask is a popular multichain wallet created by Consensys and that has
-			been around for a long time. It is a jack-of-all-trades wallet that can
-			be extended through MetaMask Snaps.
-		`),
 		contributors: [polymutex, nconsigny, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2026-05-06',

--- a/data/software-wallets/mtpelerin.ts
+++ b/data/software-wallets/mtpelerin.ts
@@ -13,16 +13,12 @@ import { featureSupported, notSupported, supported } from '@/schema/features/sup
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const mtpelerin: SoftwareWallet = {
 	metadata: {
 		id: 'mtpelerin',
 		displayName: 'Bridge Wallet',
 		tableName: 'Bridge Wallet',
-		blurb: paragraph(
-			'Buy, swap, and sell crypto with the lowest fees, zero hidden costs, and full control over your cryptoassets.',
-		),
 		contributors: [sigri, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2025-08-26',

--- a/data/software-wallets/nufi.ts
+++ b/data/software-wallets/nufi.ts
@@ -14,7 +14,6 @@ import { featureSupported, notSupported, supported } from '@/schema/features/sup
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { metamask7702DelegatorContract } from '../wallet-contracts/metamask-7702-delegator'
 
@@ -23,9 +22,6 @@ export const nufi: SoftwareWallet = {
 		id: 'nufi',
 		displayName: 'NuFi',
 		tableName: 'NuFi',
-		blurb: paragraph(`
-			Powerful wallet for powerful users.
-		`),
 		contributors: [gabrielkerekes, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2025-08-11',

--- a/data/software-wallets/okx.ts
+++ b/data/software-wallets/okx.ts
@@ -18,7 +18,6 @@ import { featureSupported, notSupported, supported } from '@/schema/features/sup
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { mattmatt } from '../contributors/0xmattmatt'
 
@@ -27,9 +26,6 @@ export const okx: SoftwareWallet = {
 		id: 'okx',
 		displayName: 'OKX Wallet',
 		tableName: 'OKX',
-		blurb: paragraph(`
-OKX Wallet is a universal crypto wallet available on multiple platforms, including app, web, and extension
-		`),
 		contributors: [mattmatt],
 		iconExtension: 'png',
 		lastUpdated: '2026-01-28',

--- a/data/software-wallets/phantom.ts
+++ b/data/software-wallets/phantom.ts
@@ -15,17 +15,11 @@ import { notSupported, supported } from '@/schema/features/support'
 import { LicensingType, SourceNotAvailableLicense } from '@/schema/features/transparency/license'
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 export const phantom: SoftwareWallet = {
 	metadata: {
 		id: 'phantom',
 		displayName: 'Phantom',
 		tableName: 'Phantom',
-		blurb: paragraph(`
-			Phantom is a user-friendly Ethereum and Solana wallet. It focuses
-			on ease of use, easy swapping of tokens and NFTs, and integration
-			with popular DeFi and NFT exchange protocols within the wallet.
-		`),
 		contributors: [nconsigny, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2025-02-08',

--- a/data/software-wallets/pillarx.ts
+++ b/data/software-wallets/pillarx.ts
@@ -7,7 +7,6 @@ import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 import { iamkio } from '../contributors/iamkio'
 import { kernal7702Contract } from '../wallet-contracts/kernal-7702'
@@ -17,9 +16,6 @@ export const pillarx: SoftwareWallet = {
 		id: 'pillarx',
 		displayName: 'PillarX',
 		tableName: 'PillarX',
-		blurb: paragraph(
-			'PillarX is a web3 wallet that allows you to manage your digital assets and interact with the blockchain.',
-		),
 		contributors: [iamkio],
 		iconExtension: 'svg',
 		lastUpdated: '2025-12-16',

--- a/data/software-wallets/rabby.ts
+++ b/data/software-wallets/rabby.ts
@@ -65,7 +65,6 @@ import {
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import { parseBrowserExtensionManifest } from '@/tools/manifest-collector/browser-ext-manifest-parser'
-import { paragraph } from '@/types/content'
 import { nonEmptySet } from '@/types/utils/non-empty'
 
 import { cure53 } from '../entities/cure53'
@@ -78,10 +77,6 @@ export const rabby: SoftwareWallet = {
 		id: 'rabby',
 		displayName: 'Rabby',
 		tableName: 'Rabby',
-		blurb: paragraph(`
-			Rabby is a user-friendly Ethereum wallet focusing on smooth UX and security.
-			It features an intuitive transaction preview feature and works on many chains.
-		`),
 		contributors: [polymutex, nconsigny, mattmatt],
 		iconExtension: 'svg',
 		lastUpdated: '2026-07-20',

--- a/data/software-wallets/rainbow.ts
+++ b/data/software-wallets/rainbow.ts
@@ -69,7 +69,6 @@ import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import { parseBrowserExtensionManifest } from '@/tools/manifest-collector/browser-ext-manifest-parser'
 import { parseMobileManifestJson } from '@/tools/manifest-collector/mobile-manifest-parser'
-import { paragraph } from '@/types/content'
 import { nonEmptySet } from '@/types/utils/non-empty'
 
 import rainbowAndroidParsed from './manifests/rainbow/android.parsed.json'
@@ -81,9 +80,6 @@ export const rainbow: SoftwareWallet = {
 		id: 'rainbow',
 		displayName: 'Rainbow',
 		tableName: 'Rainbow',
-		blurb: paragraph(`
-			Rainbow Extension. Built for speed. Built for power. Built for You.
-		`),
 		contributors: [polymutex, mattmatt, ren2140],
 		iconExtension: 'svg',
 		lastUpdated: '2026-08-02',

--- a/data/software-wallets/safe.ts
+++ b/data/software-wallets/safe.ts
@@ -27,17 +27,12 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display' // 
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license' // assuming path
 import { refNotNecessary, refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const safe: SoftwareWallet = {
 	metadata: {
 		id: 'safe',
 		displayName: 'Safe',
 		tableName: 'Safe',
-		blurb: paragraph(`
-			Safe (formerly Gnosis Safe) is a smart contract wallet focused on secure asset management
-			with multi-signature functionality for individuals and organizations.
-		`),
 		contributors: [nconsigny],
 		iconExtension: 'svg',
 		lastUpdated: '2025-03-12',

--- a/data/software-wallets/uniswap-wallet.ts
+++ b/data/software-wallets/uniswap-wallet.ts
@@ -10,17 +10,12 @@ import { notSupported, supported } from '@/schema/features/support'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const uniswapWallet: SoftwareWallet = {
 	metadata: {
 		id: 'uniswap-wallet',
 		displayName: 'Uniswap Wallet',
 		tableName: 'Uniswap',
-		blurb: paragraph(`
-			The self-custody wallet for swapping, sending, bridging,
-			and exploring apps across 16+ networks.
-		`),
 		contributors: [ren2140],
 		iconExtension: 'svg',
 		lastUpdated: '2026-04-04',

--- a/data/software-wallets/unrated.tmpl.ts
+++ b/data/software-wallets/unrated.tmpl.ts
@@ -4,18 +4,12 @@ import { WalletProfile } from '@/schema/features/profile'
 import { TransactionSubmissionL2Type } from '@/schema/features/self-sovereignty/transaction-submission'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const unratedTemplate: SoftwareWallet = {
 	metadata: {
 		id: 'unrated',
 		displayName: 'Unrated wallet template',
 		tableName: 'Unrated',
-		blurb: paragraph(`
-			This is a fictitious wallet with all of its fields unrated.
-			It is meant to be useful to copy-paste to other wallet files
-			when initially creating the skeleton structure for their data.
-		`),
 		contributors: [exampleContributor],
 		iconExtension: 'svg',
 		lastUpdated: '2020-01-01',

--- a/data/software-wallets/zerion.ts
+++ b/data/software-wallets/zerion.ts
@@ -54,7 +54,6 @@ import { FOSSLicense, LicensingType } from '@/schema/features/transparency/licen
 import { refTodo, type WithRef } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
 import { parseBrowserExtensionManifest } from '@/tools/manifest-collector/browser-ext-manifest-parser'
-import { paragraph } from '@/types/content'
 
 import zerionRawExtManifest from './manifests/zerion/klghhnkeealcohjjanjjdaeeggmfmlpl.manifest.json'
 
@@ -63,7 +62,6 @@ export const zerion: SoftwareWallet = {
 		id: 'zerion',
 		displayName: 'Zerion',
 		tableName: 'Zerion',
-		blurb: paragraph(''),
 		contributors: [lucemans, mattmatt, ren2140],
 		iconExtension: 'svg',
 		lastUpdated: '2026-08-10',

--- a/data/software-wallets/zeus.ts
+++ b/data/software-wallets/zeus.ts
@@ -27,16 +27,12 @@ import { FeeDisplayLevel } from '@/schema/features/transparency/fee-display'
 import { FOSSLicense, LicensingType } from '@/schema/features/transparency/license'
 import { refTodo } from '@/schema/reference'
 import { Variant } from '@/schema/variants'
-import { paragraph } from '@/types/content'
 
 export const zeus: SoftwareWallet = {
 	metadata: {
 		id: 'zeus',
 		displayName: 'Zeus',
 		tableName: 'Zeus',
-		blurb: paragraph(`
-			Zeus is a truly seedless and decentralized self-custodial Ethereum wallet.
-		`),
 		contributors: [greekfetacheese],
 		iconExtension: 'svg',
 		lastUpdated: '2026-01-12',

--- a/public/schemas/rated-wallet.schema.json
+++ b/public/schemas/rated-wallet.schema.json
@@ -9,7 +9,6 @@
 		"overall",
 		"perVariant",
 		"displayName",
-		"description",
 		"lastUpdated",
 		"stage",
 		"stageBreakdown"
@@ -46,10 +45,6 @@
 			"type": "string",
 			"minLength": 1,
 			"description": "Human-readable wallet name."
-		},
-		"description": {
-			"type": "string",
-			"description": "Short wallet description for JSON-LD (e.g. \"MetaMask Ethereum wallet\")."
 		},
 		"lastUpdated": {
 			"type": "string",

--- a/public/schemas/rated-wallet.schema.json
+++ b/public/schemas/rated-wallet.schema.json
@@ -49,7 +49,7 @@
 		},
 		"description": {
 			"type": "string",
-			"description": "Short wallet description (rendered blurb)."
+			"description": "Short wallet description for JSON-LD (e.g. \"MetaMask Ethereum wallet\")."
 		},
 		"lastUpdated": {
 			"type": "string",

--- a/resources/docs/contribute/wallet-data/wallet-data.md
+++ b/resources/docs/contribute/wallet-data/wallet-data.md
@@ -153,7 +153,7 @@ export const chainMonkey: Contributor = {
 
 - Create a copy of `/data/software-wallets/unrated.tmpl.ts` at `/data/software-wallets/my-little-wallet.ts`.
 - Rename the top-level object from `unratedTemplate` to `myLittleWallet`.
-- Change all `metadata.*` fields such as `id` (set to `'myLittleWallet'`), `displayName`, `blurb`, `lastUpdated` (set to today's date in `YYYY-MM-DD` format), `urls`, etc.
+- Change all `metadata.*` fields such as `id` (set to `'myLittleWallet'`), `displayName`, `lastUpdated` (set to today's date in `YYYY-MM-DD` format), `urls`, etc.
 - Find an SVG icon of the wallet and crop all the transparent edges out of the SVG. Save it as `/public/images/wallet/myLittleWallet.svg` (the filename matches the `metadata.id` field).
   - _(If you cannot find an SVG version of the icon, find a PNG or JPG version instead, crop it similarly, save it as `/public/images/wallet/myLittleWallet.png` or `/public/images/wallet/myLittleWallet.jpg`, and set `metadata.iconExtension` to `'png'` or `'jpg'` in the wallet data file.)_
 - Set yourself as the sole contributor in `metadata.contributors`.
@@ -170,10 +170,6 @@ export const myLittleWallet: SoftwareWallet<AttributeGroupId> = {
 		id: 'myLittleWallet',
 		displayName: 'My Little Wallet',
 		tableName: 'My Little Wallet',
-		blurb: paragraph(`
-			This is an example wallet that was made up for the sake of
-			this contributor guide.
-		`),
 		contributors: [chainMonkey],
 		iconExtension: 'svg',
 		lastUpdated: '2077-01-01',

--- a/src/schema/attributes.ts
+++ b/src/schema/attributes.ts
@@ -6,7 +6,7 @@ import {
 	type NonEmptyRecord,
 } from '@/types/utils/non-empty'
 
-/** Strings for content that may use {{WALLET_NAME}} only (e.g. details, blurb). */
+/** Strings for content that may use {{WALLET_NAME}} only (e.g. details). */
 export type WalletNameStrings = null | { WALLET_NAME: string }
 
 /** Strings for content that may use {{WALLET_NAME}} and/or pseudonym placeholders. */

--- a/src/schema/wallet.ts
+++ b/src/schema/wallet.ts
@@ -1,4 +1,4 @@
-import type { MarkdownParagraph, Paragraph, TypographicContent } from '@/types/content'
+import type { MarkdownParagraph, TypographicContent } from '@/types/content'
 import type { CalendarDate } from '@/types/date'
 import { getErrorMessage, prefixError } from '@/types/errors'
 import type { Dict } from '@/types/utils/dict'
@@ -103,12 +103,6 @@ export interface WalletMetadata {
 	 * added to make the image aspect ratio be 1:1 (square).
 	 */
 	iconExtension: 'jpg' | 'png' | 'svg'
-
-	/**
-	 * A short (two or three sentences) description about the wallet.
-	 * This is shown under the wallet's name in expanded view.
-	 */
-	blurb: Paragraph<WalletNameStrings>
 
 	/**
 	 * If the wallet has a built-in username scheme, this should refer to

--- a/src/utils/llms-txt.ts
+++ b/src/utils/llms-txt.ts
@@ -3,13 +3,11 @@ import { ratedSoftwareWallets } from '@/data/software-wallets'
 import { allRatedWallets } from '@/data/wallets'
 import type { RatedWallet } from '@/schema/wallet'
 import { WalletType } from '@/schema/wallet-types'
-import { walletBlurbText } from '@/utils/wallet-page-markdown'
 
 function walletEntry(wallet: RatedWallet<string>, siteUrl: string): string {
-	const blurb = walletBlurbText(wallet)
 	const url = `${siteUrl}/${wallet.metadata.id}/index.html.md`
 
-	return `- [${wallet.metadata.displayName}](${url}): ${blurb}`
+	return `- [${wallet.metadata.displayName}](${url})`
 }
 
 export function llmsTxtBody(siteUrl: string): string {

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -141,7 +141,7 @@ export function markdownBlockquote(text: string): string[] {
 
 /**
  * Collapse a possibly multi-line string into a single trimmed line.
- * Intended for short inline text only (e.g. blurbs, reference explanations).
+ * Intended for short inline text only (e.g. reference explanations).
  * Throws if the input contains multiline-only markdown (triple-backtick code
  * blocks or blockquote lines), since flattening those would produce invalid output.
  */

--- a/src/utils/wallet-json-export.ts
+++ b/src/utils/wallet-json-export.ts
@@ -37,7 +37,6 @@ import {
 	getCriterionAttributeId,
 	type StageCountsStatus,
 } from '@/utils/stage-attributes'
-import { walletBlurbText } from '@/utils/wallet-page-markdown'
 
 const DETAILS_FALLBACK = 'See full details on the wallet page.'
 
@@ -376,7 +375,7 @@ export function ratedWalletJsonExport<_AttributeGroupId extends string>(
 		types: setItems(wallet.types),
 		variants: setItems(getVariants(wallet.variants)),
 		displayName: metadata.displayName,
-		description: walletBlurbText(wallet),
+		description: `${metadata.displayName} Ethereum wallet`,
 		lastUpdated: metadata.lastUpdated,
 		stage: stageExport,
 		stageBreakdown,

--- a/src/utils/wallet-json-export.ts
+++ b/src/utils/wallet-json-export.ts
@@ -145,7 +145,6 @@ export interface RatedWalletJsonExport {
 	variants: Variant[]
 	walletId: string
 	displayName: string
-	description: string
 	lastUpdated: string
 	stage: string | null
 	stageBreakdown: StageBreakdownItemJsonExport[] | null
@@ -375,7 +374,6 @@ export function ratedWalletJsonExport<_AttributeGroupId extends string>(
 		types: setItems(wallet.types),
 		variants: setItems(getVariants(wallet.variants)),
 		displayName: metadata.displayName,
-		description: `${metadata.displayName} Ethereum wallet`,
 		lastUpdated: metadata.lastUpdated,
 		stage: stageExport,
 		stageBreakdown,

--- a/src/utils/wallet-page-markdown.ts
+++ b/src/utils/wallet-page-markdown.ts
@@ -10,22 +10,13 @@ import { toFullyQualified } from '@/schema/reference'
 import { StageCriterionRating, stageCriterionRatings } from '@/schema/stages'
 import { gitCommitRefPinRegExp } from '@/schema/url'
 import { getVariants, hasSingleVariant, type Variant } from '@/schema/variants'
-import {
-	type RatedWallet,
-	type ResolvedWallet,
-	VariantSpecificity,
-	type WalletMetadata,
-} from '@/schema/wallet'
+import { type RatedWallet, type ResolvedWallet, VariantSpecificity } from '@/schema/wallet'
 import { isTypographicContent, renderTypographicContentToString } from '@/types/content'
 import { nonEmptyEntries, nonEmptyValues, setItems } from '@/types/utils/non-empty'
 import { slugifyCamelCase, trimWhitespacePrefix } from '@/types/utils/text'
 import { getHowToImproveHeading } from '@/utils/attribute-display'
 import { getWalletEvalStrings, renderContentToText } from '@/utils/evaluation-content'
-import {
-	collapseToSingleLine,
-	markdownBlockquote,
-	normalizeMarkdownBlankLines,
-} from '@/utils/markdown-utils'
+import { collapseToSingleLine, normalizeMarkdownBlankLines } from '@/utils/markdown-utils'
 import { getWalletStageAndLadder } from '@/utils/stage'
 import {
 	allCriteriaInStage,
@@ -33,18 +24,6 @@ import {
 	getCriterionAttributeId,
 } from '@/utils/stage-attributes'
 import { getWalletUrl } from '@/utils/urls'
-
-/**
- * Return the wallet blurb as a single collapsed line, suitable for use
- * as a short description in the /llms.txt index.
- */
-export function walletBlurbText(wallet: { metadata: WalletMetadata }): string {
-	return collapseToSingleLine(
-		renderTypographicContentToString(wallet.metadata.blurb, {
-			WALLET_NAME: wallet.metadata.displayName,
-		}),
-	)
-}
 
 /**
  * Generate a clean markdown page for a wallet, following the llms.txt convention
@@ -79,10 +58,6 @@ export function walletPageMarkdown<_AttributeGroupId extends string>(
 
 	const headerLines: string[] = [
 		`# ${walletName} — Walletbeat Review`,
-		'',
-		...markdownBlockquote(
-			renderTypographicContentToString(metadata.blurb, { WALLET_NAME: walletName }),
-		),
 		'',
 		`Last updated: ${metadata.lastUpdated}`,
 		`Walletbeat page: ${siteUrl}${getWalletUrl(wallet)}`,

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -494,7 +494,6 @@
 			about: {
 				'@type': 'SoftwareApplication',
 				name: wallet.metadata.displayName,
-				description: `${wallet.metadata.displayName} Ethereum wallet`,
 				url: (
 					typeof wallet.metadata.url === 'string' ?
 						wallet.metadata.url

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -494,17 +494,7 @@
 			about: {
 				'@type': 'SoftwareApplication',
 				name: wallet.metadata.displayName,
-				description: renderStrings(
-					(
-						wallet.metadata.blurb.contentType === ContentType.TEXT ?
-							wallet.metadata.blurb.text
-						:
-							wallet.metadata.displayName + ' wallet'
-					),
-					{
-						WALLET_NAME: wallet.metadata.displayName
-					},
-				),
+				description: `${wallet.metadata.displayName} Ethereum wallet`,
 				url: (
 					typeof wallet.metadata.url === 'string' ?
 						wallet.metadata.url
@@ -626,38 +616,29 @@
 				class="wallet-overview"
 				data-column="gap-6"
 			>
-				<div data-row="wrap">
-					<p data-row-item="flexible basis-3">
-						<Typography
-							content={wallet.metadata.blurb}
-							strings={{ WALLET_NAME: wallet.metadata.displayName }}
-						/>
-					</p>
+				<nav data-row="gap-2 start wrap">
+					<a
+						href={isLabeledUrl(wallet.metadata.urls?.websites[0]) ? wallet.metadata.urls.websites[0].url : wallet.metadata.urls.websites[0]}
+						data-badge="medium"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{@html Globe}
+						Website
+					</a>
 
-					<nav data-row="gap-2 start wrap">
+					{#if wallet.metadata.urls?.repository}
 						<a
-							href={isLabeledUrl(wallet.metadata.urls?.websites[0]) ? wallet.metadata.urls.websites[0].url : wallet.metadata.urls.websites[0]}
+							href={isLabeledUrl(wallet.metadata.urls.repository[0]) ? wallet.metadata.urls.repository[0].url : wallet.metadata.urls.repository[0]}
 							data-badge="medium"
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{@html Globe}
-							Website
+							{@html Github}
+							Source Code
 						</a>
-
-						{#if wallet.metadata.urls?.repository}
-							<a
-								href={isLabeledUrl(wallet.metadata.urls.repository[0]) ? wallet.metadata.urls.repository[0].url : wallet.metadata.urls.repository[0]}
-								data-badge="medium"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{@html Github}
-								Source Code
-							</a>
-						{/if}
-					</nav>
-				</div>
+					{/if}
+				</nav>
 
 				<div
 					class="wallet-platforms"

--- a/src/views/WalletTable.svelte
+++ b/src/views/WalletTable.svelte
@@ -995,14 +995,6 @@
 									<p>
 										{wallet.metadata.displayName} does not have a {selectedVariant} version.
 									</p>
-
-								{:else if wallet.metadata.blurb}
-									<Typography
-										content={wallet.metadata.blurb}
-										strings={{
-											WALLET_NAME: wallet.metadata.displayName,
-										}}
-									/>
 								{/if}
 
 								<div class="links" data-row="gap-3 start wrap">

--- a/tests/wallet-json-export.test.ts
+++ b/tests/wallet-json-export.test.ts
@@ -14,7 +14,6 @@ import { variantEnum } from '@/schema/variants'
 import { setItems } from '@/types/utils/non-empty'
 import { getWalletStageAndLadder } from '@/utils/stage'
 import { ratedWalletJsonExport, stageToExportString } from '@/utils/wallet-json-export'
-import { walletBlurbText } from '@/utils/wallet-page-markdown'
 
 import { RatedWalletExportValidator } from './utils/assert-valid-json'
 
@@ -45,7 +44,7 @@ describe('ratedWalletJsonExport', () => {
 
 				expect(payload.walletId).toBe(wallet.metadata.id)
 				expect(payload.displayName).toBe(wallet.metadata.displayName)
-				expect(payload.description).toBe(walletBlurbText(wallet))
+				expect(payload.description).toBe(`${wallet.metadata.displayName} Ethereum wallet`)
 				expect(payload.lastUpdated).toBe(wallet.metadata.lastUpdated)
 				expect(payload.types.sort()).toEqual(setItems(wallet.types).sort())
 				expect(payload.stage).toBe(stageToExportString(stage))

--- a/tests/wallet-json-export.test.ts
+++ b/tests/wallet-json-export.test.ts
@@ -44,7 +44,6 @@ describe('ratedWalletJsonExport', () => {
 
 				expect(payload.walletId).toBe(wallet.metadata.id)
 				expect(payload.displayName).toBe(wallet.metadata.displayName)
-				expect(payload.description).toBe(`${wallet.metadata.displayName} Ethereum wallet`)
 				expect(payload.lastUpdated).toBe(wallet.metadata.lastUpdated)
 				expect(payload.types.sort()).toEqual(setItems(wallet.types).sort())
 				expect(payload.stage).toBe(stageToExportString(stage))


### PR DESCRIPTION
## Summary
- Remove the marketing `blurb` field from wallet metadata schema and all wallet data files
- Drop blurb rendering from wallet page / table UI and related JSON/markdown exports
- Clean up docs, wallet-create skill, and cspell entries that only existed for blurb copy

## Test plan
- [ ] Open a few wallet pages and confirm description copy is gone
- [ ] `pnpm check:quick`
- [ ] Spot-check wallet JSON/markdown export still builds