### PR TITLE
Skip IPFS deploy/pin steps if already pinned.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -66,12 +66,20 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Check if website bundle contents have changed
+        id: check-existing-pin
+        run: ./deploy/check-existing-pin.sh
+        env:
+          DEPLOY_DIRECTORY: dist
+          ACCESS_TOKEN_4EVERLAND: ${{ secrets.BETA_WALLBEAT_ETH_4EVERLAND_ACCESS_TOKEN }}
       - name: Deploy on IPFS
+        if: steps.check-existing-pin.outputs.already-pinned != 'true'
         run: ./deploy/deploy-omnipin.sh
         env:
           DEPLOY_DIRECTORY: dist
           OMNIPIN_FILECOIN_TOKEN: ${{ secrets.BETA_WALLETBEAT_ETH_UPDATER_EOA_PRIVATE_KEY }}
       - name: Pin on 4EVERLAND
+        if: steps.check-existing-pin.outputs.already-pinned != 'true'
         run: ./deploy/pin-omnipin.sh
         env:
           DEPLOY_DIRECTORY: dist

--- a/deploy/check-existing-pin.sh
+++ b/deploy/check-existing-pin.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+set +x
+
+if [[ -n "${DEBUG:-}" ]]; then
+	set -x
+fi
+
+if [[ -z "${DEPLOY_DIRECTORY:-}" ]]; then
+	echo 'Missing DEPLOY_DIRECTORY' >&2
+	exit 1
+fi
+
+if [[ -z "${ACCESS_TOKEN_4EVERLAND:-}" ]]; then
+	echo 'Missing ACCESS_TOKEN_4EVERLAND' >&2
+	exit 1
+fi
+
+DIRECTORY_CID="$(pnpm omnipin pack --only-hash "$DEPLOY_DIRECTORY")"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "cid=${DIRECTORY_CID}" >>"$GITHUB_OUTPUT"
+fi
+
+# A CID is considered already pinned when at least one matching pin record on
+# 4EVERLAND has status `pinned`. Any other outcome (not pinned, or the status
+# query failing) means we should go ahead and deploy/pin.
+if pnpm deploy:4everland-pin-tool check-pin-status "${DIRECTORY_CID}" | awk -F'\t' '$2 == "pinned" { found = 1 } END { exit !found }'; then
+	ALREADY_PINNED=true
+	echo "CID ${DIRECTORY_CID} is already pinned on 4EVERLAND." >&2
+else
+	ALREADY_PINNED=false
+	echo "CID ${DIRECTORY_CID} is not yet pinned on 4EVERLAND." >&2
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "already-pinned=${ALREADY_PINNED}" >>"$GITHUB_OUTPUT"
+fi

--- a/src/4everland-pin-tool/4everland-pin-tool-lib.ts
+++ b/src/4everland-pin-tool/4everland-pin-tool-lib.ts
@@ -108,6 +108,41 @@ function isPinResults(value: unknown): value is PinResults {
 }
 
 /**
+ * Check the current status of every pin matching the given CID pinned under
+ * the account identified by the given access token.
+ *
+ * A CID may have been pinned more than once, in which case multiple pin
+ * records (one per pin request) are returned. Matching is done against the
+ * API's `GET /pins?cid=<cid>` filter rather than a single `requestid`.
+ *
+ * @returns Every pin record matching `cid`, oldest first. Empty when the CID
+ *   is not pinned under the account.
+ * @throws if the request fails or the API returns a non-2xx response.
+ */
+export async function getPinStatus(token: string, cid: string): Promise<EverlandPin[]> {
+	const query = new URLSearchParams({ limit: String(PAGE_LIMIT), cid })
+	const url = `${API_BASE_URL}/pins?${query.toString()}`
+
+	const response = await fetch(url, {
+		headers: { Authorization: `Bearer ${token}` },
+	})
+
+	if (!response.ok) {
+		const body = await response.text()
+
+		throw new Error(`4EVERLAND /pins request for ${cid} failed (${response.status}): ${body}`)
+	}
+
+	const data = (await response.json()) as unknown
+
+	if (!isPinResults(data)) {
+		throw new Error('Unexpected response from the 4EVERLAND /pins endpoint.')
+	}
+
+	return data.results.sort((a, b) => Date.parse(a.created) - Date.parse(b.created))
+}
+
+/**
  * List the CIDs of every pin matching the given statuses pinned under the
  * account identified by the given access token.
  *

--- a/src/4everland-pin-tool/4everland-pin-tool.ts
+++ b/src/4everland-pin-tool/4everland-pin-tool.ts
@@ -4,6 +4,7 @@ import { getErrorMessage } from '@/types/errors'
 import { Enum } from '@/utils/enum'
 
 import {
+	getPinStatus,
 	listPinnedCIDs,
 	type PinnedCID,
 	type PinStatus,
@@ -172,6 +173,27 @@ cli
 
 			for (const pin of arranged) {
 				process.stdout.write(`${pin.cid}\n`)
+			}
+		} catch (error) {
+			process.stderr.write(`Error: ${getErrorMessage(error)}\n`)
+			process.exit(1)
+		}
+	})
+
+cli
+	.command('check-pin-status <cid>', 'Check the pin status of a CID')
+	.action(async (cid: string) => {
+		try {
+			const token = process.env.ACCESS_TOKEN_4EVERLAND
+
+			if (token === undefined || token === '') {
+				throw new Error('The ACCESS_TOKEN_4EVERLAND environment variable is required.')
+			}
+
+			const pins = await getPinStatus(token, cid)
+
+			for (const pin of pins) {
+				process.stdout.write(`${pin.requestid}\t${pin.status}\t${pin.created}\n`)
 			}
 		} catch (error) {
 			process.stderr.write(`Error: ${getErrorMessage(error)}\n`)


### PR DESCRIPTION
Saves some money when a commit does not change website bundle contents.