### PR TITLE
Use build sandboxing for build going into IPFS.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,7 +31,15 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run all checks
         run: pnpm run check:ci
-      - name: Upload dist
+      - name: Clean build
+        run: |
+          rm -rf dist &>/dev/null || true
+          pnpm build
+        env:
+          WALLETBEAT_ENV: CI
+          WALLETBEAT_BUILD_MUST_BE_SANDBOXED: true
+          WALLETBEAT_MUST_INSTALL_DEPENDENCIES_CLEANLY: true
+      - name: Upload clean bundle
         uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
@@ -61,7 +69,7 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Download dist
+      - name: Download bundle
         uses: actions/download-artifact@v8.0.1
         with:
           name: dist
@@ -111,7 +119,7 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Download dist
+      - name: Download bundle
         uses: actions/download-artifact@v8.0.1
         with:
           name: dist
@@ -152,7 +160,7 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Download dist
+      - name: Download bundle
         uses: actions/download-artifact@v8.0.1
         with:
           name: dist


### PR DESCRIPTION
Ensures CIDs are consistent across multiple builds, hopefully.