### PR TITLE
Add social proof docs

### DIFF
--- a/resources/docs/social-proof/social-proof.md
+++ b/resources/docs/social-proof/social-proof.md
@@ -3,11 +3,29 @@ title: 'Walletbeat wall of love'
 description: "A log of positive social media mentions as a result of Walletbeat's actions or existence."
 ---
 
-- **2025-12**: Walletbeat publishes the L1 Provider Independence Test: https://x.com/walletbeat/status/2002818293741301777
-  - 2026-01: Reaction: Ambire fixes its L1 RPC configuration option to be available at wallet setup time: https://x.com/walletbeat/status/2017683277730001010 / https://x.com/Ivshti/status/2017967726782783683
-  - 2026-07: Faced with a regression, Ambire commits to an integration test to avoid further regressions: https://x.com/Ivshti/status/2075451993838002660
-  - 2026-07: Reaction: MetaMask (quietly) fixes its hard-reliance on a Consensys token metadata service when sending tokens: https://x.com/walletbeat/status/2066296900785942850
-- **2026-07**: Walletbeat contributor 0xMattmatt shows how multiple wallets handle a malicious Ethereum transaction that caused a user to lose ~300k USD: https://x.com/0xMattmatt/status/2081106605463289971
-  - **Reaction**: Ambire fixes this in their next release: https://x.com/borislavItskovv/status/2081582575790006360
-  - **Reaction**: WalletChan fixes this in their next release: https://x.com/walletbeat/status/2082293464071373094
-  - **Reaction**: Ambire thanks Walletbeat for bringing this issue to their attention: https://x.com/ambire/status/2082816470560747558
+- https://x.com/SCBuergel/status/2054251881916961048
+- https://x.com/alexanderchopan/status/2086600745202389183
+- https://x.com/alexanderchopan/status/2086600610087088299
+- https://x.com/borislavItskovv/status/2081582575790006360
+- https://x.com/ambire/status/2082816470560747558
+- https://x.com/coinspect/status/2084640808611770538
+- https://x.com/joddoss/status/2085383445421662515
+- https://x.com/ZkAv_Club/status/2084956394025807981
+- https://x.com/SoyAuraBrito/status/2084948003719127125
+- https://x.com/2ctv/status/2084943855099814320
+- https://x.com/scoutingcapie/status/2083149452530115011
+- https://x.com/marcxvlad/status/2084659094745407957
+- https://x.com/scoutingcapie/status/2084640012713578900
+- https://x.com/web3privacy/status/2082835011237990487
+- https://x.com/thomasbtc/status/2083937807245144370
+- https://x.com/AlpinaBG/status/2083622964071649458
+- https://x.com/defiscan_info/status/2083184534963597650
+- https://x.com/scoutingcapie/status/2083153202812522634
+- https://x.com/apoorveth/status/2082198239122751814
+- https://x.com/web3privacy/status/2082834961195843931
+- https://x.com/web3privacy/status/2082768261767155962
+- https://x.com/taliaobbu/status/2082717762380562535
+- https://x.com/alexanderchopan/status/2082293152636096767
+- https://x.com/alexanderchopan/status/2081896550633193867
+- https://x.com/Hiraweb3/status/2079953097892237425
+- https://x.com/web3privacy/status/2079190143152291997

--- a/resources/docs/social-proof/social-proof.md
+++ b/resources/docs/social-proof/social-proof.md
@@ -1,0 +1,13 @@
+---
+title: 'Walletbeat wall of love'
+description: "A log of positive social media mentions as a result of Walletbeat's actions or existence."
+---
+
+- **2025-12**: Walletbeat publishes the L1 Provider Independence Test: https://x.com/walletbeat/status/2002818293741301777
+  - 2026-01: Reaction: Ambire fixes its L1 RPC configuration option to be available at wallet setup time: https://x.com/walletbeat/status/2017683277730001010 / https://x.com/Ivshti/status/2017967726782783683
+  - 2026-07: Faced with a regression, Ambire commits to an integration test to avoid further regressions: https://x.com/Ivshti/status/2075451993838002660
+  - 2026-07: Reaction: MetaMask (quietly) fixes its hard-reliance on a Consensys token metadata service when sending tokens: https://x.com/walletbeat/status/2066296900785942850
+- **2026-07**: Walletbeat contributor 0xMattmatt shows how multiple wallets handle a malicious Ethereum transaction that caused a user to lose ~300k USD: https://x.com/0xMattmatt/status/2081106605463289971
+  - **Reaction**: Ambire fixes this in their next release: https://x.com/borislavItskovv/status/2081582575790006360
+  - **Reaction**: WalletChan fixes this in their next release: https://x.com/walletbeat/status/2082293464071373094
+  - **Reaction**: Ambire thanks Walletbeat for bringing this issue to their attention: https://x.com/ambire/status/2082816470560747558


### PR DESCRIPTION
## Summary
- Add `resources/docs/social-proof/` with a wall-of-love log of positive social mentions tied to Walletbeat’s impact

## Test plan
- [ ] Skim `resources/docs/social-proof/social-proof.md` for formatting and link accuracy