### PR TITLE
Wallet page: replace Website button with Links dropdown

### DIFF
--- a/src/utils/wallet-external-links.ts
+++ b/src/utils/wallet-external-links.ts
@@ -1,0 +1,151 @@
+import { allEntities, isValidEntityId } from '@/data/entities'
+import { type Entity, entityUrl } from '@/schema/entity'
+import { getUrl, getUrlLabel, isLabeledUrl, isUrl, labeledUrl, type Url } from '@/schema/url'
+import type { RatedWallet, WalletMetadata } from '@/schema/wallet'
+
+export type WalletExternalLink = {
+	/** Display label for the link. */
+	label: string
+	/** Absolute URL. */
+	url: string
+}
+
+function pushUnique(
+	links: WalletExternalLink[],
+	seen: Set<string>,
+	url: Url | null | undefined,
+	label: string,
+): void {
+	if (url === null || url === undefined) {
+		return
+	}
+
+	const href = getUrl(url)
+
+	if (seen.has(href)) {
+		return
+	}
+
+	seen.add(href)
+	links.push({ label, url: href })
+}
+
+function pushUrlList(
+	links: WalletExternalLink[],
+	seen: Set<string>,
+	urls: Url[] | undefined,
+	singularLabel: string,
+): void {
+	if (urls === undefined || urls.length === 0) {
+		return
+	}
+
+	if (urls.length === 1) {
+		const only = urls[0]
+		const label = isLabeledUrl(only) ? only.label : singularLabel
+
+		pushUnique(links, seen, only, label)
+
+		return
+	}
+
+	for (const url of urls) {
+		pushUnique(links, seen, url, isLabeledUrl(url) ? url.label : getUrlLabel(url))
+	}
+}
+
+function walletDeveloperEntity(metadata: WalletMetadata): Entity | null {
+	for (const contributor of metadata.contributors) {
+		if (contributor.affiliation === 'NO_AFFILIATION') {
+			continue
+		}
+
+		for (const affiliation of contributor.affiliation) {
+			if (affiliation.developer.type.walletDeveloper) {
+				return affiliation.developer
+			}
+		}
+	}
+
+	if (isValidEntityId(metadata.id)) {
+		const entity = allEntities[metadata.id]
+
+		if (entity.type.walletDeveloper) {
+			return entity
+		}
+	}
+
+	return null
+}
+
+function privacyPolicyUrl<_AttributeGroupId extends string>(
+	wallet: RatedWallet<_AttributeGroupId>,
+): string | null {
+	for (const resolved of Object.values(wallet.variants)) {
+		const policy = resolved?.features.privacy.privacyPolicy
+
+		if (typeof policy === 'string' && policy.length > 0) {
+			return policy
+		}
+	}
+
+	const developer = walletDeveloperEntity(wallet.metadata)
+
+	if (developer !== null && isUrl(developer.privacyPolicy)) {
+		return getUrl(developer.privacyPolicy)
+	}
+
+	return null
+}
+
+/**
+ * Collect external URLs related to a wallet for display in the wallet page
+ * Links dropdown (website, docs, repository, stores, privacy policy, etc.).
+ * Social media links are omitted.
+ */
+export function getWalletExternalLinks<_AttributeGroupId extends string>(
+	wallet: RatedWallet<_AttributeGroupId>,
+): WalletExternalLink[] {
+	const links: WalletExternalLink[] = []
+	const seen = new Set<string>()
+	const urls = wallet.metadata.urls
+
+	if (urls !== undefined) {
+		pushUrlList(links, seen, urls.websites, 'Website')
+		pushUrlList(links, seen, urls.docs, 'Docs')
+		pushUrlList(links, seen, urls.repositories, 'Repository')
+		pushUrlList(links, seen, urls.extensions, 'Chrome Web Store')
+		pushUnique(links, seen, urls.playstore, 'Google Play')
+		pushUnique(links, seen, urls.appstore, 'App Store')
+		pushUrlList(links, seen, urls.webapps, 'Web app')
+	}
+
+	const privacyPolicy = privacyPolicyUrl(wallet)
+
+	if (privacyPolicy !== null) {
+		pushUnique(links, seen, privacyPolicy, 'Privacy policy')
+	}
+
+	const developer = walletDeveloperEntity(wallet.metadata)
+
+	if (developer !== null) {
+		const companyUrl = entityUrl(developer)
+
+		if (companyUrl !== null) {
+			pushUnique(
+				links,
+				seen,
+				companyUrl,
+				developer.legalName === 'NOT_A_LEGAL_ENTITY' ? developer.name : developer.legalName.name,
+			)
+		}
+	}
+
+	if (urls?.others !== undefined) {
+		for (const other of urls.others) {
+			pushUnique(links, seen, other, labeledUrl(other).label)
+		}
+	}
+
+	return links
+}

--- a/src/views/WalletPage.svelte
+++ b/src/views/WalletPage.svelte
@@ -60,6 +60,7 @@
 	import { getHowIsEvaluatedHeading, getHowToImproveHeading } from '@/utils/attribute-display'
 	import { scoreToColor } from '@/utils/colors'
 	import { getWalletEvalStrings } from '@/utils/evaluation-content'
+	import { getWalletExternalLinks } from '@/utils/wallet-external-links'
 	import { getAttributeStagesForWallet } from '@/utils/stage-attributes'
 
 
@@ -86,7 +87,6 @@
 
 	// State
 	import { SvelteURLSearchParams } from 'svelte/reactivity'
-	import { isLabeledUrl } from '@/schema/url'
 	import { IncidentStatus } from '@/types/content/news'
 	import { daysSince } from '@/types/date'
 	import { getNewsForWallet } from '@/data/news'
@@ -407,9 +407,10 @@
 		calculateOverallScore(attributeTree, wallet.overall, () => true),
 	)
 
+	const externalLinks = $derived(getWalletExternalLinks(wallet))
+
 
 	// Components
-	import { Github, Globe } from 'lucide-static'
 	import ListCollapseIcon from 'lucide-static/icons/list-collapse.svg?raw'
 	import Rows3Icon from 'lucide-static/icons/rows-3.svg?raw'
 	import Select from '@/components/Select.svelte'
@@ -604,6 +605,27 @@
 					data-row-item="wrap-end"
 					data-row="gap-2"
 				>
+					{#if externalLinks.length > 0}
+						<details class="wallet-links">
+							<summary data-badge="medium">
+								Links
+							</summary>
+							<ul>
+								{#each externalLinks as link (link.url)}
+									<li>
+										<a
+											href={link.url}
+											target="_blank"
+											rel="noopener noreferrer"
+										>
+											{link.label}
+										</a>
+									</li>
+								{/each}
+							</ul>
+						</details>
+					{/if}
+
 					{#if showStage}
 						{@const { stage, ladderEvaluation } = getWalletStageAndLadder(wallet)}
 
@@ -633,30 +655,6 @@
 							strings={{ WALLET_NAME: wallet.metadata.displayName }}
 						/>
 					</p>
-
-					<nav data-row="gap-2 start wrap">
-						<a
-							href={isLabeledUrl(wallet.metadata.urls?.websites[0]) ? wallet.metadata.urls.websites[0].url : wallet.metadata.urls.websites[0]}
-							data-badge="medium"
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{@html Globe}
-							Website
-						</a>
-
-						{#if wallet.metadata.urls?.repository}
-							<a
-								href={isLabeledUrl(wallet.metadata.urls.repository[0]) ? wallet.metadata.urls.repository[0].url : wallet.metadata.urls.repository[0]}
-								data-badge="medium"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{@html Github}
-								Source Code
-							</a>
-						{/if}
-					</nav>
 				</div>
 
 				<div
@@ -3554,6 +3552,65 @@
 
 	.wallet-overview {
 		font-size: 0.9rem;
+	}
+
+	.wallet-links {
+		position: relative;
+		width: fit-content;
+
+		&::details-content {
+			display: contents;
+			height: auto;
+			opacity: 1;
+			filter: none;
+			transform: none;
+			content-visibility: visible;
+		}
+
+		&:not([open])::details-content {
+			content-visibility: hidden;
+		}
+
+		&:not([open]) > ul {
+			display: none;
+		}
+
+		> summary {
+			cursor: pointer;
+			user-select: none;
+		}
+
+		> ul {
+			position: absolute;
+			z-index: 20;
+			inset-block-start: calc(100% + 0.35rem);
+			inset-inline-end: 0;
+			min-inline-size: max(14rem, 100%);
+			max-inline-size: min(22rem, 80vw);
+			max-block-size: min(24rem, 60vh);
+			overflow: auto;
+			margin: 0;
+			padding: 0.35rem;
+			list-style: none;
+			background-color: var(--background-primary);
+			border: 1px solid var(--border-color);
+			border-radius: 0.5rem;
+			box-shadow: 0 0.5rem 1.25rem light-dark(rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.45));
+		}
+
+		a {
+			display: block;
+			padding: 0.55rem 0.7rem;
+			border-radius: 0.35rem;
+			color: var(--text-primary);
+			font-weight: 500;
+			text-decoration: none;
+
+			&:hover {
+				background-color: var(--background-secondary);
+				text-decoration: none;
+			}
+		}
 	}
 
 	.platforms-label {


### PR DESCRIPTION
## Summary
- Replace the Website / Source Code buttons with a single Links dropdown next to the Stage badge
- Populate links from wallet metadata (website, docs, repository, stores, privacy policy, company) without social media

## Test plan
- [ ] Open a wallet page and confirm Links appears beside the Stage badge
- [ ] Confirm dropdown includes expected non-social URLs and opens them in a new tab
- [ ] Confirm Website / Source Code buttons are gone