### PR TITLE
Wallet page: stage criteria use pass/fail markers

### DIFF
--- a/src/views/WalletStageOverview.svelte
+++ b/src/views/WalletStageOverview.svelte
@@ -9,7 +9,6 @@
 		type WalletLadderEvaluation,
 		type WalletStage,
 	} from '@/schema/stages'
-	import { wbIconEmojiSequences } from '@/styles/wbicons'
 	import { stageToColor } from '@/utils/colors'
 	import { allCriteriaInStage, computeCountsAndStatus, getCriterionAttributeId, attributesById } from '@/utils/stage-attributes'
 
@@ -210,7 +209,8 @@
 												>
 													{#each criteriaGroup.criteria as criterion (criterion.id)}
 														{@const criterionEvaluation = ladderDefinition ? criterion.evaluate(wallet) : null}
-														{@const criterionRating = criterionEvaluation?.rating}
+														{@const criterionRating = criterionEvaluation?.rating ?? StageCriterionRating.UNRATED}
+														{@const criterionRatingMeta = stageCriterionRatings[criterionRating]}
 														{@const attributeId = getCriterionAttributeId(criterion)}
 														{@const attributeLink = attributeId ? getWalletUrl(wallet, { attributeAnchor: slugifyCamelCase(attributeId) }) : null}
 														{@const attribute = attributeId ? attributesById.get(attributeId) ?? null : null}
@@ -218,44 +218,34 @@
 														{@const attributeTitle = attribute?.displayName ?? attributeId}
 
 														<li
-															data-list-item-marker={attribute?.icon ? wbIconEmojiSequences[attribute.icon] : undefined}
-															style:--accent={stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED)].color}
+															data-list-item-marker={criterionRatingMeta.icon}
+															style:--accent={criterionRatingMeta.color}
 															data-stage-criterion-rating={criterionRating}
+															title={criterionRatingMeta.label}
 														>
-															<span data-row>
-																<span data-row-item="flexible">
-																	{#if attributeName}
-																		{#if attributeLink}
-																			<a href={attributeLink} title={attributeTitle}>
-																				<strong>{attributeName}</strong>
-																			</a>
-																		{:else}
-																			<strong>{attributeName}</strong>
-																		{/if}
-																		<span>
-																			—
-																			{#if isTypographicContent(criterion.description)}
-																				<Typography content={criterion.description} />
-																			{:else}
-																				{criterion.id}
-																			{/if}
-																		</span>
+															{#if attributeName}
+																{#if attributeLink}
+																	<a href={attributeLink} title={attributeTitle}>
+																		<strong>{attributeName}</strong>
+																	</a>
+																{:else}
+																	<strong>{attributeName}</strong>
+																{/if}
+																<span>
+																	—
+																	{#if isTypographicContent(criterion.description)}
+																		<Typography content={criterion.description} />
 																	{:else}
-																		{#if isTypographicContent(criterion.description)}
-																			<Typography content={criterion.description} />
-																		{:else}
-																			{criterion.id}
-																		{/if}
+																		{criterion.id}
 																	{/if}
 																</span>
-
-																<data
-																	value={criterionRating}
-																	title={stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED)].label}
-																>
-																	{stageCriterionRatings[(criterionRating ?? StageCriterionRating.UNRATED)].icon}
-																</data>
-															</span>
+															{:else}
+																{#if isTypographicContent(criterion.description)}
+																	<Typography content={criterion.description} />
+																{:else}
+																	{criterion.id}
+																{/if}
+															{/if}
 														</li>
 													{/each}
 												</ul>

--- a/src/views/WalletStageSummary.svelte
+++ b/src/views/WalletStageSummary.svelte
@@ -10,7 +10,6 @@
 		type WalletLadderEvaluation,
 		type WalletStage,
 	} from '@/schema/stages'
-	import { wbIconEmojiSequences } from '@/styles/wbicons'
 	import { isTypographicContent } from '@/types/content'
 	import { slugifyCamelCase } from '@/types/utils/text'
 	import { getWalletUrl } from '@/utils/urls'
@@ -187,45 +186,36 @@
 					{@const attribute = attributeId ? attributesById.get(attributeId) ?? null : null}
 					{@const attributeName = attribute?.displayName ?? attributeId}
 					{@const attributeLink = attributeId ? getWalletUrl(wallet, { attributeAnchor: slugifyCamelCase(attributeId) }) : null}
+					{@const criterionRatingMeta = stageCriterionRatings[evaluation.rating]}
 
 					<li
-						data-list-item-marker={attribute?.icon ? wbIconEmojiSequences[attribute.icon] : undefined}
+						data-list-item-marker={criterionRatingMeta.icon}
 						data-stage-criterion-rating={evaluation.rating}
-						style:--accent={stageCriterionRatings[evaluation.rating].color}
+						style:--accent={criterionRatingMeta.color}
+						title={criterionRatingMeta.label}
 					>
-						<span data-row="start gap-2">
-							<span data-row-item="flexible">
-								{#if attributeName}
-									{#if attributeLink}
-										<a href={attributeLink} title={attributeName}>
-											<strong>{attributeName}</strong>
-										</a>:
-									{:else}
-										<strong>{attributeName}</strong>:
-									{/if}
-									<span>
-										{#if isTypographicContent(criterion.description)}
-											<Typography content={criterion.description} />
-										{:else}
-											{criterion.id}
-										{/if}
-									</span>
+						{#if attributeName}
+							{#if attributeLink}
+								<a href={attributeLink} title={attributeName}>
+									<strong>{attributeName}</strong>
+								</a>:
+							{:else}
+								<strong>{attributeName}</strong>:
+							{/if}
+							<span>
+								{#if isTypographicContent(criterion.description)}
+									<Typography content={criterion.description} />
 								{:else}
-									{#if isTypographicContent(criterion.description)}
-										<Typography content={criterion.description} />
-									{:else}
-										{criterion.id}
-									{/if}
+									{criterion.id}
 								{/if}
 							</span>
-
-							<data
-								value={evaluation.rating}
-								title={stageCriterionRatings[evaluation.rating].label}
-							>
-								{stageCriterionRatings[evaluation.rating].icon}
-							</data>
-						</span>
+						{:else}
+							{#if isTypographicContent(criterion.description)}
+								<Typography content={criterion.description} />
+							{:else}
+								{criterion.id}
+							{/if}
+						{/if}
 					</li>
 				{/each}
 			</ul>
@@ -243,7 +233,7 @@
 		text-align: start;
 	}
 
-	li > span > span:last-child {
+	li > span {
 		color: var(--text-secondary);
 	}
 


### PR DESCRIPTION
## Summary
- Show ✅/❌ as the left list marker for stage criteria instead of attribute icons/bullets
- Remove the right-side check/cross column
- Keep criterion text on the primary readable color (status comes from the marker)

## Test plan
- [ ] Expand a stage criteria group on a wallet page
- [ ] Confirm pass/fail emojis appear on the left and not on the right
- [ ] Confirm criterion titles are not tinted pink/green